### PR TITLE
[openstack] skip bug check if package has fix

### DIFF
--- a/core/ycheck/packages.py
+++ b/core/ycheck/packages.py
@@ -82,7 +82,6 @@ class YPackageChecker(AutoChecksBase):
                 for bug in bugs:
                     minbroken = bug['minbroken']
                     minfixed = bug['minfixed']
-                    log.debug(pkgver)
                     if (not pkgver < DPKGVersionCompare(minbroken) and
                             pkgver < DPKGVersionCompare(minfixed)):
                         log.debug("bug identified for package=%s release=%s "

--- a/defs/README.md
+++ b/defs/README.md
@@ -444,10 +444,25 @@ Supported properties
   * input
   * expr
   * raises
+  * context
+  * settings - see SETTINGS
   
 Supported subdefs
   * none
 
+```
+SETTINGS
+  package
+    Optinal name of package we want to check.
+
+  versions-affected
+    List of dicts. If a package name is provided we can check its
+                   version to see if it contains the bugfix. Each
+                   element contains the following:
+      min-fixed - minimum version of the package that contains the fix.
+      min-broken - (optional) minimum version of the package that contains the
+                    bug.
+```
 
 ### Config checks
 
@@ -461,12 +476,19 @@ message is displayed in the 'known-bugs' section of a plugin output.
 Supported properties
   * requires
   * config
-  * settings
+  * settings - see SETTINGS
   * raises
   
 Supported subdefs
   * none
 
+```
+SETTINGS
+  section - Optional config file section name.
+  op - python operator to apply. Default is eq.
+  value - Expected value.
+  allow-unset - Whether the config may be unset. Default is False.
+```
 
 ### Package checks
 

--- a/defs/bugs/openstack/nova.yaml
+++ b/defs/bugs/openstack/nova.yaml
@@ -6,6 +6,15 @@
   hint: 'NotImplementedError'
   raises:
     message: 'known nova bug identified'
+  settings:
+    package: 'nova-common'
+    versions-affected:
+      # train
+      - min-broken: 2:20.0.0
+        min-fixed: 2:20.6.0-0ubuntu1~cloud1
+      # ussuri
+      - min-broken: 2:21.0.0
+        min-fixed: 2:21.1.2-0ubuntu2~cloud0
 1944619:
   input:
     type: filesystem

--- a/defs/bugs/openstack/openstack.yaml
+++ b/defs/bugs/openstack/openstack.yaml
@@ -2,3 +2,5 @@
 # directory including subdirectories.
 requires:
   property: core.plugins.openstack.OpenstackChecksBase.plugin_runnable
+context:
+  apt-all: core.plugins.openstack.OpenstackBase.apt_packages_all

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -10,6 +10,7 @@ from core import checks
 from core import ycheck
 from core.ycheck import (
     YDefsSection,
+    bugs,
     events,
     configs,
     packages,
@@ -657,3 +658,22 @@ class TestChecks(utils.BaseTestCase):
         mock_plugin.return_value.r3 = True
         group = YDefsSection('test', requires)
         self.assertTrue(group.leaf_sections[0].requires.passes)
+
+    def test_bugs_handler_pkg_check(self):
+        versions = [{'min-broken': '5.0', 'min-fixed': '5.2'},
+                    {'min-broken': '4.0', 'min-fixed': '4.2'},
+                    {'min-broken': '3.0', 'min-fixed': '3.2'}]
+        self.assertTrue(bugs.YBugChecker().package_has_bugfix('2.0',
+                                                              versions))
+        self.assertFalse(bugs.YBugChecker().package_has_bugfix('3.0',
+                                                               versions))
+        self.assertFalse(bugs.YBugChecker().package_has_bugfix('4.0',
+                                                               versions))
+        self.assertFalse(bugs.YBugChecker().package_has_bugfix('5.0',
+                                                               versions))
+        self.assertTrue(bugs.YBugChecker().package_has_bugfix('5.2',
+                                                              versions))
+        self.assertTrue(bugs.YBugChecker().package_has_bugfix('5.3',
+                                                              versions))
+        self.assertTrue(bugs.YBugChecker().package_has_bugfix('6.0',
+                                                              versions))


### PR DESCRIPTION
Adds support to bug handler for bug def to specify a package
version range that contains the fix such that the check can
be skipped if the installed package version has the fix.

Resolves: #247