### PR TITLE
Skip searching files that cause UnicodeDecodeError

### DIFF
--- a/core/searchtools.py
+++ b/core/searchtools.py
@@ -337,6 +337,9 @@ class FileSearcher(object):
 
             with open(path) as fd:
                 return self._search_task(term_key, fd, path)
+        except UnicodeDecodeError:
+            # ignore the file if it can't be decoded
+            log.debug("caught UnicodeDecodeError for path %s - skipping", path)
         except EOFError as e:
             msg = ("an exception occured while searching {} - {}".
                    format(path, e))
@@ -555,7 +558,8 @@ class FileSearcher(object):
                 for fpath, job in jobs[user_path]:
                     try:
                         result = job.get()
-                        self.results.add(fpath, result)
+                        if result:
+                            self.results.add(fpath, result)
                     except FileSearchException as e:
                         sys.stderr.write("{}\n".format(e.msg))
 

--- a/tests/unit/test_searchtools.py
+++ b/tests/unit/test_searchtools.py
@@ -114,7 +114,6 @@ class TestSearchTools(utils.BaseTestCase):
 
         results = s.search()
         self.assertEquals(set(results.files), set([filepath,
-                                                   globpath_file2,
                                                    globpath_file1]))
 
         self.assertEquals(len(results.find_by_path(filepath)), 127)


### PR DESCRIPTION
When searchtools hits a file that causes a UnicodeDecodeError
it will now be skipped to allow others to succeed.