### PR TITLE
Ensure bug-id and bug type provided when raising bugs

### DIFF
--- a/hotsos/core/exceptions.py
+++ b/hotsos/core/exceptions.py
@@ -1,0 +1,3 @@
+
+class ScenarioException(Exception):
+    pass


### PR DESCRIPTION
When raising a bug (known-bugs) both bug-id: and a bug
type: must be provided. A ScenarioException will now be
raised if this is not the case.

Resolves: #395