### PR TITLE
[storage] Report crush rules and the pools using them

### DIFF
--- a/defs/plugins.yaml
+++ b/defs/plugins.yaml
@@ -88,6 +88,7 @@ plugins:
         - CephPackageChecks
       ceph_cluster_checks:
         - CephClusterChecks
+        - CephCrushChecks
       ceph_event_checks:
         - CephDaemonLogChecks
       bcache:

--- a/plugins/storage/pyparts/ceph_cluster_checks.py
+++ b/plugins/storage/pyparts/ceph_cluster_checks.py
@@ -8,6 +8,7 @@ from core.plugins.storage import (
     bcache,
     ceph,
 )
+from core.plugins.storage.ceph import CephChecksBase
 from core.plugins.kernel import KernelChecksBase
 
 YAML_PRIORITY = 1
@@ -18,7 +19,7 @@ OSD_META_LIMIT_KB = (10 * 1024 * 1024)
 OSD_MAPS_LIMIT = 500  # mon_min_osdmap_epochs default
 
 
-class CephClusterChecks(ceph.CephChecksBase):
+class CephClusterChecks(CephChecksBase):
 
     def check_osdmaps_size(self):
         """
@@ -344,3 +345,16 @@ class CephClusterChecks(ceph.CephChecksBase):
         self.get_ceph_versions_mismatch()
         self.get_crushmap_mixed_buckets()
         self.check_osdmaps_size()
+
+
+class CephCrushChecks(CephChecksBase):
+    def get_crush_summary(self):
+        """
+        Get crush rules summary and the pools using those rules map.
+        """
+
+        if self.crush_rules:
+            self._output['crush_rules'] = self.crush_rules
+
+    def __call__(self):
+        self.get_crush_summary()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -483,6 +483,13 @@ class TestStorageCephDaemonChecks(StorageTestsBase):
         inst()
         self.assertEqual(inst.output["ceph"]["local-osds"], expected)
 
+    def test_get_crush_rules(self):
+        inst = ceph_cluster_checks.CephClusterChecks()
+        inst()
+        expected = {'replicated_rule': {'id': 0, 'type': 'replicated',
+                    'pools': ['device_health_metrics (1)', 'glance (2)']}}
+        self.assertEqual(inst.crush_rules, expected)
+
     @mock.patch.object(ceph_cluster_checks, 'KernelChecksBase')
     @mock.patch.object(ceph_cluster_checks.bcache, 'BcacheChecksBase')
     @mock.patch.object(ceph_cluster_checks.issue_utils, "add_issue")


### PR DESCRIPTION
A summary of crush rules and the pools which use those
crush rules are reported as part of standard report. This
is useful to quickly see crush rule <-> pools mapping.

A test run: https://pastebin.canonical.com/p/TYzNKZdpvr/

Closes: #170

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>