### PR TITLE
[storage] Correctly handle zero weight buckets

### DIFF
--- a/plugins/storage/pyparts/ceph_cluster_checks.py
+++ b/plugins/storage/pyparts/ceph_cluster_checks.py
@@ -302,8 +302,11 @@ class CephClusterChecks(CephChecksBase):
             issue_utils.add_issue(issue)
 
     def _is_bucket_imbalanced(self, buckets, start_bucket_id, failure_domain):
-        """
-        Recursively determine if a tree is balanced at the given failure domain
+        """Return whether a tree is unbalanced
+
+        Recursively determine if a given tree (start_bucket_id) is
+        balanced at the given failure domain (failure_domain) in the
+        CRUSH tree(s) provided by the buckets parameter.
         """
         unbalanced = False
         weight = -1
@@ -315,7 +318,11 @@ class CephClusterChecks(CephChecksBase):
                                                         failure_domain)
                 if unbalanced:
                     return unbalanced
-            else:
+            # Handle items/buckets with 0 weight correctly, by
+            # ignoring them.
+            # These are excluded from placement consideration,
+            # and therefore do not unbalance a tree.
+            elif item["weight"] > 0:
                 if weight == -1:
                     weight = item["weight"]
                 else:


### PR DESCRIPTION
CRUSH buckets with a zero weight do not unbalance a tree,
so they should not raise the warning.

Resolves: #266

Signed-off-by: Kellen Renshaw <kellen.renshaw@canonical.com>