### PR TITLE
[juju] add check for LP bug 1858519

### DIFF
--- a/defs/bugs.yaml
+++ b/defs/bugs.yaml
@@ -113,6 +113,13 @@ juju:
       hint: 'manifold worker returned unexpected error'
       message: 'Unit {} failed to start due to members in relation {} that cannot be removed.'
       message-format-result-groups: [1, 2]
+    1858519:
+      input:
+        type: filesystem
+        value: 'var/log/juju/unit-ceph-osd*.log'
+      expr: '.* Cannot zap a device used by lvm'
+      hint: 'Cannot zap'
+      message: 'The ceph-osd charm tried to zap a disk but failed since the disk had an LVM header. If you are sure the disk is not in active use by LVM, you may run pvremove on it before using it as an OSD'
 rabbitmq:
   common:
     input:


### PR DESCRIPTION
Tested by manually putting a string in the /var/log/juju/unit-ceph-osd-0.log like so,

2021-08-31 16:27:08 INFO unit.ceph-osd/0.juju-log Cannot zap a device used by lvm

root@bronzor:~/test_hotsos/hotsos# ./hotsos.sh 
INFO: analysing localhost since no sosreport path provided  
hotsos:
  version: development
  repo-info: 71e018f
system:

-- SNIP -- 
juju:
  version: 2.9.12
  machine: '0'
  charms:
    - ceph-osd-312
  units:
    local:
      - ceph-osd-0
  bugs-detected:
    - desc: Zapping a disk has failed since it was in use by LVM. If you are sure
        the disk is not in active use by LVM, you may run pvremove to remove the LVM
        header and then try to zap it
      id: https://bugs.launchpad.net/bugs/1858519
      origin: juju.default_bug_checker
kernel:
  version: 4.15.0-154-generic
  boot: ro console=ttyS1
  cpu:
    smt: enabled
  memory-checks: no issues found

INFO: see --help for more options



