### PR TITLE
Collect systemd service start time

### DIFF
--- a/defs/README.md
+++ b/defs/README.md
@@ -343,21 +343,29 @@ REQ_TYPE
     snap: package name
 
   SYSTEMD
-    Takes a systemd service and, optionally, state. Returns True if service
-    exists and, if provided, state matches. A short and long form are
-    supported as follows where the long form supports provided more than one
-    <service>: <state> pair and optionally an operator to be used instead of
-    the default 'eq' when comparing state.
+    Takes a systemd service and optionally some parameters to check.
+    Returns True if service exists and, if provided, parameters match.
+    Short and long forms are supported as follows. If a service name
+    is provided using the started-after parameter, the start time of
+    that service (if it exists) must be less than the service under
+    test.
 
     Format:
 
-    systemd: <service name>
+    systemd: <service name>  (state is not checked here)
 
     or
 
     systemd:
-      <service name>: <service state>
-      op: <python operator>
+      <service name>: <service state>  (state is checked with default op 'eq')
+
+    or
+
+    systemd:
+      <service name>:
+        state: <service state>
+        op: <python operator>  (optional. default is 'eq')
+        started-after: <other service name>  (optional)
 
   CONFIG
     A dictionary containing the information required to perform some

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -9,6 +9,7 @@ from .. import utils
 from hotsos.core.issues import IssuesManager
 from hotsos.core.config import setup_config, HotSOSConfig
 from hotsos.core.ycheck.scenarios import YScenarioChecker
+from hotsos.core.host_helpers.systemd import SystemdService
 from hotsos.core.plugins.storage import (
     ceph as ceph_core,
 )
@@ -465,7 +466,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                                        'ceph-mon/mon_elections_flapping.yaml'))
     @mock.patch('hotsos.core.plugins.storage.ceph.CephChecksBase')
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_scenario_mon_reelections(self, mock_cephbase):
         mock_cephbase.return_value = mock.MagicMock()
         mock_cephbase.return_value.plugin_runnable = True
@@ -503,7 +504,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter('ceph-mon/osd_slow_heartbeats.yaml'))
     @mock.patch('hotsos.core.plugins.storage.ceph.CephChecksBase')
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_scenario_osd_slow_heartbeats(self, mock_cephbase):
         mock_cephbase.return_value = mock.MagicMock()
         mock_cephbase.return_value.plugin_runnable = True
@@ -530,7 +531,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
     @mock.patch('hotsos.core.plugins.storage.ceph.CephCluster.health_status',
                 'HEALTH_WARN')
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_scenario_bluefs_spillover(self, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         mock_helper.return_value.ceph_health_detail_json_decoded.return_value \
@@ -548,7 +549,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter('ceph-mon/osd_slow_ops.yaml'))
     @mock.patch('hotsos.core.plugins.storage.ceph.CephChecksBase')
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_scenario_osd_slow_ops(self, mock_cephbase):
         mock_cephbase.return_value = mock.MagicMock()
         mock_cephbase.return_value.plugin_runnable = True
@@ -586,7 +587,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter('ceph-mon/osd_flapping.yaml'))
     @mock.patch('hotsos.core.plugins.storage.ceph.CephChecksBase')
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_scenario_osd_flapping(self, mock_cephbase):
         mock_cephbase.return_value = mock.MagicMock()
         mock_cephbase.return_value.plugin_runnable = True
