### PR TITLE
Catch python3-cryptography import error

### DIFF
--- a/hotsos/core/ssl.py
+++ b/hotsos/core/ssl.py
@@ -1,6 +1,13 @@
 from hotsos.core.log import log
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
+try:
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+except ImportError:
+    # This is (hopefully temporary) fix for
+    # https://github.com/canonical/hotsos/issues/326
+    x509 = None
+    default_backend = None
+
 from datetime import datetime
 
 
@@ -29,6 +36,9 @@ class SSLCertificate(object):
         """
         Return datetime() of when the certificate expires
         """
+        if not x509:
+            return
+
         cert = x509.load_pem_x509_certificate(self.certificate,
                                               default_backend())
         return cert.not_valid_after


### PR DESCRIPTION
If hotsos.core.ssl fails to import this module (which
is currently the case when running as a snap)
we now skip any code that uses it to allow the rest
of the tool to run until we get a proper fix for this.

Partially-Resolves: #326