### PR TITLE
[pylint] use git ls-files for pylint

### DIFF
--- a/core/plugins/openstack/exceptions.py
+++ b/core/plugins/openstack/exceptions.py
@@ -102,7 +102,7 @@ OSLO_MESSAGING_EXCEPTIONS = [
     "MessageUndeliverable",
 ]
 
-# From https://github.com/libvirt/libvirt-python used by Nova 
+# From https://github.com/libvirt/libvirt-python used by Nova
 PYTHON_LIBVIRT_EXCEPTIONS = [
     "libvirtError",
 ]

--- a/tools/test/run_pylint.sh
+++ b/tools/test/run_pylint.sh
@@ -1,19 +1,13 @@
 #!/bin/bash -u
 root=`dirname $0`
 num_files_checked=0
-num_errors_found=0
-dirs=( $@ )
 declare -a files_to_check=()
 
 echo "INFO: starting pylint tests"
-for dir in ${dirs[@]}; do
-    for f in `find $dir -type f| grep -v fake_data_root`; do
-        if `file $f| grep -q "Python script"`; then
-            files_to_check+=( $f )
-            num_files_checked=$((num_files_checked + 1))
-        fi
-    done
-done
+files_to_check=($(git ls-files '*.py'))
+files_to_check+=($(git ls-files --others --exclude-standard '*.py'))
+num_files_checked=${#files_to_check[@]}
+
 pylint --rcfile=${root}/.pylintrc ${files_to_check[@]}
 rc=$?
 echo -e "INFO: $num_files_checked python files checked with pylint."

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,7 @@ commands = {toxinidir}/tools/test/run_flake8.sh \
 
 [testenv:pylint]
 basepython = python3
-commands = {toxinidir}/tools/test/run_pylint.sh \
-           {toxinidir}/core \
-           {toxinidir}/plugins \
-           {toxinidir}/tools \
-           {toxinidir}/tests/unit
+commands = {toxinidir}/tools/test/run_pylint.sh
 
 [testenv:bashate]
 basepython = python3


### PR DESCRIPTION
Use git ls-files to get list of python files
instead of using find command.
Fix pylint issues in exceptions.py

Closes: #217