### PR TITLE
Support command and file input types for yaml checks

### DIFF
--- a/core/plugins/openvswitch.py
+++ b/core/plugins/openvswitch.py
@@ -23,6 +23,11 @@ class OpenvSwitchBase(object):
         self.cli = CLIHelper()
 
     @property
+    def bridges(self):
+        bridges = self.cli.ovs_vsctl_list_br()
+        return [br.strip() for br in bridges]
+
+    @property
     def offload_enabled(self):
         other_config = self.cli.ovs_vsctl_get_Open_vSwitch_other_config()
         if not other_config:

--- a/core/plugintools.py
+++ b/core/plugintools.py
@@ -199,6 +199,8 @@ class PluginRunner(object):
                 except Exception as exc:
                     failed_parts.append(part)
                     log.debug("part '%s' raised exception: %s", part, exc)
+                    if constants.DEBUG_MODE:
+                        raise
 
                 # NOTE: we don't currently expect these parts to produce any
                 # output.
@@ -237,6 +239,8 @@ class PluginRunner(object):
                     failed_parts.append(part)
                     log.debug("part '%s' raised exception: %s", part, exc)
                     output = None
+                    if constants.DEBUG_MODE:
+                        raise
 
                 if output:
                     meld_part_output(output, part_out)

--- a/defs/bugs.yaml
+++ b/defs/bugs.yaml
@@ -22,13 +22,9 @@
 #
 #   * reason: info displayed in output describing the bug/issue.
 #
-#   * path: relative path to file/directory we want to search.
+#   * input: see core.checks.YAMLDefInput
 #
 # Optional:
-#
-#   * allow-all-logs: whether to allow path to be wildcarded. The default
-#                     is True and should be set to False if searching full
-#                     history will result in excessive load or execution time.
 #
 #   * reason-format-result-groups: optional list of python.re match group ids
 #     that are available when expr is matched and that we want to use as input
@@ -39,58 +35,74 @@
 openstack:
   nova:
     1888395:
+      input:
+        type: filesystem
+        value: 'var/log/nova/nova-compute.log'
       expr: '.+NotImplementedError: Cannot load ''vifs'' in the base class'
       hint: 'NotImplementedError'
       reason: 'known bug identified in nova logs'
-      path: 'var/log/nova/nova-compute.log'
-  neutron:
+  neutron-l3-agent:
+    input:
+      type: filesystem
+      value: 'var/log/neutron/neutron-l3-agent.log'
     1883089:
       expr: '.+AttributeError: ''NoneType'' object has no attribute ''get'''
       hint: 'AttributeError'
       reason: 'identified in neutron-l3-agent logs'
-      path: 'var/log/neutron/neutron-l3-agent.log'
-    1896506:
-      expr: '.+Unknown configuration entry ''no_track'' for ip address - ignoring.*'
-      hint: 'no_track'
-      reason: 'identified bug that critically impacts keepalived'
-      path: 'var/log/syslog'
-    1907686:
-      expr: '.+OVS database connection to OVN_Northbound failed with error: ''Timeout''.+'
-      hint: 'OVS database'
-      reason: 'identified bug impacting OVN db connections'
-      path: 'var/log/neutron/neutron-openvswitch-agent.log'
     1929832:
       expr: '.+Error while deleting router \S+: \S+ProcessExecutionError: .+ /usr/bin/neutron-rootwrap: Unauthorized command: kill -15 \d+ \(no filter matched\)'
       hint: 'ProcessExecutionError'
       reason: 'identified bug impacting deletion of HA routers'
-      path: 'var/log/neutron/neutron-l3-agent.log'
     1927868:
       expr: '.+Gateway interface for router \S+ was not set up; router will not work properly'
       hint: 'Gateway'
       reason: 'neutron-l3-agent is reporting it failed to configure some router gateway ports which may render them non-functional. This has been reported as a potential package regression (see bug) - please check.'
-      path: 'var/log/neutron/neutron-l3-agent.log'
+    1896506:
+      input:
+        type: filesystem
+        value: 'var/log/syslog'
+      expr: '.+Unknown configuration entry ''no_track'' for ip address - ignoring.*'
+      hint: 'no_track'
+      reason: 'identified bug that critically impacts keepalived'
+  neutron-agents-any:
+    1907686:
+      input:
+        type: filesystem
+        value: 'var/log/neutron/neutron-openvswitch-agent.log'
+      expr: '.+OVS database connection to OVN_Northbound failed with error: ''Timeout''.+'
+      hint: 'OVS database'
+      reason: 'identified bug impacting OVN db connections'
     1928031:
