### PR TITLE
Extend bcache info

### DIFF
--- a/defs/scenarios/storage/bcache/bdev.yaml
+++ b/defs/scenarios/storage/bcache/bdev.yaml
@@ -5,7 +5,7 @@ checks:
   has_invalid_bdev_config:
     requires:
       config:
-        handler: hotsos.core.plugins.storage.bcache.BdevsConfig
+        handler: hotsos.core.plugins.storage.bcache.BDevsConfig
         assertions:
           not:
             - key: sequential_cutoff

--- a/hotsos/core/host_helpers/config.py
+++ b/hotsos/core/host_helpers/config.py
@@ -1,3 +1,4 @@
+import abc
 import os
 import re
 
@@ -72,8 +73,9 @@ class ConfigBase(object):
 
         return False
 
+    @abc.abstractmethod
     def get(self, key, section=None, expand_to_list=False):
-        raise NotImplementedError
+        """ Get a config value. """
 
 
 class SectionalConfigBase(ConfigBase):

--- a/hotsos/core/plugins/storage/bcache.py
+++ b/hotsos/core/plugins/storage/bcache.py
@@ -4,6 +4,7 @@ import re
 
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers import CLIHelper
+from hotsos.core.host_helpers.config import ConfigBase
 from hotsos.core.plugins.storage import StorageBase
 from hotsos.core.searchtools import (
     FileSearcher,
@@ -13,44 +14,91 @@ from hotsos.core.searchtools import (
 from hotsos.core import utils
 
 
+class BcacheConfig(ConfigBase):
+
+    def get(self, key):
+        cfg = os.path.join(self.path, key)
+        if os.path.exists(cfg):
+            with open(cfg) as fd:
+                return fd.read().strip()
+
+
+class BDev(object):
+
+    def __init__(self, path, cache):
+        self.cache = cache
+        self.path = path
+
+    @property
+    def cfg(self):
+        return BcacheConfig(self.path)
+
+    @property
+    def dev_to_dname(self):
+        for line in CLIHelper().udevadm_info_dev(device=self.dev):
+            expr = r'.+\s+disk/by-dname/(.+)'
+            ret = re.compile(expr).match(line)
+            if ret:
+                return ret[1]
+
+    @property
+    def dev(self):
+        return os.path.basename(os.path.realpath(os.path.join(self.path,
+                                                              'dev')))
+
+    @property
+    def name(self):
+        return os.path.basename(self.path)
+
+    def __getattr__(self, key):
+        cfg = os.path.join(self.path, key)
+        if os.path.exists(cfg):
+            with open(cfg) as fd:
+                return fd.read().strip()
+
+
+class Cacheset(object):
+
+    def __init__(self, path):
+        self.path = path
+        self.bdevs = []
+
+        self.uuid = os.path.basename(self.path)
+        for bdev in glob.glob(os.path.join(self.path, 'bdev*')):
+            self.bdevs.append(BDev(bdev, self))
+
+    @property
+    def cfg(self):
+        return BcacheConfig(self.path)
+
+    def __getattr__(self, key):
+        cfg = os.path.join(self.path, key)
+        if os.path.exists(cfg):
+            with open(cfg) as fd:
+                return fd.read().strip()
+
+
 class BcacheBase(StorageBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.cachesets = []
         self._bcache_devs = []
         self.cli = CLIHelper()
+
+        for entry in glob.glob(os.path.join(HotSOSConfig.DATA_ROOT,
+                               'sys/fs/bcache/*')):
+            self.cachesets.append(Cacheset(entry))
 
     @property
     def bcache_enabled(self):
         """ Return True if there are any backing devices configured. """
-        for cset in self.get_cachesets():
-            if self.get_cacheset_bdevs(cset):
-                return True
+        if self.cachesets:
+            for cset in self.cachesets:
+                if cset.bdevs:
+                    return True
 
-    def get_cachesets(self):
-        return glob.glob(os.path.join(HotSOSConfig.DATA_ROOT,
-                                      'sys/fs/bcache/*'))
-
-    def get_cacheset_bdevs(self, cset):
-        return glob.glob(os.path.join(cset, 'bdev*'))
-
-    def get_sysfs_cachesets(self):
-        cachesets = []
-        for entry in self.get_cachesets():
-            if os.path.exists(os.path.join(entry, "cache_available_percent")):
-                cachesets.append({"path": entry,
-                                  "uuid": os.path.basename(entry)})
-
-        for cset in cachesets:
-            path = os.path.join(cset['path'], "cache_available_percent")
-            with open(path) as fd:
-                value = fd.read().strip()
-                cset["cache_available_percent"] = int(value)
-
-            # dont include in final output
-            del cset["path"]
-
-        return cachesets
+        return False
 
     @property
     def udev_bcache_devs(self):
@@ -82,9 +130,35 @@ class BcacheBase(StorageBase):
         self._bcache_devs = devs
         return self._bcache_devs
 
+    def resolve_bdev_from_dev(self, devpath):
+        """
+        Given a device path, resolve it to a corresponding bcache BDev object.
+        """
+        bcache_name = None
+        if 'bcache' in devpath:
+            bcache_name = os.path.basename(devpath)
+        else:
+            ret = re.compile(r"/dev/mapper/crypt-(\S+)").search(devpath)
+            if ret:
+                for udev_dev in self.udev_bcache_devs:
+                    if 'name' not in udev_dev:
+                        continue
+
+                    _uuid = udev_dev.get("by-uuid")
+                    if not _uuid or _uuid != ret.group(1):
+                        continue
+
+                    bcache_name = udev_dev['name']
+
+        if bcache_name:
+            for cset in self.cachesets:
+                for bdev in cset.bdevs:
+                    if bdev.dev == bcache_name:
+                        return bdev
+
     def is_bcache_device(self, dev):
         """
-        Returns True if the device either is or is based on a bcache device
+        Returns True if the device either is or is backed by a bcache device
         e.g. dmcrypt device using bcache dev.
         """
         if dev.startswith("bcache"):
@@ -93,34 +167,30 @@ class BcacheBase(StorageBase):
         if dev.startswith("/dev/bcache"):
             return True
 
-        ret = re.compile(r"/dev/mapper/crypt-(\S+)").search(dev)
-        if ret:
-            for dev in self.udev_bcache_devs:
-                if dev.get("by-uuid") == ret.group(1):
-                    return True
+        if self.resolve_bdev_from_dev(dev):
+            return True
 
         return False
+
+
+class BDevsConfig(BcacheBase):
+
+    def get(self, key):
+        """
+        This currently assumes there is only one cacheset on the host.
+        """
+        if self.cachesets and self.cachesets[0].bdevs:
+            return self.cachesets[0].bdevs[0].cfg.get(key)
 
 
 class CachesetsConfig(BcacheBase):
 
     def get(self, key):
-        for cset in self.get_cachesets():
-            cfg = os.path.join(cset, key)
-            if os.path.exists(cfg):
-                with open(cfg) as fd:
-                    return fd.read().strip()
-
-
-class BdevsConfig(BcacheBase):
-
-    def get(self, key):
-        for cset in self.get_cachesets():
-            for bdev in self.get_cacheset_bdevs(cset):
-                cfg = os.path.join(bdev, key)
-                if os.path.exists(cfg):
-                    with open(cfg) as fd:
-                        return fd.read().strip()
+        """
+        This currently assumes there is only one cacheset on the host.
+        """
+        if self.cachesets:
+            return self.cachesets[0].cfg.get(key)
 
 
 class BcacheChecksBase(BcacheBase):


### PR DESCRIPTION
The storage.bcache plugin can now resolve a device that either is
or is based on (e.g. a dmcrypt dev) to a bcache bdev. The summary
also now represents bcache devices only within the context of
their cacheset.