### PR TITLE
Add event for ovn involuntary context switches

### DIFF
--- a/defs/events/openvswitch/ovn/ovn-controller.yaml
+++ b/defs/events/openvswitch/ovn/ovn-controller.yaml
@@ -2,5 +2,10 @@ input:
   path: 'var/log/ovn/ovn-controller.log'
 unreasonably-long-poll-interval:
   expr: '([0-9-]+)T[0-9:\.]+Z.+\|timeval(?:\(([a-zA-Z]+)(\d+)\))?\|WARN\|Unreasonably long (\d+)ms poll interval'
+  hint: 'Unreasonably'
 bridge-not-found-for-port:
   expr: '([0-9-]+)T[0-9:\.]+Z.+\|\S+\|ERR\|bridge not found for localnet port ''(\S+)'' with network name ''\S+'''
+  hint: 'bridge not found'
+involuntary-context-switches:
+  expr: '([0-9-]+)T(\d+):\d+:\d+\.\S+Z.+\|timeval\|WARN\|context switches: \d+ voluntary, (\d+) involuntary'
+  hint: timeval

--- a/defs/events/openvswitch/ovs/ovs-vswitchd.yaml
+++ b/defs/events/openvswitch/ovs/ovs-vswitchd.yaml
@@ -14,3 +14,6 @@ dpif-netlink-lost-packet-on-handler:
   expr: '([0-9-]+)T[0-9:\.]+Z.+\|system@ovs-system: lost packet on port channel.+'
 inactivity-probe:
   expr: '([0-9-]+)T[0-9:\.]+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
+involuntary-context-switches:
+  expr: '([0-9-]+)T(\d+):\d+:\d+\.\S+Z.+\|timeval\|WARN\|context switches: 0 voluntary, (\d+) involuntary'
+  hint: timeval

--- a/examples/hotsos-example-openvswitch.summary.yaml
+++ b/examples/hotsos-example-openvswitch.summary.yaml
@@ -93,6 +93,9 @@ openvswitch:
     ovn-controller:
       unreasonably-long-poll-interval:
         '2022-02-17': 1
+      involuntary-context-switches:
+        '2022-02-17':
+          '04': 136
     ovsdb-server-nb:
       inactivity-probe:
         '2022-02-17':

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -153,6 +153,26 @@ class OVSEventChecks(OpenvSwitchEventChecksBase):
 
         return {event.name: sorted_dict(info)}, 'ovs-vswitchd'
 
+    @EVENTCALLBACKS.callback(event_group='ovs')
+    def involuntary_context_switches(self, event):
+        aggregated = {}
+        for r in event.results:
+            key = r.get(1)
+            hour = r.get(2)
+            count = int(r.get(3))
+            if key not in aggregated:
+                aggregated[key] = {}
+
+            if hour in aggregated[key]:
+                aggregated[key][hour] += count
+            else:
+                aggregated[key][hour] = count
+
+        for key, value in aggregated.items():
+            aggregated[key] = sorted_dict(value)
+
+        return {event.name: aggregated}, event.section
+
 
 class OVNEventChecks(OpenvSwitchEventChecksBase):
 
@@ -180,3 +200,23 @@ class OVNEventChecks(OpenvSwitchEventChecksBase):
                                      squash_if_none_keys=True)
         if ret:
             return {event.name: ret}, event.section
+
+    @EVENTCALLBACKS.callback(event_group='ovn')
+    def involuntary_context_switches(self, event):
+        aggregated = {}
+        for r in event.results:
+            key = r.get(1)
+            hour = r.get(2)
+            count = int(r.get(3))
+            if key not in aggregated:
+                aggregated[key] = {}
+
+            if hour in aggregated[key]:
+                aggregated[key][hour] += count
+            else:
+                aggregated[key][hour] = count
+
+        for key, value in aggregated.items():
+            aggregated[key] = sorted_dict(value)
+
+        return {event.name: sorted_dict(aggregated)}, event.section

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -220,6 +220,9 @@ class TestOpenvswitchEventChecks(TestOpenvswitchBase):
                     {'unreasonably-long-poll-interval': {
                         '2022-02-16': 1,
                         '2022-02-17': 1},
+                     'involuntary-context-switches': {
+                         '2022-02-16': {'09': 634},
+                         '2022-02-17': {'04': 136}},
                      'bridge-not-found-for-port': {
                         '2022-02-16':
                             {'provnet-aa3a4fec-a788-42e6-a773-bf3a0cdb52c2':


### PR DESCRIPTION
Collect counts of involuntary context switches for
ovs/ovn agents per hours, per day and include in
summary.