+      input:
+        type: filesystem
+        value: 'var/log/neutron/neutron-ovn-metadata-agent.log'
       expr: '.+AttributeError: ''MetadataProxyHandler'' object has no attribute ''sb_idl'''
       hint: 'AttributeError'
       reason: 'identified bug impacting OVN sbdb connections from ovn agents'
-      path: 'var/log/neutron/neutron-ovn-metadata-agent.log'
 openvswitch:
   ovn:
+    input:
+      type: filesystem
+      value: 'var/log/ovn/ovn-controller.log'
     1917475:
       expr: '.+transaction error: {"details":"RBAC rules for client \\"\S+\\" role \\"\S+\\" prohibit .+ table\s+\\"\S+\\".","error":"permission error"'
       hint: 'transaction error'
       reason: 'db rbac error bug detected in ovn logs - see LP for details'
-      path: 'var/log/ovn/ovn-controller.log'
 juju:
   common:
+    input:
+      type: filesystem
+      value: 'var/log/juju/*.log'
     1910958:
       expr: '.* manifold worker .+ error: failed to initialize uniter for "(\S+)": cannot create relation state tracker: cannot remove persisted state, relation (\d+) has members'
       hint: 'manifold worker returned unexpected error'
       reason: 'Unit {} failed to start due to members in relation {} that cannot be removed.'
       reason-format-result-groups: [1, 2]
-      path: 'var/log/juju/*.log'
 rabbitmq:
   common:
+    input:
+      type: filesystem
+      value:  'var/log/rabbitmq/rabbit@*.log'
     1943937:
       expr: 'operation queue.declare caused a channel exception not_found: failed to perform operation on queue ''\S+'' in vhost ''\S+'' due to timeout'
       hint: 'not_found'
@@ -101,4 +113,4 @@ rabbitmq:
         servers before starting them all again at the same time. A rolling
         restart or restarting them simultaneously will not work. See bug for
         more detail.
-      path: 'var/log/rabbitmq/rabbit@*.log'
+

--- a/defs/config_checks.yaml
+++ b/defs/config_checks.yaml
@@ -12,7 +12,9 @@
 openstack:
   nova-dpdk:
     callback: 'dpdk_enabled'
-    path: etc/nova/nova.conf
+    input:
+      type: filesystem
+      value: etc/nova/nova.conf
     message: DPDK is enabled but rx_queue_size/tx_queue_size set incorrectly in nova.conf (expect both to be >= 1024)
     settings:
       rx_queue_size:

--- a/defs/events.yaml
+++ b/defs/events.yaml
@@ -1,16 +1,22 @@
-# Definitions used to identify events in log files. Events can be single or
-# multi-line.
+# Definitions used to identify events searches. Events can be single or
+# multi-line and the data source can be a filesystem path or command.
 #
 # Entries are defined using the following hierarchy:
 #
 # PLUGIN:
-#   GROUP_LABEL:
+#   GROUP:
 #     SECTION:
 #       EVENT:
 #
-# Supported fields (for full details see common.checks.EventChecksBase):
+# Supported fields (for more details see common.checks.EventChecksBase):
 #
-# Two types of searches are available here; single line and sequence.
+# Two types of searches are available here; single line and sequence. A
+# sequence can take one of two formats; start/end or start/body/end. Sequence
+# endings are optional and if a body is defined this results in
+# searchtools.SequenceSearchDef being used otherwise the results are simply
+# tagged with -start and -end suffix which can then be processed using
+# core.analytics.LogEventStats. If not a sequence then a single
+# searchtools.SearchDef pattern is used.
 #
 # To match single line events use the form:
 #
@@ -21,17 +27,16 @@
 # To match multi-line events (sequences) use the form:
 #
 # <label>:
-#   start:
-#     expr: <re.match pattern> used to match start of sequence
-#     hint: optional <re.match pattern> used as a low-cost filter
-#   end:
-#     expr: <re.match pattern> used to match end of sequence
+#   [start|body|end]:
+#     expr: <re.match pattern> used to match portion of sequence
 #     hint: optional <re.match pattern> used as a low-cost filter
 #
 # Mandatory fields:
 #
