### PR TITLE
[openstack] add *-manage.log to all project logs

### DIFF
--- a/core/plugins/openstack/__init__.py
+++ b/core/plugins/openstack/__init__.py
@@ -214,8 +214,12 @@ class OSTProject(object):
         """
         Returns tuples of daemon name, log path for each agent/daemon.
         """
+        proj_manage = "{}-manage".format(self.name)
+        yield proj_manage, os.path.join('var/log', self.name,
+                                        "{}.log".format(proj_manage))
         for daemon in self.daemon_names:
-            path = os.path.join('var/log', self.name, daemon)
+            path = os.path.join('var/log', self.name,
+                                "{}.log".format(daemon))
             yield daemon, self.log_path_overrides.get(daemon, path)
 
 


### PR DESCRIPTION
All openstack services have a *-manage log that contains
logs for things like database migrations so we now add
that to the list of logs we check for all projects.

Also ensures correct log path is returned when not using
--all-logs.

Resolves: #107