### PR TITLE
Avoid service start check false positives.

### DIFF
--- a/defs/README.md
+++ b/defs/README.md
@@ -345,10 +345,13 @@ REQ_TYPE
   SYSTEMD
     Takes a systemd service and optionally some parameters to check.
     Returns True if service exists and, if provided, parameters match.
-    Short and long forms are supported as follows. If a service name
-    is provided using the started-after parameter, the start time of
-    that service (if it exists) must be less than the service under
-    test.
+    Short and long forms are supported as follows.
+    
+    If a service name is provided using the started-after parameter,
+    the start time of that service (if it exists) must be at least
+    120s behind the primary service. The grace period is to avoid
+    false-positives on boot where many services are often started at
+    once.
 
     Format:
 

--- a/hotsos/core/ycheck/engine/properties.py
+++ b/hotsos/core/ycheck/engine/properties.py
@@ -801,9 +801,30 @@ class YRequirementTypeSystemd(YRequirementTypeBase):
             if a and b:
                 log.debug("%s started=%s, %s started=%s", svc.name,
                           a, started_after_svc_obj.name, b)
-                if b > a:
-                    log.debug("svc %s started before %s", svc.name,
-                              started_after_svc_obj.name)
+                if a < b:
+                    delta = b - a
+                else:
+                    delta = a - b
+
+                # Allow a small grace period to avoid false positives e.g.
+                # on node boot when services are started all at once.
+                grace = 120
+                # In order for a service A to have been started after B it must
+                # have been started more than GRACE seconds after B.
+                if a > b:
+                    if delta >= timedelta(seconds=grace):
+                        log.debug("svc %s started >= %ds of start of %s "
+                                  "(delta=%s)", svc.name, grace,
+                                  started_after_svc_obj.name, delta)
+                    else:
+                        log.debug("svc %s started < %ds of start of %s "
+                                  "(delta=%s)", svc.name, grace,
+                                  started_after_svc_obj.name, delta)
+                        return False
+                else:
+                    log.debug("svc %s started before or same as %s "
+                              "(delta=%s)", svc.name,
+                              started_after_svc_obj.name, delta)
                     return False
 
         return self.apply_ops(ops, input=svc.state)


### PR DESCRIPTION
Checks for service start ordering can produce
false positives if they are started at almost
the same time e.g. on boot. This patch allows
a grace period of 120s i.e. service A must
have been started at least 120s after service
B in order for A started-after B to be True.

Resolves: #346