### PR TITLE
Handle operations in requests within the group

### DIFF
--- a/core/ycheck/__init__.py
+++ b/core/ycheck/__init__.py
@@ -499,9 +499,10 @@ class YPropertyRequires(YPropertyOverrideBase):
                 return False
         else:
             log.debug("requirements provided as groups")
-            results = {}
+            final_results = []
             # list of requirements
             for op, requirements in self.content.items():
+                results = {}
                 if op not in results:
                     results[op] = []
 
@@ -519,20 +520,17 @@ class YPropertyRequires(YPropertyOverrideBase):
                         log.debug("invalid requirement: %s - fail", entry)
                         results[op].append(False)
 
-            # Now apply op to respective groups then AND all for the final
-            # result.
-            final_results = []
-            for op in results:
+                # Now apply op to respective groups
                 if op == 'and':
                     final_results.append(all(results[op]))
                 elif op == 'or':
                     final_results.append(any(results[op]))
                 elif op == 'not':
-                    # this is a NOR
                     final_results.append(not any(results[op]))
                 else:
                     log.debug("unknown operator '%s' found in requirement", op)
 
+            # AND all for the final result
             return all(final_results)
 
 


### PR DESCRIPTION
Currently the operations in requests are handled
together for all teh groups. So if there are
multiple groups with same operator then results of
all the groups are applied with the operator.

This patch changes the logic to apply operations
for only the results of the group.

Resolves: #276