### PR TITLE
Alert if kernel is marked as tainted

### DIFF
--- a/core/issues/issue_types.py
+++ b/core/issues/issue_types.py
@@ -8,6 +8,10 @@ class KernelError(IssueTypeBase):
     pass
 
 
+class KernelWarning(IssueTypeBase):
+    pass
+
+
 class MemoryWarning(IssueTypeBase):
     pass
 

--- a/defs/events.yaml
+++ b/defs/events.yaml
@@ -141,6 +141,9 @@ kernel:
       stacktrace:
         expr: '.*Call Trace:'
         hint: 'Call'
+      tainted:
+        expr: '.*Tainted:'
+        hint: 'Tainted'
     memory:
       oom-killer-invoked:
         expr: '(.+ \d+) (\d+:\d+:\d+) .+ (\S+) invoked oom-killer\:'

--- a/plugins/kernel/pyparts/log_event_checks.py
+++ b/plugins/kernel/pyparts/log_event_checks.py
@@ -27,6 +27,12 @@ class KernelLogEventChecks(KernelEventChecksBase):
         issue_utils.add_issue(issue)
 
     @EVENTCALLBACKS.callback
+    def tainted(self, event):
+        msg = ("kernel has been tainted")
+        issue = issue_types.KernelWarning(msg)
+        issue_utils.add_issue(issue)
+
+    @EVENTCALLBACKS.callback
     def oom_killer_invoked(self, event):
         results = event.results
         process_name = results[0].get(3)

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -130,8 +130,9 @@ class TestKernelPluginPartKernelLogEventChecks(TestKernelBase):
             else:
                 types[t] = 1
 
-        self.assertEqual(len(issues), 4)
+        self.assertEqual(len(issues), 5)
         self.assertEqual(types[issue_types.KernelError], 1)
+        self.assertEqual(types[issue_types.KernelWarning], 1)
         self.assertEqual(types[issue_types.MemoryWarning], 1)
         self.assertEqual(types[issue_types.NetworkWarning], 2)
         self.assertTrue(inst.plugin_runnable)


### PR DESCRIPTION
Indicates if running kernel mark itself as 'tainted'
due to out-of-tree, proprietary, ... modules.

If kernel is tainted:
... CPU: XX PID: YYY Comm: migration/27 Tainted: G OX ...

If not tainted:
CPU: X PID: YYY Comm: khungtaskd Not tainted

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>