### PR TITLE
Add rabbitmq-server to snap stage-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,7 @@ parts:
   hotsos-python:
     source: .
     plugin: python
-    stage-packages: [python3-yaml, python3-simplejson]
+    stage-packages: [python3-yaml, python3-simplejson, rabbitmq-server]
   sem-open-preload:
     source: https://github.com/snapcore/snapcraft-preloads.git
     source-subdir: semaphores


### PR DESCRIPTION
This is needed by commands like rabbitmqctl
report.