### PR TITLE
[storage] Clarify unbalanced check message

### DIFF
--- a/defs/scenarios/storage/ceph/ceph-mon/crushmap_bucket_checks.yaml
+++ b/defs/scenarios/storage/ceph/ceph-mon/crushmap_bucket_checks.yaml
@@ -24,10 +24,10 @@ conclusions:
     raises:
       type: CephCrushWarning
       message: >-
-        Found one or more unbalanced crush buckets e.g. crush root '{root}' using
-        failure domain '{domain}' with rule id '{ruleid}'. This can cause
-        data distribution to become skewed - please check crush map.
+        Found one or more unbalanced buckets in the cluster's CRUSH map.
+        This can cause uneven data distribution or PG mapping issues in the cluster.
+        Verify that "ceph osd crush tree --show-shadow" conforms to the expected layout for the cluster.
+        Transient issues such as "out" OSDs, or cluster expansion/maintenance can trigger this warning.
+        Affected CRUSH tree(s) and bucket types are {affected}.
       format-dict:
-        root: hotsos.core.plugins.storage.ceph.CephCrushMap.crushmap_equal_buckets_head_root
-        domain: hotsos.core.plugins.storage.ceph.CephCrushMap.crushmap_equal_buckets_head_domain
-        ruleid: hotsos.core.plugins.storage.ceph.CephCrushMap.crushmap_equal_buckets_head_ruleid
+        affected: hotsos.core.plugins.storage.ceph.CephCrushMap.crushmap_equal_buckets_pretty

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -196,12 +196,11 @@ class CephCrushMap(object):
     @property
     def crushmap_equal_buckets(self):
         """
-        Report when buckets of the failure domain type in a
-        CRUSH rule referenced tree are unbalanced.
+        Report when in-use failure domain buckets are unbalanced.
 
         Uses the trees and failure domains referenced in the
         CRUSH rules, and checks that all buckets of the failure
-        domain type in the referenced tree are equal.
+        domain type in the referenced tree are equal or of zero size.
         """
         if not self.osd_crush_dump:
             return []
@@ -222,33 +221,21 @@ class CephCrushMap(object):
                     taken = fdomain = 0
 
         unequal_buckets = []
-        for ruleid, tree, failure_domain in to_check:
+        for _, tree, failure_domain in to_check:
             unbalanced = \
                 self._is_bucket_imbalanced(buckets, tree, failure_domain)
             if unbalanced:
-                unequal_buckets.append({'root': buckets[tree]["name"],
-                                        'domain': failure_domain,
-                                        'ruleid': ruleid})
+                unequal_buckets.append(
+                    "tree {} at the {} level"
+                    .format(buckets[tree]["name"], failure_domain))
 
         return unequal_buckets
 
     @property
-    def crushmap_equal_buckets_head_root(self):
+    def crushmap_equal_buckets_pretty(self):
         unequal = self.crushmap_equal_buckets
         if unequal:
-            return unequal[0].get('root')
-
-    @property
-    def crushmap_equal_buckets_head_domain(self):
-        unequal = self.crushmap_equal_buckets
-        if unequal:
-            return unequal[0].get('domain')
-
-    @property
-    def crushmap_equal_buckets_head_ruleid(self):
-        unequal = self.crushmap_equal_buckets
-        if unequal:
-            return unequal[0].get('ruleid')
+            return ", ".join(unequal)
 
 
 class CephCluster(object):

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -318,8 +318,7 @@ class TestCoreCephCluster(StorageCephMonTestsBase):
         cluster = ceph_core.CephCluster()
         buckets = cluster.crush_map.crushmap_equal_buckets
         self.assertEqual(buckets,
-                         [{'domain': 'rack', 'root': 'default',
-                           'ruleid': 0}])
+                         ['tree default at the rack level'])
 
     def test_crushmap_equal_buckets(self):
         cluster = ceph_core.CephCluster()
@@ -835,10 +834,14 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
             return_value = osd_crush_dump
 
         YScenarioChecker()()
-        msg = ("Found one or more unbalanced crush buckets e.g. crush root "
-               "'default' using failure domain 'rack' with rule id '0'. "
-               "This can cause data distribution to become skewed - please "
-               "check crush map.")
+        msg = ("Found one or more unbalanced buckets in the cluster's CRUSH "
+               'map. This can cause uneven data distribution or PG mapping '
+               'issues in the cluster. Verify that "ceph osd crush tree '
+               '--show-shadow" conforms to the expected layout for the '
+               'cluster. Transient issues such as "out" OSDs, or cluster '
+               'expansion/maintenance can trigger this warning. Affected '
+               'CRUSH tree(s) and bucket types are tree default at the rack '
+               'level.')
         issues = list(IssuesManager().load_issues().values())[0]
         self.assertEqual([issue['desc'] for issue in issues], [msg])
 


### PR DESCRIPTION
This changes the output of the unbalanced bucket check to be clearer
about the part of the tree that should be inspected.

Fixes: #284

Signed-off-by: Kellen Renshaw <kellen.renshaw@canonical.com>