### PR TITLE
Add `bashate` to tox envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = pep8,pylint,py3
+envlist = pep8,pylint,bashate,py3
 sitepackages = False
 
 [gh-actions]


### PR DESCRIPTION
So we run `bashate` by default.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>