### PR TITLE
[openstack] fix openstack masked service check

### DIFF
--- a/core/cli_helpers.py
+++ b/core/cli_helpers.py
@@ -551,6 +551,9 @@ class CLIHelper(object):
             'systemctl_status_all':
                 [BinCmd('systemctl status --all'),
                  FileCmd('sos_commands/systemd/systemctl_status_--all')],
+            'systemctl_list_units':
+                [BinCmd('systemctl list-units'),
+                 FileCmd('sos_commands/systemd/systemctl_list-units')],
             'systemctl_list_unit_files':
                 [BinCmd('systemctl list-unit-files'),
                  FileCmd('sos_commands/systemd/systemctl_list-unit-files')],

--- a/core/plugins/openvswitch.py
+++ b/core/plugins/openvswitch.py
@@ -8,7 +8,8 @@ from core.host_helpers import HostNetworkingHelper
 
 OVS_SERVICES_EXPRS = [r"ovsdb[a-zA-Z-]*",
                       r"ovs-vswitch[a-zA-Z-]*",
-                      r"ovn[a-zA-Z-]*"]
+                      r"ovn[a-zA-Z-]*",
+                      "openvswitch-switch"]
 OVS_PKGS_CORE = [r"openvswitch-switch",
                  r"ovn",
                  ]

--- a/plugins/openstack/pyparts/service_info.py
+++ b/plugins/openstack/pyparts/service_info.py
@@ -33,9 +33,8 @@ class OpenstackInfo(OpenstackServiceChecksBase):
         """Get a list of masked services."""
         if self.service_info_str['systemd']:
             masked = self.service_info_str['systemd'].get('masked', {})
