### PR TITLE
[storage] Report PGs with large omap objects

### DIFF
--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -155,9 +155,12 @@ CEPH_OSD_CRUSH_DUMP = """
 """
 
 PG_DUMP_JSON_DECODED = {'pg_map': {
-                            'pg_stats': [
-                                {'pgid': '2.f',
-                                 'state': 'active+clean+laggy'}]}}
+                          'pg_stats': [
+                            {'stat_sum': {'num_large_omap_objects': 1},
+                             'last_scrub_stamp': '2021-09-16T21:26:00.00',
+                             'last_deep_scrub_stamp': '2021-09-16T21:26:00.00',
+                             'pgid': '2.f',
+                             'state': 'active+clean+laggy'}]}}
 
 
 class StorageTestsBase(utils.BaseTestCase):
@@ -541,6 +544,22 @@ class TestStorageCephClusterChecks(StorageTestsBase):
             PG_DUMP_JSON_DECODED
         inst = ceph_cluster_checks.CephClusterChecks()
         inst.check_laggy_pgs()
+        self.assertTrue(mock_add_issue.called)
+
+    @mock.patch.object(ceph_cluster_checks.issue_utils, 'add_issue')
+    def test_check_large_omap_objects_no_issue(self, mock_add_issue):
+        inst = ceph_cluster_checks.CephClusterChecks()
+        inst.check_large_omap_objects()
+        self.assertFalse(mock_add_issue.called)
+
+    @mock.patch('core.plugins.storage.ceph.CLIHelper')
+    @mock.patch.object(ceph_cluster_checks.issue_utils, 'add_issue')
+    def test_check_large_omap_objects_w_issue(self, mock_add_issue, mock_cli):
+        mock_cli.return_value = mock.MagicMock()
+        mock_cli.return_value.ceph_pg_dump_json_decoded.return_value = \
+            PG_DUMP_JSON_DECODED
+        inst = ceph_cluster_checks.CephClusterChecks()
+        inst.check_large_omap_objects()
         self.assertTrue(mock_add_issue.called)
 
 


### PR DESCRIPTION
Large OMAP objects are typically resolved by deep scrubbing
the PGs or by resharding the buckets if they keys are over
the limit.

Closes: #215

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>