### PR TITLE
Catch scenario exceptions

### DIFF
--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -28,6 +28,10 @@ class BugTypeBase(abc.ABC, IssueTypeBase):
         pass
 
 
+class HotSOSScenariosWarning(IssueTypeBase):
+    pass
+
+
 class SystemWarning(IssueTypeBase):
     pass
 

--- a/hotsos/core/ycheck/scenarios.py
+++ b/hotsos/core/ycheck/scenarios.py
@@ -1,5 +1,5 @@
 from hotsos.core.config import HotSOSConfig
-from hotsos.core.issues import IssuesManager
+from hotsos.core.issues import IssuesManager, HotSOSScenariosWarning
 from hotsos.core.log import log
 from hotsos.core.ycheck.engine import (
     YDefsLoader,
@@ -64,34 +64,51 @@ class YScenarioChecker(ChecksBase):
     def scenarios(self):
         return self._scenarios
 
+    def _run_scenario_conclusion(self, scenario, issue_mgr):
+        """ Determine the conclusion of this scenario. """
+        results = {}
+        # run all conclusions and use highest priority result(s). One or
+        # more conclusions may share the same priority. All conclusions
+        # that match and share the same priority will be used.
+        for name, conc in scenario.conclusions.items():
+            if conc.reached(scenario.checks):
+                if conc.priority:
+                    priority = conc.priority.value
+                else:
+                    priority = 1
+
+                if priority in results:
+                    results[priority].append(conc)
+                else:
+                    results[priority] = [conc]
+
+                log.debug("conclusion reached: %s (priority=%s)", name,
+                          priority)
+
+        if results:
+            highest = max(results.keys())
+            log.debug("selecting highest priority=%s conclusions (%s)",
+                      highest, len(results[highest]))
+            for conc in results[highest]:
+                issue_mgr.add(conc.issue, context=conc.context)
+        else:
+            log.debug("no conclusions reached")
+
     def run(self):
-        mgr = IssuesManager()
+        failed_scenarios = []
+        issue_mgr = IssuesManager()
         for scenario in self.scenarios:
-            results = {}
             log.debug("running scenario: %s", scenario.name)
-            # run all conclusions and use highest priority result(s). One or
-            # more conclusions may share the same priority. All conclusions
-            # that match and share the same priority will be used.
-            for name, conc in scenario.conclusions.items():
-                if conc.reached(scenario.checks):
-                    if conc.priority:
-                        priority = conc.priority.value
-                    else:
-                        priority = 1
+            # catch failed scenarios and allow others to run
+            try:
+                self._run_scenario_conclusion(scenario, issue_mgr)
+            except Exception:
+                log.exception("caught exception when running scenario %s:",
+                              scenario.name)
+                failed_scenarios.append(scenario.name)
 
-                    if priority in results:
-                        results[priority].append(conc)
-                    else:
-                        results[priority] = [conc]
-
-                    log.debug("conclusion reached: %s (priority=%s)", name,
-                              priority)
-
-            if results:
-                highest = max(results.keys())
-                log.debug("selecting highest priority=%s conclusions (%s)",
-                          highest, len(results[highest]))
-                for conc in results[highest]:
-                    mgr.add(conc.issue, context=conc.context)
-            else:
-                log.debug("no conclusions reached")
+        if failed_scenarios:
+            msg = ("One or more scenarios failed to run ({}) - run hotsos in "
+                   "debug mode (--debug) to get more detail".
+                   format(', '.join(failed_scenarios)))
+            issue_mgr.add(HotSOSScenariosWarning(msg))


### PR DESCRIPTION
We now catch exceptions raised by scenarios and allow others to
run. Caught exceptions result in a HotSOSScenariosWarning being
raised with the names of failed scenariosn for further analysis.