-#   path: file/dir/glob to search - this can specified at the group, section
-#         or event level with the latter taking precedence.
+#  input: see core.checks.YAMLDefInput
+#
+#  NOTE: input can specified at the group, section or event level with the
+#        latter taking precedence.
 #
 # Optional fields:
 #
@@ -44,10 +49,13 @@
 #
 openstack:
   nova-external-events:
-    path: 'var/log/nova/nova-compute.log'
-    # Searching all logs can yield too many results and we don't yet have a
-    # way to override MAX_LOGROTATE_DEPTH so disabling for now.
-    allow-all-logs: False
+    input:
+      type: filesystem
+      value: 'var/log/nova/nova-compute.log'
+      meta:
+        # Searching all logs can yield too many results and we don't yet have a
+        # way to override MAX_LOGROTATE_DEPTH so disabling for now.
+        allow-all-logs: False
     # Supported events - https://docs.openstack.org/api-ref/compute/?expanded=run-events-detail#create-external-events-os-server-external-events  # noqa E501
     events:
       network-changed:
@@ -55,14 +63,23 @@ openstack:
       network-vif-plugged:
         expr: '.+\[instance: (\S+)\].+Preparing to wait for external event (network-vif-plugged)-(\S+)\s+'
   nova-checks:
-    path: 'var/log/nova/nova-compute.log'
+    input:
+      type: filesystem
+      value: 'var/log/nova/nova-compute.log'
     warnings:
       pci-dev-not-found:
         expr: '^([0-9\-]+) (\S+) .+ No net device was found for VF \S+: nova.exception.PciDeviceNotFoundById: PCI device (\S+) not found'
         hint: 'WARNING'
   neutron-agent-checks:
     neutron-ovs-agent:
-      path: 'var/log/neutron/neutron-openvswitch-agent.log'
+      input:
+        type: filesystem
+        value: 'var/log/neutron/neutron-openvswitch-agent.log'
+        meta:
+          # Disabling all-logs for now since running against a long
+          # history of logs can generate a very large amount of data that can
+          # consume too much memory.
+          allow-all-logs: False
       # identify rpc_loop iterations and get stats and longest running loops.
       rpc-loop:
         start:
@@ -71,12 +88,10 @@ openstack:
         end:
           expr: '^([0-9\-]+) (\S+) .+ Agent rpc_loop - iteration:([0-9]+) completed..+'
           hint: 'Agent rpc_loop'
-        # NOTE: disabling all-logs for now since running against a long
-        # history of logs can generate a very large amount of data that can
-        # consume too much memory.
-        allow-all-logs: False
     neutron-l3-agent:
-      path: 'var/log/neutron/neutron-l3-agent.log'
+      input:
+        type: filesystem
+        value: 'var/log/neutron/neutron-l3-agent.log'
       # identify router updates that took the longest to complete and report the longest updates.
       router-updates:
         start:
@@ -94,9 +109,20 @@ openstack:
         end:
           expr: '^([0-9-]+) (\S+) .+ Keepalived spawned with config \S+/ha_confs/([0-9a-z-]+)/keepalived.conf .+'
           hint: 'Keepalived'
+  neutron-router-checks:
+    l3ha:
+      vrrp-transitions:
+        input:
+          type: command
+          value: journalctl
+          meta:
+            args-callback: journalctl_args
+        expr: '^([0-9-]+)T\S+ \S+ Keepalived_vrrp\[\d+\]: (?:VRRP_Instance)?\(VR_(\d+)\) .+ (\S+) STATE'
   octavia-checks:
     octavia-health-manager:
-      path: 'var/log/octavia/octavia-health-manager.log'
+      input:
+        type: filesystem
+        value: 'var/log/octavia/octavia-health-manager.log'
       amp-missed-heartbeats:
         expr: '^(\S+) \S+ .+ Amphora (\S+) health message was processed too slowly:.+'
         hint: 'Amphora'
@@ -105,11 +131,15 @@ openstack:
         hint: 'failover'
     octavia-worker:
       lb-failover-manual:
-        path: 'var/log/octavia/octavia-worker.log'
+        input:
+          type: filesystem
+          value: 'var/log/octavia/octavia-worker.log'
         expr: '^(\S+) \S+ .+ Performing failover for amphora:\s+(.+)'
         hint: 'failover'
   apparmor-checks:
