### PR TITLE
[plugin/ceph] Recalibrate OSD metadata limit

### DIFF
--- a/defs/scenarios/storage/ceph/ceph-mon/bluefs_size.yaml
+++ b/defs/scenarios/storage/ceph/ceph-mon/bluefs_size.yaml
@@ -11,10 +11,11 @@ conclusions:
       type: CephTrackerBug
       bug-id: 45903
       message: >-
-        Found {num_bad_meta_osds} Ceph OSDs with metadata size larger than 10G.
-        This could be the result of a compaction failure/bug and this host may
-        be affected by https://tracker.ceph.com/issues/45903. A workaround (>=
-        Nautilus) is to manually compact using 'ceph-bluestore-tool'.
+        Found {num_bad_meta_osds} Ceph OSDs with metadata size > {limit_percent}% of its
+        device size. This could be the result of a compaction failure. Possibly related
+        to the bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually
+        compact the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
       format-dict:
         num_bad_meta_osds: '@checks.bluefs_osds_have_oversize_metadata.requires.value_actual:len'
+        limit_percent: hotsos.core.plugins.storage.ceph.CephCluster.OSD_META_LIMIT_PERCENT
 

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -241,7 +241,7 @@ class CephCrushMap(object):
 
 
 class CephCluster(object):
-    OSD_META_LIMIT_KB = (10 * 1024 * 1024)
+    OSD_META_LIMIT_PERCENT = 5
     OSD_PG_MAX_LIMIT = 500
     OSD_PG_OPTIMAL_NUM_MAX = 200
     OSD_PG_OPTIMAL_NUM_MIN = 50
@@ -480,9 +480,8 @@ class CephCluster(object):
         for device in self.osd_df_tree['nodes']:
             if device['id'] >= 0:
                 meta_kb = device['kb_used_meta']
-                # Usually the meta data is expected to be in 0-4G range
-                # and we check if it's over 10G
-                if meta_kb > self.OSD_META_LIMIT_KB:
+                total_kb = device['kb_avail']
+                if meta_kb > (self.OSD_META_LIMIT_PERCENT / 100.0 * total_kb):
                     _bad_meta_osds.append(device['name'])
 
         return _bad_meta_osds

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -700,16 +700,17 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
         self.assertEqual([issue['desc'] for issue in issues], [msg])
 
     @mock.patch('hotsos.core.plugins.storage.ceph.CephCluster.'
-                'OSD_META_LIMIT_KB', 1024)
+                'OSD_META_LIMIT_PERCENT', 1)
     @mock.patch('hotsos.core.ycheck.YDefsLoader._is_def',
                 new=utils.is_def_filter('ceph-mon/bluefs_size.yaml'))
     def test_bluefs_size(self):
         YScenarioChecker()()
-        msg = ('Found 3 Ceph OSDs with metadata size larger than 10G. This '
-               'could be the result of a compaction failure/bug and this host '
-               'may be affected by https://tracker.ceph.com/issues/45903. A '
-               'workaround (>= Nautilus) is to manually compact using '
-               "'ceph-bluestore-tool'.")
+        msg = ('Found 3 Ceph OSDs with metadata size > 1% of its device size. '
+               'This could be the result of a compaction failure. Possibly '
+               'related to the bug https://tracker.ceph.com/issues/45903 if '
+               'Ceph < 14.2.17. To manually compact the metadata, '
+               'use \'ceph-bluestore-tool\' which is available since 14.2.0.')
+
         issues = list(IssuesManager().load_bugs().values())[0]
         self.assertEqual([issue['desc'] for issue in issues], [msg])
 


### PR DESCRIPTION
Modified the hardcoded value of OSD metadata limit from 10G to 5% of the actual OSD device size.

Fixes #400.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>