### PR TITLE
OVN SSL Checks

### DIFF
--- a/defs/scenarios/openvswitch/ovn_certificates.yaml
+++ b/defs/scenarios/openvswitch/ovn_certificates.yaml
@@ -1,0 +1,22 @@
+checks:
+  ssl_enabled:
+    requires:
+      property: hotsos.core.plugins.openvswitch.OVNChecksBase.ssl_enabled
+  ovn_certificate_expiring:
+    requires:
+      property:
+        path: hotsos.core.plugins.openvswitch.OVNChecksBase.ovn_certificate_expiring
+conclusions:
+  need-certificate-renewal:
+    decision:
+      and:
+        - ssl_enabled
+        - ovn_certificate_expiring
+    raises:
+      type: OpenvSwitchWarning
+      message: >-
+        The following certificates will expire in less than {ovn-certificates-days-to-expire} days:
+        {ovn-certificates-path}
+      format-dict:
+        ovn-certificates-path: 'hotsos.core.plugins.openvswitch.OVNChecksBase.ssl_certificate_path'
+        ovn-certificates-days-to-expire: 'hotsos.core.plugins.openvswitch.OVNChecksBase.certificate_expire_days'

--- a/hotsos/client.py
+++ b/hotsos/client.py
@@ -110,7 +110,8 @@ PLUGIN_CATALOG = {'hotsos': {
                         'part_yaml_offset': 6}},
                   'openvswitch': {
                      'summary': {
-                         'objects': [ovs_summary.OpenvSwitchSummary],
+                         'objects': [ovs_summary.OpenvSwitchSummary,
+                                     ovs_summary.OVNSummary],
                          'part_yaml_offset': 0},
                      'event_checks': {
                          'objects': [event_checks.OVSEventChecks,

--- a/hotsos/plugin_extensions/openvswitch/summary.py
+++ b/hotsos/plugin_extensions/openvswitch/summary.py
@@ -1,6 +1,9 @@
 from hotsos.core.plugintools import summary_entry_offset as idx
 from hotsos.core.host_helpers import NetworkPort
-from hotsos.core.plugins.openvswitch import OpenvSwitchChecksBase
+from hotsos.core.plugins.openvswitch import (
+    OpenvSwitchChecksBase,
+    OVNChecksBase
+)
 
 
 class OpenvSwitchSummary(OpenvSwitchChecksBase):
@@ -62,3 +65,16 @@ class OpenvSwitchSummary(OpenvSwitchChecksBase):
 
         if bridges:
             return bridges
+
+
+class OVNSummary(OVNChecksBase):
+
+    @idx(4)
+    def __summary_ovn_type(self):
+        if self.ovn_type:
+            return self.ovn_type
+
+    @idx(5)
+    def __summary_ovn_ssl_enabled(self):
+        if self.ovn_type:
+            return self.ssl_enabled


### PR DESCRIPTION
This patch aims to add SSL certificates validation for OVN.

It currently verifies the certificate name by the package name,
and adds information to the openvswitch summary in case ovn-host
or is ovn-central is installed.

Closes: #325

Signed-off-by: David Negreira <david.negreira@canonical.com>