-    path: 'var/log/kern.log'
+    input:
+      type: filesystem
+      value: 'var/log/kern.log'
     denials:
       nova:
         expr: '(\S+ \d+) \d+:\S+\s+.+apparmor="DENIED".+\s+profile="(\S+nova\S+)"\s+.+'
@@ -120,7 +150,9 @@ openstack:
 openvswitch:
   daemon-checks:
     vswitchd:
-      path: 'var/log/openvswitch/ovs-vswitchd.log'
+      input:
+        type: filesystem
+        value: 'var/log/openvswitch/ovs-vswitchd.log'
       netdev-linux-no-such-device:
         expr: '([0-9-]+)T[0-9:\.]+Z.+\|(\S+): .+ \S+: No such device'
       bridge-no-such-device:
@@ -134,16 +166,33 @@ openvswitch:
           - '([0-9-]+)T[0-9:\.]+Z.+\|receive tunnel port not found \((\w+),'
     errors-and-warnings:
       ovs-vswitchd:
-        path: 'var/log/openvswitch/ovs-vswitchd.log'
+        input:
+          type: filesystem
+          value: 'var/log/openvswitch/ovs-vswitchd.log'
         expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN)\|.+'
         hint: '(ERR|WARN)'
       ovsdb-server:
-        path: 'var/log/openvswitch/ovsdb-server.log'
+        input:
+          type: filesystem
+          value: 'var/log/openvswitch/ovsdb-server.log'
         expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN)\|.+'
         hint: '(ERR|WARN)'
+  flow-checks:
+    datapath:
+      packet-drops:
+        input:
+          type: command
+          value: ovs_appctl_dpctl_show
+          meta:
+            kwargs:
+              datapath: 'system@ovs-system'
+        start: '\s+port \d+: (\S+) .+'
+        body: '\s+([RT]X) \S+:(\d+) \S+:(\d+) \S+:(\d+) \S+:(\d+) \S+:(\d+)'
 kernel:
   kernlog:
-    path: 'var/log/kern.log'
+    input:
+      type: filesystem
+      value: 'var/log/kern.log'
     common:
       stacktrace:
         expr: '.*Call Trace:'
@@ -161,13 +210,17 @@ kernel:
         hint: 'conntrack'
 rabbitmq:
   cluster-checks:
-    path: 'var/log/rabbitmq/rabbit@*.log'
+    input:
+      type: filesystem
+      value: 'var/log/rabbitmq/rabbit@*.log'
     rabbitlog:
       cluster-partitions:
         expr: '.+ \S+_partitioned_network'
         hint: 'partition'
   synced-queues:
-    path: 'var/log/rabbitmq/rabbit@*.log'
+    input:
+      type: filesystem
+      value: 'var/log/rabbitmq/rabbit@*.log'
     rabbitlog:
       no-sync:
         expr: 'Mirrored queue ''.+'' in vhost ''.+'': Stopping'
@@ -178,7 +231,9 @@ rabbitmq:
 storage:
   ceph:
     cephlogs:
-      path: 'var/log/ceph/ceph*.log'
+      input:
+        type: filesystem
+        value: 'var/log/ceph/ceph*.log'
       osd-reported-failed:
         expr: '^([0-9-]+)\S* \S+ .+ (osd.[0-9]+) reported failed by osd.[0-9]+'
         hint: 'reported failed'

--- a/defs/plugins.yaml
+++ b/defs/plugins.yaml
@@ -44,7 +44,7 @@ plugins:
     parts:
       ovs_checks:
         - OpenvSwitchDaemonChecks
-        - OpenvSwitchDPChecks
+        - OpenvSwitchFlowChecks
       ovs_resources:
         - OpenvSwitchConfigChecks
         - OpenvSwitchPackageChecks

--- a/plugins/openstack/pyparts/neutron_l3ha.py
+++ b/plugins/openstack/pyparts/neutron_l3ha.py
@@ -1,53 +1,37 @@
 import os
 import re
 
+from core.log import log
 from core import constants
+from core.cli_helpers import CLIHelper
+from core.checks import CallbackHelper
 from core.issues import (
     issue_types,
     issue_utils,
 )
