### PR TITLE
Split ceph event defs into mon/osd

### DIFF
--- a/defs/events/storage/ceph/mon/mon.yaml
+++ b/defs/events/storage/ceph/mon/mon.yaml
@@ -1,0 +1,6 @@
+requires:
+  systemd:
+    # both mon and osd nodes will have a ceph-mon package and service installed
+    # but it will typically be disabled if not in used so we use that as a
+    # means of knowing what type of node it is.
+    ceph-mon: enabled

--- a/defs/events/storage/ceph/mon/monlogs.yaml
+++ b/defs/events/storage/ceph/mon/monlogs.yaml
@@ -6,21 +6,10 @@ osd-reported-failed:
 mon-elections-called:
   expr: '^([0-9-]+)\S* \S+ .+ (mon.\S+) calling monitor election'
   hint: 'calling monitor election'
-slow-requests:
-  expr: '^([0-9-]+)\S* \S+ .+ ([0-9]+) slow requests are blocked .+ \(REQUEST_SLOW\)'
-  hint: 'REQUEST_SLOW'
-crc-err-bluestore:
-  expr: '^([0-9-]+)\S* .+ _verify_csum bad .+'
-  hint: '_verify_csum'
-crc-err-rocksdb:
-  expr: '^([0-9-]+)\S* .+ rocksdb: .+block checksum mismatch'
-  hint: 'checksum mismatch'
 long-heartbeat-pings:
   expr: '^([0-9-]+)\S* \S+ .+ Long heartbeat ping times on \S+ interface seen'
   hint: 'Long heartbeat ping'
 heartbeat-no-reply:
   expr: '^([0-9-]+)\S* \S+ \S+ \S+ osd.[0-9]+ .+ heartbeat_check: no reply from [0-9.:]+ (osd.[0-9]+)'
   hint: 'heartbeat_check'
-superblock-read-error:
-  expr: '.+ unable to read osd superblock'
-  hint: 'osd superblock'
+

--- a/defs/events/storage/ceph/osd/osd.yaml
+++ b/defs/events/storage/ceph/osd/osd.yaml
@@ -1,0 +1,3 @@
+requires:
+  systemd:
+    ceph-osd: enabled

--- a/defs/events/storage/ceph/osd/osdlogs.yaml
+++ b/defs/events/storage/ceph/osd/osdlogs.yaml
@@ -1,0 +1,14 @@
+input:
+  path: 'var/log/ceph/ceph*.log'
+slow-requests:
+  expr: '^([0-9-]+)\S* \S+ .+ ([0-9]+) slow requests are blocked .+ \(REQUEST_SLOW\)'
+  hint: 'REQUEST_SLOW'
+crc-err-bluestore:
+  expr: '^([0-9-]+)\S* .+ _verify_csum bad .+'
+  hint: '_verify_csum'
+crc-err-rocksdb:
+  expr: '^([0-9-]+)\S* .+ rocksdb: .+block checksum mismatch'
+  hint: 'checksum mismatch'
+superblock-read-error:
+  expr: '.+ unable to read osd superblock'
+  hint: 'osd superblock'


### PR DESCRIPTION
This splits the event defs for storage.ceph into
storage.ceph.mon and storage.ceph.osd so that only
searches relevant to each are run and this is gated
on whether or not mon or osd are avaiable on that
node.