@@ -625,7 +626,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter(
                     'ceph-mon/osd_maps_backlog_too_large.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_scenario_osd_maps_backlog_too_large(self, mock_helper):
         pinned = {'osdmap_manifest': {'pinned_maps': range(5496)}}
         mock_helper.return_value = mock.MagicMock()
@@ -646,7 +647,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter(
                                 'ceph-mon/required_osd_release_mismatch.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_required_osd_release(self, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         mock_helper.return_value.ceph_versions.return_value = \
@@ -664,7 +665,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
     @mock.patch('hotsos.core.ycheck.YDefsLoader._is_def',
                 new=utils.is_def_filter('ceph-mon/laggy_pgs.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_laggy_pgs(self, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         mock_helper.return_value.ceph_pg_dump_json_decoded.return_value = \
@@ -715,7 +716,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
     @mock.patch('hotsos.core.ycheck.YDefsLoader._is_def',
                 new=utils.is_def_filter('ceph-mon/large_omap_objects.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_large_omap_objects(self, mock_cli):
         mock_cli.return_value = mock.MagicMock()
         mock_cli.return_value.ceph_pg_dump_json_decoded.return_value = \
@@ -750,7 +751,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter(
                                        'ceph-mon/ceph_versions_mismatch.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_ceph_versions_mismatch_p1(self, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         mock_helper.return_value.ceph_versions.return_value = \
@@ -768,7 +769,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter(
                                        'ceph-mon/ceph_versions_mismatch.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_ceph_versions_mismatch_p2(self, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         mock_helper.return_value.ceph_versions.return_value = \
@@ -785,7 +786,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
     @mock.patch('hotsos.core.ycheck.YDefsLoader._is_def',
                 new=utils.is_def_filter('ceph-mon/pg_imbalance.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_ceph_pg_imbalance(self, mock_helper):
         self.setup_fake_cli_osds_imbalanced_pgs(mock_helper)
         YScenarioChecker()()
@@ -804,7 +805,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter(
                                        'ceph-mon/crushmap_bucket_checks.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_crushmap_bucket_checks_mixed_buckets(self, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         mock_helper.return_value.ceph_osd_crush_dump_json_decoded.\
@@ -822,7 +823,7 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter(
                                        'ceph-mon/crushmap_bucket_checks.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
-                {'ceph-mon': 'enabled'})
+                {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     def test_crushmap_bucket_checks_unbalanced_buckets(self, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         test_data_path = ('sos_commands/ceph_mon/json_output/'

--- a/tests/unit/storage/test_ceph_osd.py
+++ b/tests/unit/storage/test_ceph_osd.py
@@ -9,6 +9,7 @@ from hotsos.core.config import setup_config
 from hotsos.core import host_helpers
 from hotsos.core.issues import IssuesManager
 from hotsos.core.ycheck.scenarios import YScenarioChecker
+from hotsos.core.host_helpers.systemd import SystemdService
 from hotsos.core.plugins.storage import (
     ceph as ceph_core,
 )
@@ -223,8 +224,8 @@ class TestCephScenarioChecks(StorageCephOSDTestsBase):
     @mock.patch('hotsos.core.plugins.storage.ceph.CephDaemonConfigShowAllOSDs')
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ceph-osd/bugs.yaml'))
-    @mock.patch('hotsos.core.ycheck.engine.properties.ServiceChecksBase.'
-                'services', {'ceph-osd': 'enabled'})
+    @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
+                {'ceph-osd': SystemdService('ceph-osd', 'enabled')})
     def test_bug_check_lp1959649(self, mock_cephdaemon, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         mock_helper.return_value.dpkg_l.return_value = \
@@ -297,8 +298,8 @@ class TestCephScenarioChecks(StorageCephOSDTestsBase):
     @mock.patch('hotsos.core.host_helpers.packaging.CLIHelper')
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ceph-osd/bcache_lp1936136.yaml'))
-    @mock.patch('hotsos.core.ycheck.engine.properties.ServiceChecksBase.'
-                'services', {'ceph-osd': 'enabled'})
+    @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',
+                {'ceph-osd': SystemdService('ceph-osd', 'enabled')})
     def test_lp1936136(self, mocl_cli, mock_cephbase, mock_kernelbase,
                        mock_cset_config, mock_ceph_config):
         def fake_ceph_config(key):

--- a/tests/unit/test_ycheck.py
+++ b/tests/unit/test_ycheck.py
@@ -141,7 +141,7 @@ pluginX:
 """
 
 
-YAML_DEF_REQUIRES_SYSTEMD_PASS = """
+YAML_DEF_REQUIRES_SYSTEMD_PASS_1 = """
 pluginX:
   groupA:
     requires:
@@ -149,6 +149,18 @@ pluginX:
         ondemand: enabled
         nova-compute: enabled
 """
+
+
+YAML_DEF_REQUIRES_SYSTEMD_PASS_2 = """
+pluginX:
+  groupA:
+    requires:
+      systemd:
+        neutron-openvswitch-agent:
+          state: enabled
+          started-after: openvswitch-switch
+"""
+
 
 YAML_DEF_REQUIRES_SYSTEMD_FAIL_1 = """
 pluginX:
@@ -170,6 +182,18 @@ pluginX:
           state: disabled
           op: eq
 """
+
+
+YAML_DEF_REQUIRES_SYSTEMD_FAIL_3 = """
+pluginX:
+  groupA:
+    requires:
+      systemd:
+        openvswitch-switch:
+          state: enabled
+          started-after: neutron-openvswitch-agent
+"""
+
 
 YAML_DEF_REQUIRES_GROUPED = """
 passdef1:
@@ -829,19 +853,28 @@ class TestYamlChecks(utils.BaseTestCase):
 
     def test_yaml_def_requires_systemd_pass(self):
         mydef = YDefsSection('mydef',
-                             yaml.safe_load(YAML_DEF_REQUIRES_SYSTEMD_PASS))
+                             yaml.safe_load(YAML_DEF_REQUIRES_SYSTEMD_PASS_1))
         for entry in mydef.leaf_sections:
             self.assertTrue(entry.requires.passes)
 
-    def test_yaml_def_requires_systemd_fail_1(self):
+        mydef = YDefsSection('mydef',
+                             yaml.safe_load(YAML_DEF_REQUIRES_SYSTEMD_PASS_2))
+        for entry in mydef.leaf_sections:
+            self.assertTrue(entry.requires.passes)
+
+    def test_yaml_def_requires_systemd_fail(self):
         mydef = YDefsSection('mydef',
                              yaml.safe_load(YAML_DEF_REQUIRES_SYSTEMD_FAIL_1))
         for entry in mydef.leaf_sections:
             self.assertFalse(entry.requires.passes)
 
-    def test_yaml_def_requires_systemd_fail_2(self):
         mydef = YDefsSection('mydef',
                              yaml.safe_load(YAML_DEF_REQUIRES_SYSTEMD_FAIL_2))
+        for entry in mydef.leaf_sections:
+            self.assertFalse(entry.requires.passes)
+
+        mydef = YDefsSection('mydef',
+                             yaml.safe_load(YAML_DEF_REQUIRES_SYSTEMD_FAIL_3))
         for entry in mydef.leaf_sections:
             self.assertFalse(entry.requires.passes)
 


### PR DESCRIPTION
The ServiceChecksBase not supports retreiving the most
recent start time of a service and we also add support
to the Ydef requires.systemd property to check if
a service was started after another or not.

This is a pre-requisite for issue 331