-from core.cli_helpers import CLIHelper
-from core.searchtools import (
-    SearchDef,
-    FileSearcher,
-)
-from core.utils import mktemp_dump
 from core.plugins.openstack import (
     NEUTRON_HA_PATH,
-    OpenstackChecksBase,
+    OpenstackEventChecksBase,
 )
 
 VRRP_TRANSITION_WARN_THRESHOLD = 8
 YAML_PRIORITY = 8
+EVENTCALLBACKS = CallbackHelper()
 
 
-class NeutronL3HAChecks(OpenstackChecksBase):
+class NeutronL3HAChecks(OpenstackEventChecksBase):
 
-    def __init__(self):
-        super().__init__()
-        self.searcher = FileSearcher()
-        self.f_journalctl = None
-        self.router_vrrp_pids = {}
-        self.router_vr_ids = {}
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, callback_helper=EVENTCALLBACKS,
+                         yaml_defs_group='neutron-router-checks',
+                         **kwargs)
+        self.vr_id_to_router = {}
         self.cli = CLIHelper()
 
     @property
     def output(self):
         if self._output:
             return {"neutron-l3ha": self._output}
-
-    def __del__(self):
-        if self.f_journalctl and os.path.exists(self.f_journalctl):
-            os.unlink(self.f_journalctl)
-
-    def _get_journalctl_l3_agent(self):
-        if not constants.USE_ALL_LOGS:
-            date = self.cli.date(format="--iso-8601").rstrip()
-        else:
-            date = None
-
-        out = self.cli.journalctl(unit="neutron-l3-agent", date=date)
-        self.f_journalctl = mktemp_dump(''.join(out))
 
     def get_neutron_ha_info(self):
         ha_state_path = os.path.join(constants.DATA_ROOT, NEUTRON_HA_PATH)
@@ -58,7 +42,6 @@ class NeutronL3HAChecks(OpenstackChecksBase):
         for entry in os.listdir(ha_state_path):
             entry = os.path.join(ha_state_path, entry)
             if os.path.isdir(entry):
-                pid_path = "{}{}".format(entry, ".pid.keepalived-vrrp")
                 keepalived_conf_path = os.path.join(entry, "keepalived.conf")
                 state_path = os.path.join(entry, "state")
                 if os.path.exists(state_path):
@@ -73,72 +56,26 @@ class NeutronL3HAChecks(OpenstackChecksBase):
                     if os.path.isfile(keepalived_conf_path):
                         with open(keepalived_conf_path) as fd:
                             for line in fd:
-                                expr = ".+ virtual_router_id ([0-9]+)"
+                                expr = r".+ virtual_router_id (\d+)"
                                 ret = re.compile(expr).search(line)
                                 if ret:
-                                    self.router_vr_ids[router] = ret.group(1)
-
-                    if os.path.isfile(pid_path):
-                        with open(pid_path) as fd:
-                            pid = fd.read().strip()
-                            self.router_vrrp_pids[router] = pid
+                                    vr_id = ret.group(1)
+                                    self.vr_id_to_router[vr_id] = router
 
         if router_states:
             self._output["agent"] = router_states
 
-    def get_vrrp_transitions(self):
-        """
-        List routers that have had a vrrp state transition along with the
-        number of transitions. Excludes routers that have not had any change of
-        state.
-        """
-        if not self.router_vrrp_pids:
-            return
-
-        self._get_journalctl_l3_agent()
-        transitions = {}
-        for router in self.router_vrrp_pids:
-            vr_id = self.router_vr_ids[router]
-            # NOTE: the VRRP_Instance part does not exist in keepalived 2.x
-            expr = (r"^([0-9-]+)T\S+ \S+ Keepalived_vrrp"
-                    r"\[([0-9]+)\]: (?:VRRP_Instance)?\(VR_{}\) .+ (\S+) "
-                    "STATE.*".format(vr_id))
-            d = SearchDef(expr, tag=router)
-            self.searcher.add_search_term(d, self.f_journalctl)
-
-        results = self.searcher.search()
-        for router in self.router_vrrp_pids:
-            t_count = len(results.find_by_tag(router))
-            if not t_count:
-                continue
-
-            for r in results.find_by_tag(router):
-                ts_date = r.get(1)
-                if router not in transitions:
-                    transitions[router] = {}
-
-                if ts_date in transitions[router]:
-                    transitions[router][ts_date] += 1
-                else:
-                    transitions[router][ts_date] = 1
-
-        if transitions:
-            self._output["keepalived"] = {"transitions": transitions}
-
-    def check_vrrp_transitions(self):
+    def check_vrrp_transitions(self, transitions):
         # there will likely be a large number of transitions if we look across
         # all time so dont run this check.
         if constants.USE_ALL_LOGS:
             return
 
