### PR TITLE
Expand messages raised for rabbitmq issues

### DIFF
--- a/defs/scenarios/rabbitmq/cluster_logchecks.yaml
+++ b/defs/scenarios/rabbitmq/cluster_logchecks.yaml
@@ -35,5 +35,5 @@ conclusions:
       type: core.issues.issue_types.RabbitMQWarning
       message: >-
         Messages were discarded because transient mirrored classic queues are
-        not syncronized. Please stop all rabbitmq-server units and restart the
+        not synchronized. Please stop all rabbitmq-server units and restart the
         cluster. Note that a rolling restart will not work.


### PR DESCRIPTION
OpenStack uses classic transient mirrored queues. In case a broker is lost and
re-added to the cluster, the mirrored queue will not be synchronized but will
receive new messages. Over time, the new broker's queue will end up being
synchronized once all messages from before have expired.

In case nodes are lost and re-added the following two scenarios are possible:

1. If the current primary broker is lost and there are no fully synchronized
   secondaries, RabbitMQ will stop the queue.

```
09:26:25.793 [error] Discarding message {'$gen_call',{<0.753.0>,#Ref<0.989368845.173015041.56949>},{info,[name,pid,slave_pids,synchronised_slave_pids]}} from <0.753.0> to <0.943.0> in an old incarnation (3) of this node (1)
```

2. When the brokers are back up after such a shut-down, RabbitMQ will not
   restart the queue and fail with

```
09:31:08.102 [error] Discarding message {'$gen_call',{<0.928.0>,#Ref<0.989368845.173015041.62682>},{info,[name,pid,slave_pids,synchronised_slave_pids]}} from <0.928.0> to <0.943.0> in an old incarnation (3) of this node (1)
```

Which is just another symptom of the same underlying problem.

In either case the solution is to shut down the cluster and restart it.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>