### PR TITLE
[systemd] fix sysctl check

### DIFF
--- a/plugins/system/pyparts/checks.py
+++ b/plugins/system/pyparts/checks.py
@@ -60,6 +60,11 @@ class SystemChecks(SystemChecksBase):
                 continue
 
             for conf in os.listdir(path):
+                # Only files ending in .conf are recognised by sysctl so don't
+                # count content of other files as expected.
+                if not conf.endswith('.conf'):
+                    continue
+
                 sysctl = SYSCtlHelper(os.path.join(path, conf))
                 for key, value in sysctl.all.items():
                     if key in sysctl_key_priorities:

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -51,10 +51,10 @@ class TestSystemChecks(utils.BaseTestCase):
             orig_data_root = os.environ['DATA_ROOT']
             os.environ['DATA_ROOT'] = dtmp
             os.makedirs(os.path.join(dtmp, 'etc'))
-            shutil.copy(os.path.join(orig_data_root, 'etc/sysctl.conf'),
-                        os.path.join(dtmp, 'etc'))
-            shutil.copytree(os.path.join(orig_data_root, 'etc/sysctl.d'),
-                            os.path.join(dtmp, 'etc/sysctl.d'))
+            etc_sysctl_conf = os.path.join(orig_data_root, 'etc/sysctl.conf')
+            etc_sysctl_d = os.path.join(orig_data_root, 'etc/sysctl.d')
+            shutil.copy(etc_sysctl_conf, os.path.join(dtmp, 'etc'))
+            shutil.copytree(etc_sysctl_d, os.path.join(dtmp, 'etc/sysctl.d'))
             shutil.copytree(os.path.join(orig_data_root, 'usr/lib/sysctl.d'),
                             os.path.join(dtmp, 'usr/lib/sysctl.d'))
             os.makedirs(os.path.join(dtmp, 'sos_commands'))
@@ -66,6 +66,11 @@ class TestSystemChecks(utils.BaseTestCase):
             with open(os.path.join(dtmp, 'etc/sysctl.d/99-unit-test.conf'),
                       'w') as fd:
                 fd.write("kernel.pid_max = 12345678")
+
+            # inject an unset value into an invalid file
+            with open(os.path.join(dtmp, 'etc/sysctl.d/98-unit-test.conf.bak'),
+                      'w') as fd:
+                fd.write("kernel.watchdog = 0")
 
             inst = checks.SystemChecks()
             inst()


### PR DESCRIPTION
systctl only reads files under sysctl.d that end in
.conf so we need to ingore ones that dont.

Resolves: #223