-        if "transitions" not in self._output.get("keepalived", {}):
-            return
-
         max_transitions = 0
         warn_count = 0
         threshold = VRRP_TRANSITION_WARN_THRESHOLD
-        for router in self._output["keepalived"]["transitions"]:
-            r = self._output["keepalived"]["transitions"][router]
+        for router in transitions:
+            r = transitions[router]
             transitions = sum([t for d, t in r.items()])
             if transitions > threshold:
                 max_transitions = max(transitions, max_transitions)
@@ -151,11 +88,34 @@ class NeutronL3HAChecks(OpenstackChecksBase):
                                                           max_transitions))
             issue_utils.add_issue(issue_types.NeutronL3HAWarning(msg))
 
-    def __call__(self):
-        # Only run if we think Openstack is installed.
-        if not self.openstack_installed:
-            return
+    def journalctl_args(self):
+        """ Args callback for event cli command """
+        args = []
+        kwargs = {'unit': 'neutron-l3-agent'}
+        if not constants.USE_ALL_LOGS:
+            kwargs['date'] = self.cli.date(format="--iso-8601").rstrip()
 
+        return args, kwargs
+
+    @EVENTCALLBACKS.callback
+    def vrrp_transitions(self, event):
         self.get_neutron_ha_info()
-        self.get_vrrp_transitions()
-        self.check_vrrp_transitions()
+        transitions = {}
+        for r in event.results:
+            ts_date = r.get(1)
+            vr_id = r.get(2)
+            router = self.vr_id_to_router.get(vr_id)
+            if not router:
+                log.debug("no router found with vr_id %s", vr_id)
+                continue
+
+            if router not in transitions:
+                transitions[router] = {ts_date: 1}
+            elif ts_date in transitions[router]:
+                transitions[router][ts_date] += 1
+            else:
+                transitions[router][ts_date] = 1
+
+        if transitions:
+            self.check_vrrp_transitions(transitions)
+            return {'transitions': transitions}, 'keepalived'

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -1,10 +1,54 @@
 import os
+import yaml
 
 import mock
 
 import utils
 
 from core import checks
+
+
+YAML_DEF1 = """
+pluginX:
+  groupA:
+    input:
+      type: filesystem
+      value: foo/bar1
+    sectionA:
+      artifactX:
+        settingA: True
+"""
+
+YAML_DEF2 = """
+pluginX:
+  groupA:
+    input:
+      type: filesystem
+      value: foo/bar1
+    sectionA:
+      input:
+        type: filesystem
+        value: foo/bar2
+      artifactX:
+        settingA: True
+"""
+
+YAML_DEF3 = """
+pluginX:
+  groupA:
+    input:
+      type: filesystem
+      value: foo/bar1
+    sectionA:
+      input:
+        type: filesystem
+        value: foo/bar2
+      artifactX:
+        input:
+            type: filesystem
+            value: foo/bar3
+        settingA: True
+"""
 
 
 class TestChecks(utils.BaseTestCase):
@@ -81,3 +125,36 @@ class TestChecks(utils.BaseTestCase):
             obj = checks.PackageBugChecksBase('ussuri', pkg_info)
             obj()
             self.assertFalse(mock_add_known_bug.called)
