### PR TITLE
[openstack] check scaling_governor is performance

### DIFF
--- a/core/plugins/kernel.py
+++ b/core/plugins/kernel.py
@@ -8,6 +8,7 @@ from core import (
     plugintools,
 )
 from core.cli_helpers import CLIHelper
+from core.plugins.system import SystemBase
 
 BUDDY_INFO = os.path.join(constants.DATA_ROOT, "proc/buddyinfo")
 SLABINFO = os.path.join(constants.DATA_ROOT, "proc/slabinfo")
@@ -48,6 +49,22 @@ class CPU(SYSFSBase):
             return True
 
         return False
+
+    def cpufreq_scaling_governor(self, cpu_id):
+        return self.get('devices/system/cpu/cpu{}/cpufreq/scaling_governor'.
+                        format(cpu_id))
+
+    @property
+    def cpufreq_scaling_governor_all(self):
+        governors = set()
+        for id in range(SystemBase().num_cpus):
+            cpu_governor = self.cpufreq_scaling_governor(id)
+            if cpu_governor:
+                governors.add(cpu_governor)
+            else:
+                governors.add('unknown')
+
+        return ','.join(list(governors))
 
 
 class KernelConfig(checks.ConfigBase):

--- a/core/plugins/system.py
+++ b/core/plugins/system.py
@@ -99,12 +99,15 @@ class SystemBase(plugintools.PluginPartBase):
 
     @property
     def num_cpus(self):
+        """ Return number of cpus or 0 if none found. """
         lscpu_output = CLIHelper().lscpu()
         if lscpu_output:
             for line in lscpu_output:
                 ret = re.compile(r"^CPU\(s\):\s+([0-9]+)\s*.*").match(line)
                 if ret:
                     return int(ret[1])
+
+        return 0
 
     @property
     def loadavg(self):

--- a/defs/scenarios/openstack/system_cpufreq_mode.yaml
+++ b/defs/scenarios/openstack/system_cpufreq_mode.yaml
@@ -1,0 +1,27 @@
+checks:
+  cpufreq-not-performance-mode:
+    requires:
+      property: core.plugins.kernel.CPU.cpufreq_scaling_governor_all
+      value: performance
+      op: ne
+  nova-compute-installed:
+    requires:
+      apt: nova-compute
+conclusions:
+  compute-not-performance:
+    decision:
+      and:
+        - cpufreq-not-performance-mode
+        - nova-compute-installed
+    raises:
+      type: core.issues.issue_types.OpenstackWarning
+      message: >-
+        This node is used as an Openstack hypervisor but is not using cpufreq
+        scaling_governor in "performance" mode (actual={governor}). This is not
+        recommended and can result in performance degradation. To fix this you
+        can install cpufrequtils and set "GOVERNOR=performance" in
+        /etc/default/cpufrequtils.
+        NOTE: requires node reboot to take effect.
+      format-dict:
+        governor: core.plugins.kernel.CPU.cpufreq_scaling_governor_all
+

--- a/plugins/kernel/pyparts/info.py
+++ b/plugins/kernel/pyparts/info.py
@@ -21,6 +21,9 @@ class KernelGeneralChecks(KernelChecksBase):
         if cpu.isolated is not None and cpu.isolated != '':
             info['isolated'] = cpu.isolated
 
+        cpu_gov_all = cpu.cpufreq_scaling_governor_all
+        info['cpufreq-scaling-governor'] = cpu_gov_all
+
         return info
 
     def __call__(self):

--- a/plugins/system/pyparts/general.py
+++ b/plugins/system/pyparts/general.py
@@ -14,7 +14,7 @@ class SystemGeneral(SystemChecksBase):
             self._output["os"] = self.os_release_name
 
         if self.num_cpus:
-            self._output["num-cpus"] = int(self.num_cpus)
+            self._output["num-cpus"] = self.num_cpus
 
         if self.loadavg:
             self._output["load"] = self.loadavg

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -27,6 +27,7 @@ class TestKernelKernelInfo(TestKernelBase):
         inst = info.KernelGeneralChecks()
         inst()
         expected = {'boot': 'ro',
+                    'cpu': {'cpufreq-scaling-governor': 'unknown'},
                     'systemd': {'CPUAffinity': '0-7,32-39'},
                     'version': '5.4.0-80-generic'}
         self.assertTrue(inst.plugin_runnable)

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -898,6 +898,8 @@ class TestOpenstackBugChecks(TestOpenstackBase):
 
 class TestOpenstackScenarioChecks(TestOpenstackBase):
 
+    @mock.patch('core.plugins.kernel.CPU.cpufreq_scaling_governor_all',
+                'performance')
     @mock.patch('core.issues.issue_utils.add_issue')
     def test_scenarios_none(self, mock_add_issue):
         YScenarioChecker()()
@@ -909,15 +911,17 @@ class TestOpenstackScenarioChecks(TestOpenstackBase):
         issues = []
 
         def fake_add_issue(issue):
-            issues.append(issue)
+            issues.append(type(issue))
 
         mock_base.return_value = mock.MagicMock()
         mock_base.return_value.installed = True
         mock_base.return_value.hm_port_has_address = False
         mock_add_issue.side_effect = fake_add_issue
         YScenarioChecker()()
-        self.assertEqual(len(issues), 1)
-        self.assertEqual(type(issues[0]), issue_types.OpenstackError)
+        self.assertEqual(len(issues), 2)
+        for itype in [issue_types.OpenstackError,
+                      issue_types.OpenstackWarning]:
+            self.assertTrue(itype in issues)
 
 
 class TestOpenstackPackageChecks(TestOpenstackBase):


### PR DESCRIPTION
Adds cpu scaling_governor mode to kernel plugin
output and adds scenario check that performance
mode is used if host is used as a nova hypervisor.

Resolves: #245