### PR TITLE
Add Pacemaker Plugin

### DIFF
--- a/client.py
+++ b/client.py
@@ -39,6 +39,8 @@ from plugin_extensions.storage import (
 )
 from plugin_extensions.vault.summary import VaultSummary
 
+from plugin_extensions.pacemaker.summary import PacemakerSummary
+
 
 class HotSOSSummary(plugintools.PluginPartBase):
     """
@@ -70,6 +72,7 @@ PLUGIN_RUN_ORDER = [
     'juju',
     'maas',
     'kernel',
+    'pacemaker',
 ]
 
 
@@ -160,6 +163,10 @@ PLUGIN_CATALOG = {'hotsos': {
                   'vault': {
                      'summary': {
                          'objects': [VaultSummary],
+                         'part_yaml_offset': 0}},
+                  'pacemaker': {
+                     'summary': {
+                         'objects': [PacemakerSummary],
                          'part_yaml_offset': 0}}}
 
 

--- a/core/cli_helpers.py
+++ b/core/cli_helpers.py
@@ -639,6 +639,9 @@ class CLIHelper(object):
                          'ovs-ofctl_-O_OpenFlow10_show_{bridge}'),
                  FileCmd('sos_commands/openvswitch/'
                          'ovs-ofctl_show_{bridge}')],
+            'pacemaker_crm_status':
+                [BinCmd('crm status'),
+                 FileCmd('sos_commands/pacemaker/crm_status')],
             'ps':
                 [BinCmd('ps auxwww'),
                  FileCmd('ps')],

--- a/core/issues/issue_types.py
+++ b/core/issues/issue_types.py
@@ -94,3 +94,7 @@ class OpenstackError(IssueTypeBase):
 
 class KubernetesWarning(IssueTypeBase):
     pass
+
+
+class PacemakerWarning(IssueTypeBase):
+    pass

--- a/core/plugins/pacemaker.py
+++ b/core/plugins/pacemaker.py
@@ -1,0 +1,55 @@
+import re
+
+from core import checks
+from core.plugintools import PluginPartBase
+from core.cli_helpers import CLIHelper
+
+PACEMAKER_PKGS_CORE = ['pacemaker', 'crmsh', 'corosync']
+PACEMAKER_SVC_EXPR = ['pacemaker[a-zA-Z-]*',
+                      'corosync']
+
+
+class PacemakerBase(object):
+
+    @property
+    def crm_status(self):
+        return CLIHelper().pacemaker_crm_status
+
+    @property
+    def offline_nodes(self):
+        crm_status = self.crm_status()
+        for line in crm_status:
+            regex_match = re.search(r'.*OFFLINE.*\[\s(.*)\s\]',
+                                    line)
+            if regex_match:
+                return regex_match.group(1).split()
+        return []
+
+    @property
+    def online_nodes(self):
+        crm_status = self.crm_status()
+        for line in crm_status:
+            regex_match = re.search(r'.*Online.*\[\s(.*)\s\]',
+                                    line)
+            if regex_match:
+                return regex_match.group(1).split()
+        return []
+
+
+class PacemakerChecksBase(PacemakerBase, PluginPartBase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.apt_check = checks.APTPackageChecksBase(
+            core_pkgs=PACEMAKER_PKGS_CORE)
+        svc_exprs = PACEMAKER_SVC_EXPR
+        self.svc_check = checks.ServiceChecksBase(service_exprs=svc_exprs)
+        self.pacemaker = PacemakerBase()
+
+    @property
+    def apt_packages_all(self):
+        return self.apt_check.all_formatted
+
+    @property
+    def plugin_runnable(self):
+        return len(self.apt_check.core) > 0

--- a/defs/scenarios/pacemaker/pacemaker.yaml
+++ b/defs/scenarios/pacemaker/pacemaker.yaml
@@ -1,0 +1,2 @@
+requires:
+  property: core.plugins.pacemaker.PacemakerChecksBase.plugin_runnable

--- a/defs/scenarios/pacemaker/pacemaker_node1_found.yaml
+++ b/defs/scenarios/pacemaker/pacemaker_node1_found.yaml
@@ -1,0 +1,20 @@
+checks:
+  node1-found:
+    requires:
+      property: core.plugins.pacemaker.PacemakerBase.offline_nodes
+      op: contains
+      value: node1
+conclusions:
+  node1-found-needs-removal:
+    decision: node1-found
+    raises:
+      type: core.issues.PacemakerWarning
+      message: >-
+       A node with the hostname node1 is currently configured and enabled on
+       pacemaker.
+       This is related to bug:
+       https://bugs.launchpad.net/charm-hacluster/+bug/1874719.
+       You can remove the node by running the following command on the
+       application-hacluster leader:
+       juju run-action <application>-hacluster/leaderdelete-node-from-ring
+       delete-node-from-ring node=node1 --wait

--- a/examples/hotsos-example-pacemaker.short.summary.yaml
+++ b/examples/hotsos-example-pacemaker.short.summary.yaml
@@ -1,0 +1,13 @@
+potential-issues:
+  system:
+    SystemWarnings:
+      - Unattended upgrades are enabled which can lead to uncontrolled changes to
+        this environment. If maintenance windows are required please consider disabling
+        unattended upgrades. (origin=system.auto_scenario_check)
+  pacemaker:
+    PacemakerWarnings:
+      - 'A node with the hostname node1 is currently configured and enabled on pacemaker.
+        This is related to bug: https://bugs.launchpad.net/charm-hacluster/+bug/1874719.
+        You can remove the node by running the following command on the application-hacluster
+        leader: juju run-action <application>-hacluster/leaderdelete-node-from-ring
+        delete-node-from-ring node=node1 --wait (origin=pacemaker.auto_scenario_check)'

--- a/examples/hotsos-example-pacemaker.summary.yaml
+++ b/examples/hotsos-example-pacemaker.summary.yaml
@@ -1,0 +1,47 @@
+hotsos:
+  version: development
+  repo-info: 29c68372
+system:
+  hostname: juju-04f1e3-0-lxd-5
+  os: ubuntu focal
+  num-cpus: 2
+  load: 6.42, 4.37, 3.94
+  virtualisation: lxc
+  rootfs: /dev/vda2        308585260 24171768 268668880   9% /
+  unattended-upgrades: ENABLED
+  date: do 10 feb 2022 9:51:32 UTC
+  potential-issues:
+    SystemWarnings:
+      - Unattended upgrades are enabled which can lead to uncontrolled changes to
+        this environment. If maintenance windows are required please consider disabling
+        unattended upgrades. (origin=system.auto_scenario_check)
+pacemaker:
+  services:
+    systemd:
+      enabled:
+        - corosync
+        - pacemaker
+    ps:
+      - corosync (1)
+      - pacemakerd (1)
+  dpkg:
+    - corosync 3.0.3-2ubuntu2.1
+    - crmsh 4.2.0-2ubuntu1
+    - pacemaker 2.0.3-3ubuntu4.3
+    - pacemaker-cli-utils 2.0.3-3ubuntu4.3
+    - pacemaker-common 2.0.3-3ubuntu4.3
+    - pacemaker-resource-agents 2.0.3-3ubuntu4.3
+  nodes:
+    online:
+      - juju-04f1e3-0-lxd-5
+      - juju-04f1e3-1-lxd-6
+      - juju-04f1e3-2-lxd-6
+    offline:
+      - node1
+  potential-issues:
+    PacemakerWarnings:
+      - 'A node with the hostname node1 is currently configured and enabled on pacemaker.
+        This is related to bug: https://bugs.launchpad.net/charm-hacluster/+bug/1874719.
+        You can remove the node by running the following command on the application-hacluster
+        leader: juju run-action <application>-hacluster/leaderdelete-node-from-ring
+        delete-node-from-ring node=node1 --wait (origin=pacemaker.auto_scenario_check)'

--- a/plugin_extensions/pacemaker/summary.py
+++ b/plugin_extensions/pacemaker/summary.py
@@ -1,0 +1,27 @@
+from core.plugintools import summary_entry_offset as idx
+from core.plugins.pacemaker import PacemakerChecksBase
+
+
+class PacemakerSummary(PacemakerChecksBase):
+
+    @idx(0)
+    def __summary_services(self):
+        if self.svc_check.services:
+            return {'systemd': self.svc_check.service_info,
+                    'ps': self.svc_check.process_info}
+
+    @idx(1)
+    def __summary_dpkg(self):
+        apt = self.apt_check.all_formatted
+        if apt:
+            return apt
+
+    @idx(2)
+    def __summary_nodes(self):
+        nodes = {}
+        if self.online_nodes:
+            nodes["online"] = self.online_nodes
+        if self.offline_nodes:
+            nodes["offline"] = self.offline_nodes
+        if nodes:
+            return nodes

--- a/tests/unit/test_pacemaker.py
+++ b/tests/unit/test_pacemaker.py
@@ -1,0 +1,91 @@
+import os
+
+import mock
+
+from tests.unit import utils
+
+from core.config import setup_config, HotSOSConfig
+from core.ycheck.scenarios import YScenarioChecker
+from plugin_extensions.pacemaker import summary
+
+
+class TestPacemakerBase(utils.BaseTestCase):
+
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+        setup_config(PLUGIN_NAME='pacemaker',
+                     DATA_ROOT=os.path.join(utils.TESTS_DIR,
+                                            'fake_data_root/vault'))
+
+
+class TestPacemakerSummary(TestPacemakerBase):
+    def test_dpkg(self):
+        expected = ['corosync 3.0.3-2ubuntu2.1',
+                    'crmsh 4.2.0-2ubuntu1',
+                    'pacemaker 2.0.3-3ubuntu4.3',
+                    'pacemaker-cli-utils 2.0.3-3ubuntu4.3',
+                    'pacemaker-common 2.0.3-3ubuntu4.3',
+                    'pacemaker-resource-agents 2.0.3-3ubuntu4.3']
+        inst = summary.PacemakerSummary()
+        actual = self.part_output_to_actual(inst.output)
+        self.assertEqual(actual["dpkg"], expected)
+
+    def test_services(self):
+        expected = {'ps': ['corosync (1)', 'pacemakerd (1)'],
+                    'systemd': {
+            'enabled': [
+                'corosync',
+                'pacemaker']
+        }}
+        inst = summary.PacemakerSummary()
+        actual = self.part_output_to_actual(inst.output)
+        self.assertEqual(actual["services"], expected)
+
+    def test_offline_nodes(self):
+        expected = ['node1']
+        inst = summary.PacemakerSummary()
+        actual = self.part_output_to_actual(inst.output)
+        self.assertEqual(actual["nodes"]["offline"], expected)
+
+    def test_online_nodes(self):
+        expected = ['juju-04f1e3-0-lxd-5',
+                    'juju-04f1e3-1-lxd-6',
+                    'juju-04f1e3-2-lxd-6']
+        inst = summary.PacemakerSummary()
+        actual = self.part_output_to_actual(inst.output)
+        self.assertEqual(actual["nodes"]["online"], expected)
+
+
+class TestPacemakerScenarios(TestPacemakerBase):
+    @mock.patch('core.plugins.pacemaker.CLIHelper')
+    @mock.patch('core.ycheck.YDefsLoader._is_def',
+                new=utils.is_def_filter('pacemaker_node1_found.yaml'))
+    @mock.patch('core.issues.utils.add_issue')
+    def test_node1_found(self, mock_add_issue, mock_helper):
+        raised_issues = []
+
+        def fake_add_issue(issue):
+            raised_issues.append(issue)
+
+        mock_helper.return_value = mock.MagicMock()
+        test_data_path = ('sos_commands/pacemaker/crm_status')
+        crm_status_path = os.path.join(HotSOSConfig.DATA_ROOT,
+                                       test_data_path)
+        with open(crm_status_path) as crm_status:
+            mock_helper.return_value.pacemaker_crm_status.\
+                return_value = crm_status
+
+            mock_add_issue.side_effect = fake_add_issue
+            YScenarioChecker()()
+            self.assertTrue(mock_add_issue.called)
+            msg = (
+                "A node with the hostname node1 is currently configured and "
+                "enabled on pacemaker. This is related to bug: "
+                "https://bugs.launchpad.net/charm-hacluster/+bug/1874719. "
+                "You can remove the node by running the following command on "
+                "the application-hacluster leader: juju run-action "
+                "<application>-hacluster/leaderdelete-node-from-ring "
+                "delete-node-from-ring node=node1 --wait")
+            msgs = [issue.msg for issue in raised_issues]
+            self.assertEqual(len(msgs), 1)
+            self.assertEqual(msgs, [msg])

--- a/tools/test/functest.sh
+++ b/tools/test/functest.sh
@@ -12,6 +12,7 @@ declare -A PLUGIN_ROOTS=(
     [rabbitmq]=./tests/unit/fake_data_root/rabbitmq
     [storage]=./tests/unit/fake_data_root/storage/ceph-mon
     [vault]=./tests/unit/fake_data_root/vault
+    [pacemaker]=./tests/unit/fake_data_root/vault
 )
 PLUGINS=(
     openstack
@@ -25,6 +26,7 @@ PLUGINS=(
     sosreport
     system
     vault
+    pacemaker
 )
 result=true
 


### PR DESCRIPTION
This aims to add a pacemaker plugin to hotsos.
It also adds a check to verify if a hostname with 'node1'
is configured on pacemaker, and presents a warning with the
correct action to remove it via juju.

Closes #296

Signed-off-by: David Negreira <david.negreira@canonical.com>