### PR TITLE
[kubernetes] detect apt or snap packages

### DIFF
--- a/core/plugins/kubernetes.py
+++ b/core/plugins/kubernetes.py
@@ -16,25 +16,26 @@ SERVICES = [r"etcd\S*",
             r"kube-\S*",
             ]
 
-# Snaps that only exist in a K8s deployment
-K8S_SNAPS = [r'charm[\S]+',
-             r'conjure-up',
-             r'cdk-addons',
-             r'helm',
-             r'kubernetes-[\S]+',
-             r'kube-[\S]+',
-             r'kubectl',
-             r'kubelet',
-             r'kubeadm',
-             r'kubefed',
-             ]
-# Snaps that are used in a K8s deployment
-K8S_DEP_SNAPS = [r'core[0-9]*',
-                 r'docker',
-                 r'go',
-                 r'vault',
-                 r'etcd',
-                 ]
+# Packages that only exist in a K8s deployment
+K8S_PACKAGES = [r'charm[\S]+',
+                r'cdk-addons',
+                r'helm',
+                r'kubernetes-[\S]+',
+                r'kube-[\S]+',
+                r'kubectl',
+                r'kubelet',
+                r'kubeadm',
+                r'kubefed',
+                ]
+# Packages that are used in a K8s deployment
+K8S_PACKAGE_DEPS = [r'docker',
+                    r'go',
+                    r'vault',
+                    r'etcd',
+                    r'conjure-up',
+                    ]
+# Snap-only deps
+K8S_PACKAGE_DEPS_SNAP = [r'core[0-9]*']
 
 
 class KubernetesBase(object):
@@ -66,12 +67,14 @@ class KubernetesBase(object):
         if self._pods:
             return self._pods
 
+        _pods = []
         pods_path = os.path.join(constants.DATA_ROOT,
                                  "var/log/pods")
         if os.path.exists(pods_path):
             for pod in os.listdir(pods_path):
-                self._pods.append(pod)
+                _pods.append(pod)
 
+        self._pods = sorted(_pods)
         return self._pods
 
     @property
@@ -79,12 +82,15 @@ class KubernetesBase(object):
         if self._containers:
             return self._containers
 
+        _containers = []
         containers_path = os.path.join(constants.DATA_ROOT,
                                        "var/log/containers")
         if os.path.exists(containers_path):
             for pod in os.listdir(containers_path):
-                self._containers.append(pod)
+                pod = pod.partition('.log')[0]
+                _containers.append(pod)
 
+        self._containers = sorted(_containers)
         return self._containers
 
 
@@ -93,13 +99,17 @@ class KubernetesChecksBase(KubernetesBase, plugintools.PluginPartBase,
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        deps = K8S_DEP_SNAPS
-        self.snap_check = checks.SnapPackageChecksBase(core_snaps=K8S_SNAPS,
-                                                       other_snaps=deps)
+        deps = K8S_PACKAGE_DEPS
+        # Deployments can use snap or apt versions of packages so we check both
+        self.apt_check = checks.APTPackageChecksBase(core_pkgs=K8S_PACKAGES,
+                                                     other_pkgs=deps)
+        snap_deps = deps + K8S_PACKAGE_DEPS_SNAP
+        self.snap_check = checks.SnapPackageChecksBase(core_snaps=K8S_PACKAGES,
+                                                       other_snaps=snap_deps)
 
     @property
     def plugin_runnable(self):
-        if self.snap_check.core:
+        if self.apt_check.core or self.snap_check.core:
             return True
 
         return False

--- a/defs/plugins.yaml
+++ b/defs/plugins.yaml
@@ -61,9 +61,9 @@ plugins:
   kubernetes:
     parts:
       service_info:
-        - KubernetesResourceChecks
         - KubernetesServiceChecks
         - KubernetesPackageChecks
+        - KubernetesResourceChecks
       network_checks:
         - KubernetesNetworkChecks
   rabbitmq:

--- a/plugins/kubernetes/pyparts/service_info.py
+++ b/plugins/kubernetes/pyparts/service_info.py
@@ -7,14 +7,20 @@ class KubernetesPackageChecks(KubernetesChecksBase):
 
     def __call__(self):
         """ Display relevant snaps installed. """
-        self._output["snaps"] = self.snap_check.all_formatted
+        snaps = self.snap_check.all_formatted
+        if snaps:
+            self._output['snaps'] = snaps
+
+        dpkg = self.apt_check.all_formatted
+        if dpkg:
+            self._output['dpkg'] = dpkg
 
 
 class KubernetesServiceChecks(KubernetesChecksBase):
 
     def get_running_services_info(self):
         if self.services:
-            self._output["services"] = self.service_info_str
+            self._output['services'] = self.service_info_str
 
     def __call__(self):
         """ Display relevant services and their status. """

--- a/tests/unit/test_kubernetes.py
+++ b/tests/unit/test_kubernetes.py
@@ -83,9 +83,9 @@ class TestKubernetesServiceInfo(KubernetesTestsBase):
         filterered_snaps = []
         for line in self.snaps_list:
             found = False
-            for snap in kubernetes_core.K8S_SNAPS:
+            for pkg in kubernetes_core.K8S_PACKAGES:
                 obj = service_info.KubernetesPackageChecks()
-                if obj.snap_check._get_snap_info_from_line(line, snap):
+                if obj.snap_check._get_snap_info_from_line(line, pkg):
                     found = True
                     break
 
@@ -96,7 +96,7 @@ class TestKubernetesServiceInfo(KubernetesTestsBase):
         inst = service_info.KubernetesPackageChecks()
         inst()
         self.assertFalse(inst.plugin_runnable)
-        self.assertEqual(inst.output, {'snaps': []})
+        self.assertEqual(inst.output, None)
 
 
 class TestKubernetesNetworkChecks(KubernetesTestsBase):


### PR DESCRIPTION
We currently assume that all things k8s are installed from
snaps but some deployments e.g. kubeadm using upstream docs
will use apt packages.

Resolves: #238