### PR TITLE
Add speed to NetworkPort

### DIFF
--- a/core/cli_helpers.py
+++ b/core/cli_helpers.py
@@ -541,6 +541,9 @@ class CLIHelper(object):
             'dpkg_l':
                 [BinCmd('dpkg -l'),
                  FileCmd('sos_commands/dpkg/dpkg_-l', safe_decode=True)],
+            'ethtool':
+                [BinCmd('ethool'),
+                 FileCmd('sos_commands/networking/ethtool_{interface}')],
             'hostname':
                 [BinCmd('hostname', singleline=True),
                  FileCmd('hostname', singleline=True)],

--- a/core/host_helpers.py
+++ b/core/host_helpers.py
@@ -40,7 +40,21 @@ class NetworkPort(object):
     def to_dict(self):
         return {self.name: {'addresses': self.addresses,
                             'hwaddr': self.hwaddr,
-                            'state': self.state}}
+                            'state': self.state,
+                            'speed': self.speed}}
+
+    @property
+    def speed(self):
+        # need to strip @* since sosreport does that too
+        name = self.name.partition('@')[0]
+        out = self.cli_helper.ethtool(interface=name)
+        if out:
+            for line in out:
+                ret = re.match(r'\s*Speed:\s+(\S+)', line)
+                if ret:
+                    return ret.group(1)
+
+        return 'unknown'
 
     @property
     def stats(self):

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -480,18 +480,21 @@ class TestOpenstackServiceNetworkChecks(TestOpenstackBase):
                     'br-ens3': {
                         'addresses': ['10.0.0.49'],
                         'hwaddr': '52:54:00:e2:28:a3',
-                        'state': 'UP'}}},
+                        'state': 'UP',
+                        'speed': 'unknown'}}},
                 'neutron': {'local_ip': {
                     'br-ens3': {
                         'addresses': ['10.0.0.49'],
                         'hwaddr': '52:54:00:e2:28:a3',
-                        'state': 'UP'}}},
+                        'state': 'UP',
+                        'speed': 'unknown'}}},
                 'octavia': {'o-hm0': {
                     'o-hm0': {
                         'addresses': [
                             'fc00:2203:1448:17b7:f816:3eff:fe4f:ed8a'],
                         'hwaddr': 'fa:16:3e:4f:ed:8a',
-                        'state': 'UNKNOWN'}}}
+                        'state': 'UNKNOWN',
+                        'speed': 'unknown'}}}
             },
             'namespaces': {
                 'fip': 1,

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -67,7 +67,8 @@ class TestOpenvswitchServiceInfo(TestOpenvswitchBase):
                                     {'ens7': {
                                         'addresses': [],
                                         'hwaddr': '52:54:00:78:19:c3',
-                                        'state': 'UP'}}],
+                                        'state': 'UP',
+                                        'speed': 'Unknown!'}}],
                                 'br-ex': [],
                                 'br-int': ['(7 ports)'],
                                 'br-tun': ['vxlan-0a000032',

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -244,12 +244,14 @@ class TestStorageCephServiceInfo(StorageTestsBase):
                                 'br-ens3': {
                                     'addresses': ['10.0.0.49'],
                                     'hwaddr': '52:54:00:e2:28:a3',
-                                    'state': 'UP'}},
+                                    'state': 'UP',
+                                    'speed': 'unknown'}},
                             'public': {
                                 'br-ens3': {
                                     'addresses': ['10.0.0.49'],
                                     'hwaddr': '52:54:00:e2:28:a3',
-                                    'state': 'UP'}}
+                                    'state': 'UP',
+                                    'speed': 'unknown'}}
                             },
                         'services': svc_info,
                         'release': 'octopus',
@@ -267,12 +269,14 @@ class TestStorageCephServiceInfo(StorageTestsBase):
                                 'br-ens3': {
                                     'addresses': ['10.0.0.49'],
                                     'hwaddr': '52:54:00:e2:28:a3',
-                                    'state': 'UP'}},
+                                    'state': 'UP',
+                                    'speed': 'unknown'}},
                             'public': {
                                 'br-ens3': {
                                     'addresses': ['10.0.0.49'],
                                     'hwaddr': '52:54:00:e2:28:a3',
-                                    'state': 'UP'}}
+                                    'state': 'UP',
+                                    'speed': 'unknown'}}
                             },
                         'release': 'unknown',
                         'status': 'HEALTH_WARN'}}
@@ -306,10 +310,12 @@ class TestStorageCephServiceInfo(StorageTestsBase):
     def test_ceph_base_interfaces(self):
         expected = {'cluster': {'br-ens3': {'addresses': ['10.0.0.49'],
                                             'hwaddr': '52:54:00:e2:28:a3',
-                                            'state': 'UP'}},
+                                            'state': 'UP',
+                                            'speed': 'unknown'}},
                     'public': {'br-ens3': {'addresses': ['10.0.0.49'],
                                            'hwaddr': '52:54:00:e2:28:a3',
-                                           'state': 'UP'}}}
+                                           'state': 'UP',
+                                           'speed': 'unknown'}}}
         ports = ceph_core.CephChecksBase().bind_interfaces
         _ports = {}
         for config, port in ports.items():


### PR DESCRIPTION
When we display port info such as state it is useful to
also have the port link speed. This is now included in
NetworkPort.