### PR TITLE
Add ydefs path requirement type

### DIFF
--- a/defs/README.md
+++ b/defs/README.md
@@ -165,8 +165,15 @@ format
 ```
 input:
   command: core.cli_helpers.CLIHelpers command
-  path: filesystem path (relative to DATA_ROOT)
+  path: FS_PATH
   options: OPTIONS
+
+or
+
+input: FS_PATH
+
+FS_PATH
+  This is a filesystem path that must be relative to DATA_ROOT.
 
 OPTIONS
     A dictionary of key: value pairs as follows:
@@ -311,6 +318,11 @@ REQ_GROUP
     - ...
 
 REQ_TYPE
+  PATH
+    This has the same format as the input property and is used to
+    assert if a path exists or not. Note that all-logs is not applied
+    to the path. 
+
   PROPERTY
     Calls a Python property and if provided, applies a set of
     operators. If no operators are specified, the "truth" operator

--- a/tests/unit/test_ycheck.py
+++ b/tests/unit/test_ycheck.py
@@ -216,6 +216,9 @@ pluginX:
 YAML_DEF_REQUIRES_GROUPED = """
 passdef1:
   requires:
+    - path: sos_commands/networking
+    - not:
+        path: sos_commands/networking_foo
     - apt: python3.8
     - and:
         - apt:
@@ -236,6 +239,7 @@ passdef2:
       - apt: blah
 faildef1:
   requires:
+    - path: sos_commands/networking_foo
     - and:
         - apt: doo
         - apt: daa


### PR DESCRIPTION
You can now test if an fs path exists or not when defining a
requires by doing e.g.

requires:
  path: foo