### PR TITLE
[openstack/storage] Test if bache-tuning charm is enabled

### DIFF
--- a/defs/plugins.yaml
+++ b/defs/plugins.yaml
@@ -91,3 +91,4 @@ plugins:
       bcache:
         - BcacheDeviceChecks
         - BcacheCSetChecks
+        - BcacheCharmChecks

--- a/plugins/storage/pyparts/ceph_cluster_checks.py
+++ b/plugins/storage/pyparts/ceph_cluster_checks.py
@@ -27,8 +27,8 @@ class CephClusterChecks(CephChecksBase):
             return
 
         if self.health_status != 'HEALTH_OK':
-            msg = ("Ceph cluster is '{}'. Please check 'ceph status' for "
-                   "details".format(self.health_status))
+            msg = ("Ceph cluster is in '{}' state. Please check 'ceph status' "
+                   "for details".format(self.health_status))
             issue_utils.add_issue(issue_types.CephHealthWarning(msg))
 
     def check_laggy_pgs(self):

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -651,3 +651,17 @@ class TestStorageConfigChecks(StorageTestsBase):
             os.environ['DATA_ROOT'] = dtmp
             YConfigChecker()()
             self.assertFalse(mock_add_issue.called)
+
+    @mock.patch('core.issues.issue_utils.add_issue')
+    def test_bcache_unit(self, mock_add_issue):
+        issues = []
+
+        def fake_add_issue(issue):
+            issues.append(issue)
+
+        mock_add_issue.side_effect = fake_add_issue
+        inst = bcache.BcacheCharmChecks()
+        inst()
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(type(issues[0]), issue_types.BcacheWarning)
+        self.assertTrue(mock_add_issue.called)


### PR DESCRIPTION
If there are OSD units deployed with bcache devices, we want
to check if the default bcache params are tweaked with
bcache-tuning charm.

Closes: #195

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>