### PR TITLE
Fix config check issue message

### DIFF
--- a/defs/README.md
+++ b/defs/README.md
@@ -628,9 +628,10 @@ ASSERTION
 
 ```
 CACHE_KEYS
-  ops
-  key
-  value_actual
+  assertion_results - a string of concatenated assertion checks
+  key - the last key to be checked
+  ops - the last ops to be run
+  value_actual - the actual value checked against
 ```
 
 ### PropertyCollection

--- a/defs/scenarios/storage/bcache/bdev.yaml
+++ b/defs/scenarios/storage/bcache/bdev.yaml
@@ -23,8 +23,7 @@ conclusions:
     raises:
       type: BcacheWarning
       message: >-
-        bcache config {key} expected to be {op} but actual={value_actual}.
+        One or more of the following bcache bdev config assertions failed:
+        {assertions}
       format-dict:
-        key: '@checks.has_invalid_bdev_config.requires.key'
-        op: '@checks.has_invalid_bdev_config.requires.ops'
-        value_actual: '@checks.has_invalid_bdev_config.requires.value_actual'
+        assertions: '@checks.has_invalid_bdev_config.requires.assertion_results'

--- a/defs/scenarios/storage/bcache/cacheset.yaml
+++ b/defs/scenarios/storage/bcache/cacheset.yaml
@@ -30,11 +30,10 @@ conclusions:
     raises:
       type: BcacheWarning
       message: >-
-        bcache cacheset config {key} expected to be {op} but actual={value_actual}.
+        One or more of the following bcache cacheset config assertions failed:
+        {assertions}
       format-dict:
-        key: '@checks.cset_has_invalid_config.requires.key'
-        op: '@checks.cset_has_invalid_config.requires.ops'
-        value_actual: '@checks.cset_has_invalid_config.requires.value_actual'
+        assertions: '@checks.cset_has_invalid_config.requires.assertion_results'
   bcache-bug-lp1900438:
     decision:
       and:
@@ -48,4 +47,3 @@ conclusions:
         implies this node could be suffering from bug LP 1900438 - please check.
       format-dict:
         actual: '@checks.cset_config_lp1900438_limit.requires.value_actual'
-

--- a/hotsos/core/ycheck/engine/properties/requires/common.py
+++ b/hotsos/core/ycheck/engine/properties/requires/common.py
@@ -19,7 +19,10 @@ class OpsUtils(object):
         for op in ops:
             item = str(op[0])
             if len(op) > 1:
-                item = "{} {}".format(item, op[1])
+                if type(op[1]) == str:
+                    item = "{} \"{}\"".format(item, op[1])
+                else:
+                    item = "{} {}".format(item, op[1])
 
             _result.append(item)
 

--- a/hotsos/core/ycheck/engine/properties/requires/types/config.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/config.py
@@ -71,9 +71,19 @@ class YPropertyAssertionsBase(YPropertyMappedOverrideBase,
         log.debug("assertion: %s (%s) %s result=%s",
                   item.key, actual, self.ops_to_str(item.ops or []), _result)
 
-        # This is a bit iffy since it only gives us the final config
-        # assertion checked.
         cache = self.context.cache
+        msg = "{} {}/actual=\"{}\"".format(item.key,
+                                           self.ops_to_str(item.ops or []),
+                                           actual)
+        if cache.assertion_results is not None:
+            cache.set('assertion_results', "{}, {}".
+                      format(cache.assertion_results, msg))
+        else:
+            cache.set('assertion_results', msg)
+
+        # NOTE: This can be useful for single assertion checks but should be
+        # used with caution since it will only ever store the last config
+        # checked.
         cache.set('key', item.key)
         cache.set('ops', self.ops_to_str(item.ops or []))
         cache.set('value_actual', actual)

--- a/tests/unit/storage/test_bcache.py
+++ b/tests/unit/storage/test_bcache.py
@@ -129,8 +129,10 @@ class TestBCacheScenarioChecks(StorageBCacheTestsBase):
                 'which implies this node could be suffering from bug LP '
                 '1900438 - please check.')
             issue_msg = (
-                'bcache cacheset config congested_write_threshold_us '
-                'expected to be eq 0 but actual=100.')
+                'One or more of the following bcache cacheset config '
+                'assertions failed: congested_read_threshold_us '
+                'eq 0/actual="100", congested_write_threshold_us eq '
+                '0/actual="100"')
             issues = list(IssuesManager().load_issues().values())[0]
             self.assertEqual([issue['desc'] for issue in issues], [issue_msg])
             bugs = list(IssuesManager().load_bugs().values())[0]
@@ -143,7 +145,11 @@ class TestBCacheScenarioChecks(StorageBCacheTestsBase):
             self.setup_bcachefs(dtmp, bdev_error=True)
             setup_config(DATA_ROOT=dtmp)
             YScenarioChecker()()
-            msg = ('bcache config writeback_percent expected to be ge '
-                   '10 but actual=1.')
+            msg = ('One or more of the following bcache bdev config '
+                   'assertions failed: sequential_cutoff eq '
+                   '"0.0k"/actual="0.0k", cache_mode eq "writethrough '
+                   '[writeback] writearound none"/actual="writethrough '
+                   '[writeback] writearound none", writeback_percent ge '
+                   '10/actual="1"')
             issues = list(IssuesManager().load_issues().values())[0]
             self.assertEqual([issue['desc'] for issue in issues], [msg])


### PR DESCRIPTION
The config check property will store the last key/ops/actual_value
to be checked and the bcache store checks where always reporting the
last config checked when raising an issue which was not necessarily
the one that failed its assertion. This fixes that problem by
introducing a new cache key 'assertion_results' that contains all
assertions so that can be included in a message.

Resolves: #393