### PR TITLE
Drop unnecessary `channel_id`

### DIFF
--- a/.github/workflows/notifications.yaml
+++ b/.github/workflows/notifications.yaml
@@ -5,7 +5,7 @@ on:
       - opened
   pull_request:
     branches:
-      - main
+      - master
     types:
       - opened
       - reopened
@@ -36,7 +36,6 @@ jobs:
           URL=$(jq -r '.issue.html_url' ${GITHUB_EVENT_PATH})
           curl -i -X POST -H "Content-Type: application/json" \
             -d "{ \
-              \"channel_id\": \"${{ secrets.CHANNEL_ID }}\", \
               \"text\": \"New Issue: ${{ github.event.action }} '${TITLE}' at ${URL}\" \
               }" \
             ${{ secrets.WEBHOOK_URI }}


### PR DESCRIPTION
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>