-            if 'keystone' in masked:
-                del masked['keystone']
-
+            expected_masked = OST_PROJECTS.default_masked_services
+            masked = set(masked).difference(expected_masked)
             if masked:
                 _masked = {', '.join(masked)}
                 msg = ('The following Openstack systemd services are masked: '

--- a/tests/unit/fake_data_root/sos_commands/systemd/systemctl_list-units
+++ b/tests/unit/fake_data_root/sos_commands/systemd/systemctl_list-units
@@ -1,0 +1,315 @@
+  UNIT                                                                        LOAD   ACTIVE SUB       DESCRIPTION                                                                   
+  proc-sys-fs-binfmt_misc.automount                                           loaded active running   Arbitrary Executable File Formats File System Automount Point                 
+  sys-devices-pci0000:00-0000:00:03.0-virtio0-net-ens3.device                 loaded active plugged   Virtio network device                                                         
+  sys-devices-pci0000:00-0000:00:04.0-virtio1-net-ens4.device                 loaded active plugged   Virtio network device                                                         
+  sys-devices-pci0000:00-0000:00:05.0-virtio2-net-ens5.device                 loaded active plugged   Virtio network device                                                         
+  sys-devices-pci0000:00-0000:00:06.0-virtio3-net-ens6.device                 loaded active plugged   Virtio network device                                                         
+  sys-devices-pci0000:00-0000:00:07.0-virtio4-net-ens7.device                 loaded active plugged   Virtio network device                                                         
+  sys-devices-pci0000:00-0000:00:08.0-virtio5-net-ens8.device                 loaded active plugged   Virtio network device                                                         
+  sys-devices-pci0000:00-0000:00:09.0-virtio6-net-ens9.device                 loaded active plugged   Virtio network device                                                         
+  sys-devices-pci0000:00-0000:00:0b.0-virtio7-block-vda-vda1.device           loaded active plugged   /sys/devices/pci0000:00/0000:00:0b.0/virtio7/block/vda/vda1                   
+  sys-devices-pci0000:00-0000:00:0b.0-virtio7-block-vda-vda2.device           loaded active plugged   /sys/devices/pci0000:00/0000:00:0b.0/virtio7/block/vda/vda2                   
+  sys-devices-pci0000:00-0000:00:0b.0-virtio7-block-vda.device                loaded active plugged   /sys/devices/pci0000:00/0000:00:0b.0/virtio7/block/vda                        
+  sys-devices-pci0000:00-0000:00:0c.0-virtio8-block-vdb-vdb1.device           loaded active plugged   /sys/devices/pci0000:00/0000:00:0c.0/virtio8/block/vdb/vdb1                   
+  sys-devices-pci0000:00-0000:00:0c.0-virtio8-block-vdb-vdb2.device           loaded active plugged   /sys/devices/pci0000:00/0000:00:0c.0/virtio8/block/vdb/vdb2                   
+  sys-devices-pci0000:00-0000:00:0c.0-virtio8-block-vdb.device                loaded active plugged   /sys/devices/pci0000:00/0000:00:0c.0/virtio8/block/vdb                        
+  sys-devices-pci0000:00-0000:00:0d.0-virtio9-block-vdc.device                loaded active plugged   /sys/devices/pci0000:00/0000:00:0d.0/virtio9/block/vdc                        
+  sys-devices-pci0000:00-0000:00:0f.0-virtio11-block-vdd.device               loaded active plugged   /sys/devices/pci0000:00/0000:00:0f.0/virtio11/block/vdd                       
+  sys-devices-pci0000:00-0000:00:10.0-virtio12-block-vde.device               loaded active plugged   /sys/devices/pci0000:00/0000:00:10.0/virtio12/block/vde                       
+  sys-devices-platform-serial8250-tty-ttyS1.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS1                                    
+  sys-devices-platform-serial8250-tty-ttyS10.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS10                                   
+  sys-devices-platform-serial8250-tty-ttyS11.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS11                                   
+  sys-devices-platform-serial8250-tty-ttyS12.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS12                                   
+  sys-devices-platform-serial8250-tty-ttyS13.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS13                                   
+  sys-devices-platform-serial8250-tty-ttyS14.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS14                                   
+  sys-devices-platform-serial8250-tty-ttyS15.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS15                                   
+  sys-devices-platform-serial8250-tty-ttyS16.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS16                                   
+  sys-devices-platform-serial8250-tty-ttyS17.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS17                                   
+  sys-devices-platform-serial8250-tty-ttyS18.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS18                                   
+  sys-devices-platform-serial8250-tty-ttyS19.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS19                                   
+  sys-devices-platform-serial8250-tty-ttyS2.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS2                                    
+  sys-devices-platform-serial8250-tty-ttyS20.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS20                                   
+  sys-devices-platform-serial8250-tty-ttyS21.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS21                                   
+  sys-devices-platform-serial8250-tty-ttyS22.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS22                                   
+  sys-devices-platform-serial8250-tty-ttyS23.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS23                                   
+  sys-devices-platform-serial8250-tty-ttyS24.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS24                                   
+  sys-devices-platform-serial8250-tty-ttyS25.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS25                                   
+  sys-devices-platform-serial8250-tty-ttyS26.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS26                                   
+  sys-devices-platform-serial8250-tty-ttyS27.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS27                                   
+  sys-devices-platform-serial8250-tty-ttyS28.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS28                                   
+  sys-devices-platform-serial8250-tty-ttyS29.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS29                                   
+  sys-devices-platform-serial8250-tty-ttyS3.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS3                                    
+  sys-devices-platform-serial8250-tty-ttyS30.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS30                                   
+  sys-devices-platform-serial8250-tty-ttyS31.device                           loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS31                                   
+  sys-devices-platform-serial8250-tty-ttyS4.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS4                                    
+  sys-devices-platform-serial8250-tty-ttyS5.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS5                                    
+  sys-devices-platform-serial8250-tty-ttyS6.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS6                                    
+  sys-devices-platform-serial8250-tty-ttyS7.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS7                                    
+  sys-devices-platform-serial8250-tty-ttyS8.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS8                                    
+  sys-devices-platform-serial8250-tty-ttyS9.device                            loaded active plugged   /sys/devices/platform/serial8250/tty/ttyS9                                    
+  sys-devices-pnp0-00:04-tty-ttyS0.device                                     loaded active plugged   /sys/devices/pnp0/00:04/tty/ttyS0                                             
+  sys-devices-virtual-block-bcache0.device                                    loaded active plugged   /sys/devices/virtual/block/bcache0                                            
+  sys-devices-virtual-block-bcache1.device                                    loaded active plugged   /sys/devices/virtual/block/bcache1                                            
+  sys-devices-virtual-block-dm\x2d0.device                                    loaded active plugged   /sys/devices/virtual/block/dm-0                                               
+  sys-devices-virtual-block-dm\x2d1.device                                    loaded active plugged   /sys/devices/virtual/block/dm-1                                               
+  sys-devices-virtual-block-dm\x2d2.device                                    loaded active plugged   /sys/devices/virtual/block/dm-2                                               
+  sys-devices-virtual-block-loop0.device                                      loaded active plugged   /sys/devices/virtual/block/loop0                                              
+  sys-devices-virtual-block-loop1.device                                      loaded active plugged   /sys/devices/virtual/block/loop1                                              
+  sys-devices-virtual-block-loop2.device                                      loaded active plugged   /sys/devices/virtual/block/loop2                                              
+  sys-devices-virtual-block-loop3.device                                      loaded active plugged   /sys/devices/virtual/block/loop3                                              
+  sys-devices-virtual-block-loop5.device                                      loaded active plugged   /sys/devices/virtual/block/loop5                                              
+  sys-devices-virtual-block-loop6.device                                      loaded active plugged   /sys/devices/virtual/block/loop6                                              
+  sys-devices-virtual-block-loop7.device                                      loaded active plugged   /sys/devices/virtual/block/loop7                                              
+  sys-devices-virtual-block-loop8.device                                      loaded active plugged   /sys/devices/virtual/block/loop8                                              
+  sys-devices-virtual-block-loop9.device                                      loaded active plugged   /sys/devices/virtual/block/loop9                                              
+  sys-devices-virtual-misc-rfkill.device                                      loaded active plugged   /sys/devices/virtual/misc/rfkill                                              
+  sys-devices-virtual-net-1lxd0\x2d0.device                                   loaded active plugged   /sys/devices/virtual/net/1lxd0-0                                              
+  sys-devices-virtual-net-1lxd1\x2d0.device                                   loaded active plugged   /sys/devices/virtual/net/1lxd1-0                                              
+  sys-devices-virtual-net-1lxd2\x2d0.device                                   loaded active plugged   /sys/devices/virtual/net/1lxd2-0                                              
+  sys-devices-virtual-net-1lxd3\x2d0.device                                   loaded active plugged   /sys/devices/virtual/net/1lxd3-0                                              
+  sys-devices-virtual-net-1lxd4\x2d0.device                                   loaded active plugged   /sys/devices/virtual/net/1lxd4-0                                              
+  sys-devices-virtual-net-br\x2ddata.device                                   loaded active plugged   /sys/devices/virtual/net/br-data                                              
+  sys-devices-virtual-net-br\x2dens3.device                                   loaded active plugged   /sys/devices/virtual/net/br-ens3                                              
+  sys-devices-virtual-net-br\x2dex.device                                     loaded active plugged   /sys/devices/virtual/net/br-ex                                                
+  sys-devices-virtual-net-br\x2dint.device                                    loaded active plugged   /sys/devices/virtual/net/br-int                                               
+  sys-devices-virtual-net-br\x2dtun.device                                    loaded active plugged   /sys/devices/virtual/net/br-tun                                               
+  sys-devices-virtual-net-lxdbr0.device                                       loaded active plugged   /sys/devices/virtual/net/lxdbr0                                               
+  sys-devices-virtual-net-ovs\x2dsystem.device                                loaded active plugged   /sys/devices/virtual/net/ovs-system                                           
+  sys-devices-virtual-net-tap03c4d61b\x2d60.device                            loaded active plugged   /sys/devices/virtual/net/tap03c4d61b-60                                       
+  sys-devices-virtual-net-tap0906171f\x2d17.device                            loaded active plugged   /sys/devices/virtual/net/tap0906171f-17                                       
+  sys-devices-virtual-net-vxlan_sys_4789.device                               loaded active plugged   /sys/devices/virtual/net/vxlan_sys_4789                                       
+  sys-devices-virtual-tty-ttyprintk.device                                    loaded active plugged   /sys/devices/virtual/tty/ttyprintk                                            
+  sys-module-configfs.device                                                  loaded active plugged   /sys/module/configfs                                                          
+  sys-module-fuse.device                                                      loaded active plugged   /sys/module/fuse                                                              
+  sys-subsystem-net-devices-1lxd0\x2d0.device                                 loaded active plugged   /sys/subsystem/net/devices/1lxd0-0                                            
+  sys-subsystem-net-devices-1lxd1\x2d0.device                                 loaded active plugged   /sys/subsystem/net/devices/1lxd1-0                                            
+  sys-subsystem-net-devices-1lxd2\x2d0.device                                 loaded active plugged   /sys/subsystem/net/devices/1lxd2-0                                            
+  sys-subsystem-net-devices-1lxd3\x2d0.device                                 loaded active plugged   /sys/subsystem/net/devices/1lxd3-0                                            
+  sys-subsystem-net-devices-1lxd4\x2d0.device                                 loaded active plugged   /sys/subsystem/net/devices/1lxd4-0                                            
+  sys-subsystem-net-devices-br\x2ddata.device                                 loaded active plugged   /sys/subsystem/net/devices/br-data                                            
+  sys-subsystem-net-devices-br\x2dens3.device                                 loaded active plugged   /sys/subsystem/net/devices/br-ens3                                            
+  sys-subsystem-net-devices-br\x2dex.device                                   loaded active plugged   /sys/subsystem/net/devices/br-ex                                              
+  sys-subsystem-net-devices-br\x2dint.device                                  loaded active plugged   /sys/subsystem/net/devices/br-int                                             
+  sys-subsystem-net-devices-br\x2dtun.device                                  loaded active plugged   /sys/subsystem/net/devices/br-tun                                             
+  sys-subsystem-net-devices-ens3.device                                       loaded active plugged   Virtio network device                                                         
+  sys-subsystem-net-devices-ens4.device                                       loaded active plugged   Virtio network device                                                         
+  sys-subsystem-net-devices-ens5.device                                       loaded active plugged   Virtio network device                                                         
+  sys-subsystem-net-devices-ens6.device                                       loaded active plugged   Virtio network device                                                         
+  sys-subsystem-net-devices-ens7.device                                       loaded active plugged   Virtio network device                                                         
+  sys-subsystem-net-devices-ens8.device                                       loaded active plugged   Virtio network device                                                         
+  sys-subsystem-net-devices-ens9.device                                       loaded active plugged   Virtio network device                                                         
+  sys-subsystem-net-devices-lxdbr0.device                                     loaded active plugged   /sys/subsystem/net/devices/lxdbr0                                             
+  sys-subsystem-net-devices-ovs\x2dsystem.device                              loaded active plugged   /sys/subsystem/net/devices/ovs-system                                         
+  sys-subsystem-net-devices-tap03c4d61b\x2d60.device                          loaded active plugged   /sys/subsystem/net/devices/tap03c4d61b-60                                     
+  sys-subsystem-net-devices-tap0906171f\x2d17.device                          loaded active plugged   /sys/subsystem/net/devices/tap0906171f-17                                     
+  sys-subsystem-net-devices-vxlan_sys_4789.device                             loaded active plugged   /sys/subsystem/net/devices/vxlan_sys_4789                                     
+  -.mount                                                                     loaded active mounted   Root Mount                                                                    
+  dev-hugepages.mount                                                         loaded active mounted   Huge Pages File System                                                        
+  dev-mqueue.mount                                                            loaded active mounted   POSIX Message Queue File System                                               
+  proc-sys-fs-binfmt_misc.mount                                               loaded active mounted   Arbitrary Executable File Formats File System                                 
+  run-netns-fip\x2d7553f34c\x2db718\x2d4a4b\x2d8bbd\x2d2d7a1cd5cf62.mount     loaded active mounted   /run/netns/fip-7553f34c-b718-4a4b-8bbd-2d7a1cd5cf62                           
+  run-netns-qrouter\x2d1e086be2\x2d93c2\x2d4740\x2d921d\x2d3e3237f23959.mount loaded active mounted   /run/netns/qrouter-1e086be2-93c2-4740-921d-3e3237f23959                       
+  run-netns-snat\x2d1e086be2\x2d93c2\x2d4740\x2d921d\x2d3e3237f23959.mount    loaded active mounted   /run/netns/snat-1e086be2-93c2-4740-921d-3e3237f23959                          
+  run-netns.mount                                                             loaded active mounted   /run/netns                                                                    
+  run-rpc_pipefs.mount                                                        loaded active mounted   RPC Pipe File System                                                          
+  run-snapd-ns-hotsos.mnt.mount                                               loaded active mounted   /run/snapd/ns/hotsos.mnt                                                      
+  run-snapd-ns-lxd.mnt.mount                                                  loaded active mounted   /run/snapd/ns/lxd.mnt                                                         
+  run-snapd-ns.mount                                                          loaded active mounted   /run/snapd/ns                                                                 
+  run-user-1000.mount                                                         loaded active mounted   /run/user/1000                                                                
+  snap-core18-2074.mount                                                      loaded active mounted   Mount unit for core18, revision 2074                                          
+  snap-core18-2128.mount                                                      loaded active mounted   Mount unit for core18, revision 2128                                          
+  snap-core20-1081.mount                                                      loaded active mounted   Mount unit for core20, revision 1081                                          
+  snap-hotsos-304.mount                                                       loaded active mounted   Mount unit for hotsos, revision 304                                           
+  snap-hotsos-305.mount                                                       loaded active mounted   Mount unit for hotsos, revision 305                                           
+  snap-lxd-21039.mount                                                        loaded active mounted   Mount unit for lxd, revision 21039                                            
+  snap-lxd-21260.mount                                                        loaded active mounted   Mount unit for lxd, revision 21260                                            
+  snap-snapd-12398.mount                                                      loaded active mounted   Mount unit for snapd, revision 12398                                          
+  snap-snapd-12704.mount                                                      loaded active mounted   Mount unit for snapd, revision 12704                                          
+  sys-fs-fuse-connections.mount                                               loaded active mounted   FUSE Control File System                                                      
+  sys-kernel-config.mount                                                     loaded active mounted   Kernel Configuration File System                                              
+  sys-kernel-debug-tracing.mount                                              loaded active mounted   /sys/kernel/debug/tracing                                                     
+  sys-kernel-debug.mount                                                      loaded active mounted   Kernel Debug File System                                                      
+  sys-kernel-tracing.mount                                                    loaded active mounted   Kernel Trace File System                                                      
+  var-lib-ceph-osd-ceph\x2d0.mount                                            loaded active mounted   /var/lib/ceph/osd/ceph-0                                                      
+  var-snap-lxd-common-ns-mntns.mount                                          loaded active mounted   /var/snap/lxd/common/ns/mntns                                                 
+  var-snap-lxd-common-ns-shmounts.mount                                       loaded active mounted   /var/snap/lxd/common/ns/shmounts                                              
+  var-snap-lxd-common-ns.mount                                                loaded active mounted   /var/snap/lxd/common/ns                                                       
+  systemd-ask-password-console.path                                           loaded active waiting   Dispatch Password Requests to Console Directory Watch                         
+  systemd-ask-password-wall.path                                              loaded active waiting   Forward Password Requests to Wall Directory Watch                             
+  init.scope                                                                  loaded active running   System and Service Manager                                                    
+  machine-qemu\x2d3\x2dinstance\x2d00000008.scope                             loaded active running   Virtual Machine qemu-3-instance-00000008                                      
+  machine-qemu\x2d4\x2dinstance\x2d0000000b.scope                             loaded active running   Virtual Machine qemu-4-instance-0000000b                                      
+  session-186.scope                                                           loaded active running   Session 186 of user ubuntu                                                    
+  snap.lxd.lxd.81ed5a89-bd08-4cb1-b1eb-de37109c1a0e.scope                     loaded active running   snap.lxd.lxd.81ed5a89-bd08-4cb1-b1eb-de37109c1a0e.scope                       
+  apparmor.service                                                            loaded active exited    Load AppArmor profiles                                                        
+  apport.service                                                              loaded active exited    LSB: automatic crash report generation                                        
+  atd.service                                                                 loaded active running   Deferred execution scheduler                                                  
+  blk-availability.service                                                    loaded active exited    Availability of block devices                                                 
+  ceph-crash.service                                                          loaded active running   Ceph crash dump collector                                                     
+  ceph-osd@0.service                                                          loaded active running   Ceph object storage daemon osd.0                                              
+  cloud-config.service                                                        loaded active exited    Apply the settings specified in cloud-config                                  
+  cloud-final.service                                                         loaded active exited    Execute cloud user/final scripts                                              
+  cloud-init-local.service                                                    loaded active exited    Initial cloud-init job (pre-networking)                                       
+  cloud-init.service                                                          loaded active exited    Initial cloud-init job (metadata service crawler)                             
+  console-setup.service                                                       loaded active exited    Set console font and keymap                                                   
+  cron.service                                                                loaded active running   Regular background program processing daemon                                  
+  dbus.service                                                                loaded active running   D-Bus System Message Bus                                                      
+  finalrd.service                                                             loaded active exited    Create final runtime dir for shutdown pivot root                              
+* fwupd-refresh.service                                                       loaded failed failed    Refresh fwupd metadata and update motd                                        
+  fwupd.service                                                               loaded active running   Firmware update daemon                                                        
+  getty@tty1.service                                                          loaded active running   Getty on tty1                                                                 
+  grub-common.service                                                         loaded active exited    LSB: Record successful boot for GRUB                                          
+  haproxy.service                                                             loaded active running   HAProxy Load Balancer                                                         
+  ipvsadm.service                                                             loaded active exited    LSB: ipvsadm daemon                                                           
+  irqbalance.service                                                          loaded active running   irqbalance daemon                                                             
+  jujud-machine-1.service                                                     loaded active running   juju agent for machine-1                                                      
+  keyboard-setup.service                                                      loaded active exited    Set the console keyboard layout                                               
+  kmod-static-nodes.service                                                   loaded active exited    Create list of static device nodes for the current kernel                     
+  libvirt-guests.service                                                      loaded active exited    Suspend/Resume Running libvirt Guests                                         
+  libvirtd.service                                                            loaded active running   Virtualization daemon                                                         
+  lvm2-monitor.service                                                        loaded active exited    Monitoring of LVM2 mirrors, snapshots etc. using dmeventd or progress polling 
+  multipathd.service                                                          loaded active running   Device-Mapper Multipath Device Controller                                     
+  networkd-dispatcher.service                                                 loaded active running   Dispatcher daemon for systemd-networkd                                        
+  neutron-dhcp-agent.service                                                  loaded active running   OpenStack Neutron DHCP agent                                                  
+  neutron-l3-agent.service                                                    loaded active running   OpenStack Neutron L3 agent                                                    
+  neutron-metadata-agent.service                                              loaded active running   OpenStack Neutron Metadata Agent                                              
+  neutron-openvswitch-agent.service                                           loaded active running   Openstack Neutron Open vSwitch Plugin Agent                                   
+  neutron-ovs-cleanup.service                                                 loaded active exited    OpenStack Neutron OVS cleanup                                                 
+  nova-api-metadata.service                                                   loaded active running   OpenStack Compute metadata API                                                
+  nova-compute.service                                                        loaded active running   OpenStack Compute                                                             
+  openvswitch-switch.service                                                  loaded active exited    Open vSwitch                                                                  
+  ovs-record-hostname.service                                                 loaded active exited    Open vSwitch Record Hostname                                                  
+  ovs-vswitchd.service                                                        loaded active running   Open vSwitch Forwarding Unit                                                  
+  ovsdb-server.service                                                        loaded active running   Open vSwitch Database Unit                                                    
+  polkit.service                                                              loaded active running   Authorization Manager                                                         
+  qemu-kvm.service                                                            loaded active exited    QEMU KVM preparation - module, ksm, hugepages                                 
+  radosgw.service                                                             loaded active exited    LSB: radosgw RESTful rados gateway                                            
+  rbdmap.service                                                              loaded active exited    Map RBD devices                                                               
+  rpcbind.service                                                             loaded active running   RPC bind portmap service                                                      
+  rsyslog.service                                                             loaded active running   System Logging Service                                                        
+  setvtrgb.service                                                            loaded active exited    Set console scheme                                                            
+  smartmontools.service                                                       loaded active running   Self Monitoring and Reporting Technology (SMART) Daemon                       
+  snap.lxd.daemon.service                                                     loaded active running   Service for snap application lxd.daemon                                       
+  snap.lxd.workaround.service                                                 loaded active exited    /bin/true                                                                     
+  snapd.apparmor.service                                                      loaded active exited    Load AppArmor profiles managed internally by snapd                            
+  snapd.seeded.service                                                        loaded active exited    Wait until snapd is fully seeded                                              
+  snapd.service                                                               loaded active running   Snap Daemon                                                                   
+  ssh.service                                                                 loaded active running   OpenBSD Secure Shell server                                                   
+  systemd-hostnamed.service                                                   loaded active running   Hostname Service                                                              
+  systemd-journal-flush.service                                               loaded active exited    Flush Journal to Persistent Storage                                           
+  systemd-journald.service                                                    loaded active running   Journal Service                                                               
+  systemd-logind.service                                                      loaded active running   Login Service                                                                 
+  systemd-machined.service                                                    loaded active running   Virtual Machine and Container Registration Service                            
+  systemd-modules-load.service                                                loaded active exited    Load Kernel Modules                                                           
+  systemd-networkd-wait-online.service                                        loaded active exited    Wait for Network to be Configured                                             
+  systemd-networkd.service                                                    loaded active running   Network Service                                                               
+  systemd-random-seed.service                                                 loaded active exited    Load/Save Random Seed                                                         
+  systemd-remount-fs.service                                                  loaded active exited    Remount Root and Kernel File Systems                                          
+  systemd-resolved.service                                                    loaded active running   Network Name Resolution                                                       
+  systemd-sysctl.service                                                      loaded active exited    Apply Kernel Variables                                                        
+  systemd-sysusers.service                                                    loaded active exited    Create System Users                                                           
+  systemd-timesyncd.service                                                   loaded active running   Network Time Synchronization                                                  
+  systemd-tmpfiles-setup-dev.service                                          loaded active exited    Create Static Device Nodes in /dev                                            
+  systemd-tmpfiles-setup.service                                              loaded active exited    Create Volatile Files and Directories                                         
+  systemd-udev-settle.service                                                 loaded active exited    udev Wait for Complete Device Initialization                                  
+  systemd-udev-trigger.service                                                loaded active exited    udev Coldplug all Devices                                                     
+  systemd-udevd.service                                                       loaded active running   udev Kernel Device Manager                                                    
+  systemd-update-utmp.service                                                 loaded active exited    Update UTMP about System Boot/Shutdown                                        
+  systemd-user-sessions.service                                               loaded active exited    Permit User Sessions                                                          
+  ubuntu-fan.service                                                          loaded active exited    Ubuntu FAN network setup                                                      
+  udisks2.service                                                             loaded active running   Disk Manager                                                                  
+  ufw.service                                                                 loaded active exited    Uncomplicated firewall                                                        
+  unattended-upgrades.service                                                 loaded active running   Unattended Upgrades Shutdown                                                  
+  upower.service                                                              loaded active running   Daemon for power management                                                   
+  user-runtime-dir@1000.service                                               loaded active exited    User Runtime Directory /run/user/1000                                         
+  user@1000.service                                                           loaded active running   User Manager for UID 1000                                                     
+  uuidd.service                                                               loaded active running   Daemon for generating UUIDs                                                   
+  virtlogd.service                                                            loaded active running   Virtual machine log manager                                                   
+  -.slice                                                                     loaded active active    Root Slice                                                                    
+  machine.slice                                                               loaded active active    Virtual Machine and Container Slice                                           
+  system-ceph\x2dosd.slice                                                    loaded active active    system-ceph\x2dosd.slice                                                      
+  system-ceph\x2dvolume.slice                                                 loaded active active    system-ceph\x2dvolume.slice                                                   
+  system-getty.slice                                                          loaded active active    system-getty.slice                                                            
+  system-lvm2\x2dpvscan.slice                                                 loaded active active    system-lvm2\x2dpvscan.slice                                                   
+  system-modprobe.slice                                                       loaded active active    system-modprobe.slice                                                         
+  system-vaultlocker\x2ddecrypt.slice                                         loaded active active    system-vaultlocker\x2ddecrypt.slice                                           
+  system.slice                                                                loaded active active    System Slice                                                                  
+  user-1000.slice                                                             loaded active active    User Slice of UID 1000                                                        
+  user.slice                                                                  loaded active active    User and Session Slice                                                        
+  dbus.socket                                                                 loaded active running   D-Bus System Message Bus Socket                                               
+  dm-event.socket                                                             loaded active listening Device-mapper event daemon FIFOs                                              
+  iscsid.socket                                                               loaded active listening Open-iSCSI iscsid Socket                                                      
+  libvirtd-admin.socket                                                       loaded active running   Libvirt admin socket                                                          
+  libvirtd-ro.socket                                                          loaded active running   Libvirt local read-only socket                                                
+  libvirtd.socket                                                             loaded active running   Libvirt local socket                                                          
+  lvm2-lvmpolld.socket                                                        loaded active listening LVM2 poll daemon socket                                                       
+  multipathd.socket                                                           loaded active running   multipathd control socket                                                     
+  rpcbind.socket                                                              loaded active running   RPCbind Server Activation Socket                                              
+  snap.lxd.daemon.unix.socket                                                 loaded active running   Socket unix for snap application lxd.daemon                                   
+  snapd.socket                                                                loaded active running   Socket activation for snappy daemon                                           
+  syslog.socket                                                               loaded active running   Syslog Socket                                                                 
+  systemd-initctl.socket                                                      loaded active listening initctl Compatibility Named Pipe                                              
+  systemd-journald-audit.socket                                               loaded active running   Journal Audit Socket                                                          
+  systemd-journald-dev-log.socket                                             loaded active running   Journal Socket (/dev/log)                                                     
+  systemd-journald.socket                                                     loaded active running   Journal Socket                                                                
+  systemd-networkd.socket                                                     loaded active running   Network Service Netlink Socket                                                
+  systemd-rfkill.socket                                                       loaded active listening Load/Save RF Kill Switch Status /dev/rfkill Watch                             
+  systemd-udevd-control.socket                                                loaded active running   udev Control Socket                                                           
+  systemd-udevd-kernel.socket                                                 loaded active running   udev Kernel Socket                                                            
+  uuidd.socket                                                                loaded active running   UUID daemon activation socket                                                 
+  virtlockd-admin.socket                                                      loaded active listening Virtual machine lock manager admin socket                                     
+  virtlockd.socket                                                            loaded active listening Virtual machine lock manager socket                                           
+  virtlogd-admin.socket                                                       loaded active running   Virtual machine log manager socket                                            
+  virtlogd.socket                                                             loaded active running   Virtual machine log manager socket                                            
+  swap.img.swap                                                               loaded active active    /swap.img                                                                     
+  basic.target                                                                loaded active active    Basic System                                                                  
+  ceph-mds.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mds@.service instances at once    
+  ceph-mgr.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mgr@.service instances at once    
+  ceph-mon.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mon@.service instances at once    
+  ceph-osd.target                                                             loaded active active    ceph target allowing to start/stop all ceph-osd@.service instances at once    
+  ceph-radosgw.target                                                         loaded active active    ceph target allowing to start/stop all ceph-radosgw@.service instances at once
+  ceph.target                                                                 loaded active active    ceph target allowing to start/stop all ceph*@.service instances at once       
+  cloud-config.target                                                         loaded active active    Cloud-config availability                                                     
+  cloud-init.target                                                           loaded active active    Cloud-init target                                                             
+  cryptsetup.target                                                           loaded active active    Local Encrypted Volumes                                                       
+  getty.target                                                                loaded active active    Login Prompts                                                                 
+  graphical.target                                                            loaded active active    Graphical Interface                                                           
+  local-fs-pre.target                                                         loaded active active    Local File Systems (Pre)                                                      
+  local-fs.target                                                             loaded active active    Local File Systems                                                            
+  machines.target                                                             loaded active active    Containers                                                                    
+  multi-user.target                                                           loaded active active    Multi-User System                                                             
+  network-online.target                                                       loaded active active    Network is Online                                                             
+  network-pre.target                                                          loaded active active    Network (Pre)                                                                 
+  network.target                                                              loaded active active    Network                                                                       
+  nfs-client.target                                                           loaded active active    NFS client services                                                           
+  nss-lookup.target                                                           loaded active active    Host and Network Name Lookups                                                 
+  nss-user-lookup.target                                                      loaded active active    User and Group Name Lookups                                                   
+  paths.target                                                                loaded active active    Paths                                                                         
+  remote-fs-pre.target                                                        loaded active active    Remote File Systems (Pre)                                                     
+  remote-fs.target                                                            loaded active active    Remote File Systems                                                           
+  rpcbind.target                                                              loaded active active    RPC Port Mapper                                                               
+  slices.target                                                               loaded active active    Slices                                                                        
+  sockets.target                                                              loaded active active    Sockets                                                                       
+  swap.target                                                                 loaded active active    Swap                                                                          
+  sysinit.target                                                              loaded active active    System Initialization                                                         
+  time-set.target                                                             loaded active active    System Time Set                                                               
+  time-sync.target                                                            loaded active active    System Time Synchronized                                                      
+  timers.target                                                               loaded active active    Timers                                                                        
+  virt-guest-shutdown.target                                                  loaded active active    Libvirt guests shutdown                                                       
+  apt-daily-upgrade.timer                                                     loaded active waiting   Daily apt upgrade and clean activities                                        
+  apt-daily.timer                                                             loaded active waiting   Daily apt download activities                                                 
+  e2scrub_all.timer                                                           loaded active waiting   Periodic ext4 Online Metadata Check for All Filesystems                       
+  fstrim.timer                                                                loaded active waiting   Discard unused blocks once a week                                             
+  fwupd-refresh.timer                                                         loaded active waiting   Refresh fwupd metadata regularly                                              
+  logrotate.timer                                                             loaded active waiting   Daily rotation of log files                                                   
+  man-db.timer                                                                loaded active waiting   Daily man-db regeneration                                                     
+  motd-news.timer                                                             loaded active waiting   Message of the Day                                                            
+  systemd-tmpfiles-clean.timer                                                loaded active waiting   Daily Cleanup of Temporary Directories                                        
+  ua-messaging.timer                                                          loaded active waiting   Ubuntu Advantage update messaging                                             
+
+LOAD   = Reflects whether the unit definition was properly loaded.
+ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
+SUB    = The low-level unit activation state, values depend on unit type.
+
+307 loaded units listed. Pass --all to see loaded but inactive units, too.
+To show all installed unit files use 'systemctl list-unit-files'.

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -46,10 +46,18 @@ class TestOpenvswitchServiceInfo(TestOpenvswitchBase):
         self.assertEqual(inst.output, expected)
 
     def test_get_resource_checks(self):
-        expected = {'services': {'systemd': {'static':
-                                             ['ovs-vswitchd', 'ovsdb-server']},
-                                 'ps': ['ovs-vswitchd (1)', 'ovsdb-client (1)',
-                                        'ovsdb-server (1)']}}
+        expected = {'services': {
+                        'systemd': {
+                            'enabled': [
+                                'openvswitch-switch'
+                                ],
+                            'static': [
+                                'ovs-vswitchd', 'ovsdb-server'
+                                ]
+                            },
+                        'ps': [
+                            'ovs-vswitchd (1)', 'ovsdb-client (1)',
+                            'ovsdb-server (1)']}}
         inst = service_info.OpenvSwitchServiceChecks()
         inst()
         self.assertEqual(inst.output, expected)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -223,14 +223,16 @@ class TestStorageCephServiceInfo(StorageTestsBase):
 
     def test_get_service_info(self):
         svc_info = {'systemd': {'enabled': [
-                                    'ceph-crash'],
+                                    'ceph-crash',
+                                    'ceph-osd',
+                                    ],
                                 'disabled': [
+                                    'ceph-mon',
                                     'ceph-mds',
                                     'ceph-mgr',
-                                    'ceph-mon',
-                                    'ceph-radosgw'],
-                                'indirect': ['ceph-osd',
-                                             'ceph-volume'],
+                                    'ceph-radosgw',
+                                    ],
+                                'indirect': ['ceph-volume'],
                                 'generated': ['radosgw']},
                     'ps': ['ceph-crash (1)', 'ceph-osd (1)']}
         expected = {'ceph': {


### PR DESCRIPTION
Adds support for registering services that are expected to
be marked as masked with each project definition and excludes
them from the final check.

Resolves: #183