+
+    def test_yaml_def_group_input(self):
+        plugin_checks = yaml.safe_load(YAML_DEF1).get('pluginX')
+        for name, group in plugin_checks.items():
+            group = checks.YAMLDefGroup(name, group, event_check_obj=None)
+            for section in group.sections:
+                for entry in section.entries:
+                    self.assertEquals(entry.input.type, 'filesystem')
+                    self.assertEquals(entry.input.value,
+                                      os.path.join(checks.constants.DATA_ROOT,
+                                                   'foo/bar1'))
+
+    def test_yaml_def_section_input_override(self):
+        plugin_checks = yaml.safe_load(YAML_DEF2).get('pluginX')
+        for name, group in plugin_checks.items():
+            group = checks.YAMLDefGroup(name, group, event_check_obj=None)
+            for section in group.sections:
+                for entry in section.entries:
+                    self.assertEquals(entry.input.type, 'filesystem')
+                    self.assertEquals(entry.input.value,
+                                      os.path.join(checks.constants.DATA_ROOT,
+                                                   'foo/bar2'))
+
+    def test_yaml_def_entry_input_override(self):
+        plugin_checks = yaml.safe_load(YAML_DEF3).get('pluginX')
+        for name, group in plugin_checks.items():
+            group = checks.YAMLDefGroup(name, group, event_check_obj=None)
+            for section in group.sections:
+                for entry in section.entries:
+                    self.assertEquals(entry.input.type, 'filesystem')
+                    self.assertEquals(entry.input.value,
+                                      os.path.join(checks.constants.DATA_ROOT,
+                                                   'foo/bar3'))

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -159,8 +159,9 @@ class TestKernelPluginPartKernelLogEventChecks(TestKernelBase):
         mock_result2 = mock.MagicMock()
         mock_result2.get.return_value = 'tap7e105503-64'
 
-        event = EventCheckResult([mock_result1, mock_result2], 'section8',
-                                 'over_mtu_dropped_packets')
+        event = EventCheckResult(defs_section='section8',
+                                 defs_event='over_mtu_dropped_packets',
+                                 search_results=[mock_result1, mock_result2])
         ret = inst.over_mtu_dropped_packets(event)
         self.assertTrue(inst.plugin_runnable)
         self.assertEqual(ret, expected)

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -501,12 +501,22 @@ class TestOpenstackPluginPartAgentChecks(TestOpenstackBase):
 
         mock_add_known_bug.side_effect = fake_add_bug
         checks.BugChecksBase()()
-        calls = [mock.call("1896506",
+        calls = [mock.call('1929832',
+                           ('identified bug impacting deletion of HA '
+                            'routers')),
+                 mock.call('1927868',
+                           ('neutron-l3-agent is reporting it failed to '
+                            'configure some router gateway ports which may '
+                            'render them non-functional. This has been '
+                            'reported as a potential package regression (see '
+                            'bug) - please check.')),
+                 mock.call('1896506',
                            ('identified bug that critically impacts '
                             'keepalived')),
-                 mock.call("1929832",
-                           ('identified bug impacting deletion of HA '
-                            'routers'))]
+                 mock.call('1928031',
+                           ('identified bug impacting OVN sbdb connections '
+                            'from ovn agents'))]
+
         mock_add_known_bug.assert_has_calls(calls)
         self.assertEqual(len(bugs), 4)
 
@@ -709,9 +719,7 @@ class TestOpenstackPluginPartNeutronL3HA_checks(TestOpenstackBase):
                      }
                     }
         inst = neutron_l3ha.NeutronL3HAChecks()
-        inst.get_neutron_ha_info()
-        inst.get_vrrp_transitions()
-        inst.check_vrrp_transitions()
+        inst()
         self.assertEqual(inst.output["neutron-l3ha"], expected)
 
     @mock.patch.object(neutron_l3ha.issue_utils, "add_issue")
@@ -729,9 +737,7 @@ class TestOpenstackPluginPartNeutronL3HA_checks(TestOpenstackBase):
                      }
                     }
         inst = neutron_l3ha.NeutronL3HAChecks()
-        inst.get_neutron_ha_info()
-        inst.get_vrrp_transitions()
-        inst.check_vrrp_transitions()
+        inst()
         self.assertEqual(inst.output["neutron-l3ha"], expected)
         self.assertTrue(mock_add_issue.called)
 

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -82,6 +82,6 @@ class TestOpenvswitchPluginPartOpenvswitchDaemonChecks(TestOpenvswitchBase):
                      {'RX':
                       {'dropped': 1394875,
                        'packets': 309}}}}
-        inst = ovs_checks.OpenvSwitchDPChecks()
+        inst = ovs_checks.OpenvSwitchFlowChecks()
         inst()
         self.assertEqual(inst.output, expected)


### PR DESCRIPTION
Currently we only support using the yaml based definitions
for file-based searches. This patch introduces the ability
to define different data sources i.e. file or command. This
is now applied to all defs types i.e. events, bugs etc.

Also ports event searches that use commands as input into
yaml.