### PR TITLE
Add `json` option to output

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -20,6 +20,10 @@ class constants_properties(type):
         return cls._MASTER_YAML_OUT()
 
     @property
+    def OUTPUT_FORMAT(cls):
+        return cls._OUTPUT_FORMAT()
+
+    @property
     def PLUGIN_TMP_DIR(cls):
         return cls._PLUGIN_TMP_DIR()
 
@@ -77,6 +81,10 @@ class constants(object, metaclass=constants_properties):
     @classmethod
     def _MASTER_YAML_OUT(cls):
         return os.environ.get('MASTER_YAML_OUT')
+
+    @classmethod
+    def _OUTPUT_FORMAT(cls):
+        return os.environ.get('OUTPUT_FORMAT', 'yaml')
 
     @classmethod
     def _PLUGIN_TMP_DIR(cls):

--- a/core/plugintools.py
+++ b/core/plugintools.py
@@ -17,7 +17,7 @@ class HOTSOSDumper(yaml.Dumper):
 def save_part(data, priority=0):
     """
     Save part output yaml in temporary location. These are collected and
-    aggregrated at the end of the plugin run.
+    aggregated at the end of the plugin run.
     """
     HOTSOSDumper.add_representer(
         dict,

--- a/tools/output_format_converter.py
+++ b/tools/output_format_converter.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import yaml
+
+from core import constants
+from core.log import log
+
+if __name__ == '__main__':
+    log.debug('Converting master yaml file')
+    if constants.OUTPUT_FORMAT == 'yaml':
+        sys.exit(0)
+    with open(constants.MASTER_YAML_OUT, encoding='utf-8') as fd:
+        master_yaml = yaml.safe_load(fd)
+    if constants.OUTPUT_FORMAT == 'json':
+        with open(constants.MASTER_YAML_OUT, 'w', encoding='utf-8') as fd:
+            fd.write(json.dumps(master_yaml, indent=2, sort_keys=True))


### PR DESCRIPTION
This change adds a `json` option to the hotsos output. The default is still
`yaml`.

Closes: canonical/hotsos#207
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>