### PR TITLE
Fix Pacemaker node1 message

### DIFF
--- a/defs/scenarios/pacemaker/pacemaker_node1_found.yaml
+++ b/defs/scenarios/pacemaker/pacemaker_node1_found.yaml
@@ -14,5 +14,10 @@ conclusions:
        A node with the hostname node1 is currently configured and enabled on
        pacemaker. This is caused by a known bug and you can remove the node by
        running the following command on the application-hacluster leader:
-       juju run-action <application>-hacluster/leaderdelete-node-from-ring
+       juju run-action <application>-hacluster/leader
        delete-node-from-ring node=node1 --wait
+
+       If the above action is not available in the charm, you can run the
+       following command:
+       juju run --application <application>-hacluster --
+       sudo crm_node -R node1 --force

--- a/examples/hotsos-example-pacemaker.short.summary.yaml
+++ b/examples/hotsos-example-pacemaker.short.summary.yaml
@@ -9,7 +9,10 @@ bugs-detected:
     - desc: 'A node with the hostname node1 is currently configured and enabled on
         pacemaker. This is caused by a known bug and you can remove the node by running
         the following command on the application-hacluster leader: juju run-action
-        <application>-hacluster/leaderdelete-node-from-ring delete-node-from-ring
-        node=node1 --wait'
+        <application>-hacluster/leader delete-node-from-ring node=node1 --wait
+
+        If the above action is not available in the charm, you can run the following
+        command: juju run --application <application>-hacluster -- sudo crm_node -R
+        node1 --force'
       id: https://bugs.launchpad.net/bugs/1874719
       origin: pacemaker.auto_scenario_check

--- a/examples/hotsos-example-pacemaker.summary.yaml
+++ b/examples/hotsos-example-pacemaker.summary.yaml
@@ -42,7 +42,10 @@ pacemaker:
     - desc: 'A node with the hostname node1 is currently configured and enabled on
         pacemaker. This is caused by a known bug and you can remove the node by running
         the following command on the application-hacluster leader: juju run-action
-        <application>-hacluster/leaderdelete-node-from-ring delete-node-from-ring
-        node=node1 --wait'
+        <application>-hacluster/leader delete-node-from-ring node=node1 --wait
+
+        If the above action is not available in the charm, you can run the following
+        command: juju run --application <application>-hacluster -- sudo crm_node -R
+        node1 --force'
       id: https://bugs.launchpad.net/bugs/1874719
       origin: pacemaker.auto_scenario_check

--- a/tests/unit/test_pacemaker.py
+++ b/tests/unit/test_pacemaker.py
@@ -84,8 +84,12 @@ class TestPacemakerScenarios(TestPacemakerBase):
                 'can remove the node by running the following command on the '
                 'application-hacluster leader: '
                 'juju run-action '
-                '<application>-hacluster/leaderdelete-node-from-ring '
-                'delete-node-from-ring node=node1 --wait')
+                '<application>-hacluster/leader '
+                'delete-node-from-ring node=node1 --wait\n'
+                'If the above action is not available in the charm, you can '
+                'run the following command: '
+                'juju run --application <application>-hacluster -- '
+                'sudo crm_node -R node1 --force')
             msgs = [issue.msg for issue in raised_issues]
             self.assertEqual(len(msgs), 1)
             self.assertEqual(msgs, [msg])


### PR DESCRIPTION
I've received some feedback about the Pacemaker message and here are
some of the fixes for it.

* Fix a typo on juju run-action command
* Add an alternative to the command since the hacluster charm did not
always have `the delete-node-from-ring` action

Signed-off-by: David Negreira <david.negreira@canonical.com>