### PR TITLE
remove needless --help info stderr output

### DIFF
--- a/hotsos.sh
+++ b/hotsos.sh
@@ -431,6 +431,4 @@ for data_root in "${SOS_PATHS[@]}"; do
         echo "" 1>&2
         rm $MASTER_YAML_OUT
     fi
-
-    echo "INFO: see --help for more options" 1>&2
 done


### PR DESCRIPTION
I'm pretty sure everyone knows --help will provide help text, we don't need to print that information; especially not at every hotsos processing.