### PR TITLE
Introduce filesearcher constraints

### DIFF
--- a/defs/scenarios/juju/charm_checks.yaml
+++ b/defs/scenarios/juju/charm_checks.yaml
@@ -5,8 +5,7 @@ checks:
     search:
       expr: '^(\S+) (\S+) .+ERROR cannot write leadership settings: cannot write settings: failed to merge leadership settings: application "(\S+)"'
       constraints:
-        # 7 days
-        search-result-age-hours: 168
+        search-result-age-hours: 168  # 7 days
 conclusions:
   units-have-leadership-errors:
     decision: units_have_leadership_errors

--- a/defs/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
+++ b/defs/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
@@ -8,7 +8,7 @@ checks:
         # i.e. must occur 5 times within same 24 hour period
         min-results: 5
         search-period-hours: 24
-        search-results-age-hours: 48
+        search-result-age-hours: 48
   ceph_interfaces_have_errors:
     requires:
       property: hotsos.core.plugins.storage.ceph.CephChecksBase.has_interface_errors

--- a/hotsos/core/host_helpers/network.py
+++ b/hotsos/core/host_helpers/network.py
@@ -7,7 +7,7 @@ from hotsos.core.log import log
 from hotsos.core.host_helpers.common import HostHelpersBase
 from hotsos.core.host_helpers.cli import CLIHelper
 from hotsos.core.utils import mktemp_dump
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     FileSearcher,
     SearchDef,
     SequenceSearchDef,

--- a/hotsos/core/plugins/kernel/kernlog/calltrace.py
+++ b/hotsos/core/plugins/kernel/kernlog/calltrace.py
@@ -2,7 +2,7 @@ import abc
 import re
 
 from hotsos.core.log import log
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     SearchDef,
     SequenceSearchDef,
 )
@@ -106,7 +106,7 @@ class GenericTraceType(TraceTypeBase):
         """
         Run through the results.
 
-        @param results: list of searchtools.SearchResult objects.
+        @param results: list of search.searchtools.SearchResult objects.
         """
         for _trace in result:
             # just a save a value i.e. to make the list length represent the
@@ -235,7 +235,7 @@ class BcacheDeadlockType(TraceTypeBase):
     def apply(self, result):
         """
         Run through the results.
-        @param results: list of searchtools.SearchResult objects.
+        @param results: list of search.searchtools.SearchResult objects.
         """
         if len(result) > 0:
             # we have found at least one deadlock

--- a/hotsos/core/plugins/kernel/kernlog/common.py
+++ b/hotsos/core/plugins/kernel/kernlog/common.py
@@ -3,7 +3,7 @@ import os
 
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers import CLIHelper, HostNetworkingHelper
-from hotsos.core.searchtools import FileSearcher
+from hotsos.core.search import FileSearcher
 
 KERNLOG_TS = r'\[\s*\d+\.\d+\]'
 KERNLOG_PREFIX = (r'(?:\S+\s+\d+\s+[\d:]+\s+\S+\s+\S+:\s+)?{}'.

--- a/hotsos/core/plugins/kernel/kernlog/events.py
+++ b/hotsos/core/plugins/kernel/kernlog/events.py
@@ -1,5 +1,5 @@
 from hotsos.core.log import log
-from hotsos.core.searchtools import SearchDef
+from hotsos.core.search import SearchDef
 from hotsos.core.plugins.kernel.kernlog.common import KernLogBase
 
 

--- a/hotsos/core/plugins/openstack/openstack.py
+++ b/hotsos/core/plugins/openstack/openstack.py
@@ -179,6 +179,8 @@ OST_EXCEPTIONS = {'barbican': BARBICAN_EXCEPTIONS + CASTELLAN_EXCEPTIONS,
                   'placement': PLACEMENT_EXCEPTIONS,
                   }
 
+OPENSTACK_LOGS_TS_EXPR = r"^([\d-]+\s+[\d:]+)"
+
 
 class OpenstackConfig(host_helpers.SectionalConfigBase):
     pass

--- a/hotsos/core/plugins/openvswitch/common.py
+++ b/hotsos/core/plugins/openvswitch/common.py
@@ -18,6 +18,7 @@ OVS_PKGS_DEPS = ['libc-bin',
                  'openvswitch-switch-dpdk',
                  ]
 PY_CLIENT_PREFIX = r"python3?-{}\S*"
+OPENVSWITCH_LOGS_TS_EXPR = r"^([0-9-]+)T([0-9:]+)"
 
 
 class OpenvSwitchChecksBase(plugintools.PluginPartBase):

--- a/hotsos/core/plugins/openvswitch/ovn.py
+++ b/hotsos/core/plugins/openvswitch/ovn.py
@@ -1,7 +1,7 @@
 import abc
 
 from hotsos.core.log import log
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     SearchDef,
     SequenceSearchDef,
     FileSearcher,

--- a/hotsos/core/plugins/rabbitmq/report.py
+++ b/hotsos/core/plugins/rabbitmq/report.py
@@ -2,7 +2,7 @@ import os
 
 from hotsos.core.log import log
 from hotsos.core.utils import mktemp_dump, sorted_dict, cached_property
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     SearchDef,
     SequenceSearchDef,
     FileSearcher,

--- a/hotsos/core/plugins/sosreport.py
+++ b/hotsos/core/plugins/sosreport.py
@@ -3,7 +3,7 @@ import os
 from hotsos.core.host_helpers import APTPackageHelper
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.plugintools import PluginPartBase
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     SearchDef,
     FileSearcher,
 )

--- a/hotsos/core/plugins/storage/bcache.py
+++ b/hotsos/core/plugins/storage/bcache.py
@@ -6,7 +6,7 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers import CLIHelper
 from hotsos.core.host_helpers.config import ConfigBase
 from hotsos.core.plugins.storage import StorageBase
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     FileSearcher,
     SequenceSearchDef,
     SearchDef

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -23,13 +23,13 @@ from hotsos.core.host_helpers import (
 from hotsos.core.host_helpers.cli import get_ps_axo_flags_available
 from hotsos.core.plugins.storage import StorageBase
 from hotsos.core.plugins.storage.bcache import BcacheBase
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     FileSearcher,
     SequenceSearchDef,
     SearchDef
 )
 
-
+CEPH_LOGS_TS_EXPR = r"^([\d-]+)[\sT]([\d:]+)"
 CEPH_SERVICES_EXPRS = [r"ceph-[a-z0-9-]+",
                        r"rados[a-z0-9-:]+"]
 CEPH_PKGS_CORE = [r"ceph",

--- a/hotsos/core/search/__init__.py
+++ b/hotsos/core/search/__init__.py
@@ -1,0 +1,5 @@
+from .searchtools import (   # noqa: F403,F401
+    FileSearcher,
+    SearchDef,
+    SequenceSearchDef,
+)

--- a/hotsos/core/search/constraints.py
+++ b/hotsos/core/search/constraints.py
@@ -1,0 +1,547 @@
+import abc
+import re
+import uuid
+
+from datetime import datetime, timedelta
+
+from hotsos.core.host_helpers.cli import CLIHelper
+from hotsos.core.log import log
+from hotsos.core.config import HotSOSConfig
+from hotsos.core.utils import cached_property
+
+
+class ConstraintBase(abc.ABC):
+
+    @cached_property
+    def id(self):
+        """
+        A unique identifier for this constraint.
+        """
+        return uuid.uuid4()
+
+    @abc.abstractmethod
+    def apply_to_line(self, line):
+        """
+        Apply constraint to a single line.
+
+        @param fd: file descriptor
+        """
+
+    @abc.abstractmethod
+    def apply_to_file(self, fd):
+        """
+        Apply constraint to an entire file.
+
+        @param fd: file descriptor
+        """
+
+    @abc.abstractmethod
+    def stats(self):
+        """ provide runtime stats for this object. """
+
+    @abc.abstractmethod
+    def __repr__(self):
+        """ provide string repr of this object. """
+
+
+class SkipRangeOverlapException(Exception):
+    def __init__(self, ln):
+        msg = ("the current and previous skip ranges overlap which "
+               "suggests that we have re-entered a range by skipping "
+               "line {}.".format(ln))
+        super().__init__(msg)
+
+
+class SkipRange(object):
+    # skip directions
+    SKIP_BWD = 0
+    SKIP_FWD = 1
+
+    def __init__(self):
+        self.direction = self.SKIP_BWD
+        self.current = set()
+        self.prev = set()
+
+    def re_entered(self):
+        if self.prev.intersection(self.current):
+            return True
+
+        return False
+
+    def add(self, ln):
+        self.current.add(ln)
+        if self.prev.intersection(self.current):
+            raise SkipRangeOverlapException(ln)
+
+    def __len__(self):
+        return len(self.current)
+
+    def save_and_reset(self):
+        if self.current:
+            self.prev = self.current
+            self.current = set()
+            self.direction = self.SKIP_BWD
+
+    def __repr__(self):
+        if self.current:
+            _r = sorted(list(self.current))
+            if self.direction == self.SKIP_BWD:
+                _dir = '<-'
+            else:
+                _dir = '->'
+
+            return "+skip({}{}{})".format(_r[0], _dir, _r[-1])
+
+        return ""
+
+
+class BinarySearchState(object):
+    # max contiguous skip lines before bailing on file search
+    SKIP_MAX = 1000
+
+    RC_FOUND_GOOD = 0
+    RC_FOUND_BAD = 1
+    RC_SKIPPING = 2
+    RC_ERROR = 3
+
+    def __init__(self, fd_info):
+        self.fd_info = fd_info
+        self.search_range_start = 0
+        self.search_range_end = len(self.fd_info.markers) - 1
+        self.rc = self.RC_FOUND_GOOD
+        self.cur_ln = 0
+        self.update_pos_pointers()
+        self.invalid_range = SkipRange()
+        self.last_known_good_ln = None
+
+    def save_last_known_good(self):
+        self.last_known_good_ln = self.cur_ln
+
+    def skip_current_line(self):
+        if len(self.invalid_range) == self.SKIP_MAX - 1:
+            self.rc = self.RC_ERROR
+            log.warning("reached max contiguous skips (%d) - skipping "
+                        "constraint for file %s", self.SKIP_MAX,
+                        self.fd_info.fd.name)
+            return
+
+        self.rc = self.RC_SKIPPING
+        try:
+            self.invalid_range.add(self.cur_ln)
+            if (self.invalid_range.direction == SkipRange.SKIP_BWD and
+                    self.cur_ln > self.search_range_start):
+                self.cur_ln -= 1
+            elif self.cur_ln < self.search_range_end:
+                if self.invalid_range.direction == SkipRange.SKIP_BWD:
+                    log.debug("changing skip direction to fwd")
+
+                self.invalid_range.direction = SkipRange.SKIP_FWD
+                self.cur_ln += 1
+
+            self.update_pos_pointers()
+        except SkipRangeOverlapException:
+            if self.last_known_good_ln is not None:
+                self.rc = self.RC_FOUND_GOOD
+                self.cur_ln = self.last_known_good_ln
+                self.update_pos_pointers()
+                log.debug("re-entered skip range so good line is %s",
+                          self.cur_ln)
+                self.fd_info.fd.seek(self.cur_pos)
+            else:
+                self.rc = self.RC_ERROR
+                log.error("last known good not set so not sure where to "
+                          "go after skip range overlap.")
+
+    def update_pos_pointers(self):
+        ln = self.cur_ln
+        self.cur_pos = self.fd_info.markers[ln]
+        if len(self.fd_info.markers) > ln + 1:
+            self.next_pos = self.fd_info.markers[ln + 1]
+        else:
+            self.next_pos = self.fd_info.eof_pos
+
+    def get_next_midpoint(self):
+        """
+        Given two line numbers in a file, find the mid point.
+        """
+        start = self.search_range_start
+        end = self.search_range_end
+        if start == end:
+            return start, self.fd_info.markers[start]
+
+        range = end - start
+        mid = start + int(range / 2) + (range % 2)
+        log.debug("midpoint: start=%s, mid=%s, end=%s", start, mid, end)
+        self.cur_ln = mid
+
+    def __repr__(self):
+        return ("start={}{}, end={}, cur_pos={}, cur_ln={}".format(
+                self.search_range_start,
+                self.invalid_range,
+                self.search_range_end,
+                self.cur_pos,
+                self.cur_ln))
+
+
+class SeekInfo(object):
+
+    def __init__(self, fd):
+        self.fd = fd
+        self.iterations = 0
+        self._orig_pos = self.fd.tell()
+
+    @cached_property
+    def markers(self):
+        """
+        Creates a dictionary of line numbers and their positions in the file.
+        This is done relative to the current position in the file and is
+        non-destructive i.e. original position is restored.
+        """
+        _markers = {}
+        ln = 0
+        self.fd.seek(self.orig_pos)
+        while True:
+            _markers[ln] = self.fd.tell()
+            self.fd.readline()
+            if self.fd.tell() >= self.eof_pos:
+                break
+
+            ln += 1
+
+        # restore
+        self.fd.seek(self.orig_pos)
+        return _markers
+
+    @cached_property
+    def eof_pos(self):
+        """
+        Returns file EOF position.
+        """
+        orig = self.fd.tell()
+        eof = self.fd.seek(0, 2)
+        self.fd.seek(orig)
+        return eof
+
+    @cached_property
+    def orig_pos(self):
+        """
+        The original position of the file descriptor.
+
+        NOTE: cannot be called when iterating over an fd. Must be called before
+        any destructive operations take place.
+        """
+        return self._orig_pos
+
+    def reset(self):
+        log.debug("restoring file position to start (%s)",
+                  self.orig_pos)
+        self.fd.seek(self.orig_pos)
+
+
+class BinarySeekSearchBase(ConstraintBase):
+    """
+    Provides a way to seek to a point in a file using a binary search and a
+    given condition.
+    """
+
+    @abc.abstractmethod
+    def extracted_datetime(self, line):
+        """
+        Extract datetime from line. Returns a datetime object or None if unable
+        to extract one from the line.
+
+        @param line: text line to extract a datetime from.
+        """
+
+    def _seek_and_validate(self, datetime_obj):
+        """
+        Seek to position and validate. If the line at pos is valid the new
+        position is returned otherwise None.
+
+        NOTE: this operation is destructive and will always point to the next
+              line after being called.
+
+        @param pos: position in a file.
+        """
+        if self._line_date_is_valid(datetime_obj):
+            return self.fd_info.fd.tell()
+
+    def _seek_next(self, status):
+        log.debug("seek %s", status)
+        self.fd_info.fd.seek(status.cur_pos)
+        # don't read the whole line since we only need the date at the start.
+        # hopefully 64 bytes is enough for any date+time format.
+        datetime_obj = self.extracted_datetime(self.fd_info.fd.read(64))
+        self.fd_info.fd.seek(status.next_pos)
+        if datetime_obj is None:
+            # until we get out of a skip range we want to leave the pos at the
+            # start but we rely on the caller to enforce this so that we don't
+            # have to seek(0) after every skip.
+            status.skip_current_line()
+            return status
+
+        newpos = self._seek_and_validate(datetime_obj)
+        if newpos is None:
+            status.rc = status.RC_FOUND_BAD
+            if status.cur_ln == 0:
+                log.debug("first line is not valid, checking last line")
+                status.cur_ln = status.search_range_end
+                status.update_pos_pointers()
+            elif (status.search_range_end - status.search_range_start) >= 1:
+                # _start_ln = status.search_range_start
+                status.search_range_start = status.cur_ln
+                # log.debug("going forwards (%s->%s:%s)", _start_ln,
+                #           status.search_range_start, status.search_range_end)
+                status.invalid_range.save_and_reset()
+                status.get_next_midpoint()
+                status.update_pos_pointers()
+        else:
+            status.save_last_known_good()
+            status.rc = status.RC_FOUND_GOOD
+            if status.cur_ln == 0:
+                log.debug("first line is valid so assuming same for rest of "
+                          "file")
+                self.fd_info.reset()
+            elif status.search_range_end - status.search_range_start <= 1:
+                log.debug("found final good ln=%s", status.cur_ln)
+                self.fd_info.fd.seek(status.cur_pos)
+            elif (len(status.invalid_range) > 0 and
+                  status.invalid_range.direction == SkipRange.SKIP_FWD):
+                log.debug("found good after skip range")
+                self.fd_info.fd.seek(status.cur_pos)
+            else:
+                # set rc to bad since we are going to a new range
+                status.rc = status.RC_FOUND_BAD
+                # _end_ln = status.search_range_end
+                status.search_range_end = status.cur_ln
+                # log.debug("going backwards (%s:%s->%s)",
+                #           status.search_range_start, _end_ln,
+                #           status.search_range_end)
+                self.fd_info.fd.seek(status.cur_pos)
+                status.invalid_range.save_and_reset()
+                status.get_next_midpoint()
+                status.update_pos_pointers()
+
+        return status
+
+    def _seek_to_first_valid(self, destructive=True):
+        """
+        Find first valid line in file using binary search. By default this is a
+        destructive and will actually seek to the line. If no line is found the
+        descriptor will be at EOF.
+
+        Returns offset at which valid line was found.
+
+        @param destructive: by default this seek operation is destructive i.e.
+                            it will find the least valid point and stay there.
+                            If that is not desired this can be set to False.
+        """
+        # log.debug("seeking to valid line")
+        offset = 0
+        search_state = BinarySearchState(self.fd_info)
+        while True:
+            self.fd_info.iterations += 1
+            search_state = self._seek_next(search_state)
+            if search_state.rc == search_state.RC_ERROR:
+                offset = 0
+                self.fd_info.reset()
+                break
+
+            # log.debug(search_state)
+            if ((search_state.rc == search_state.RC_FOUND_GOOD) or
+                    (search_state.search_range_end -
+                        search_state.search_range_start < 1)):
+                # log.debug("seek ended at offset=%s", search_state.cur_ln)
+                offset = search_state.cur_ln
+                break
+
+            if ((search_state.rc == search_state.RC_SKIPPING) and
+                    (search_state.cur_ln >= search_state.search_range_end)):
+                if (len(search_state.invalid_range) ==
+                        search_state.search_range_end):
+                    # offset and pos should still be SOF so we
+                    # make this the same
+                    search_state.cur_ln = 0
+                    self.fd_info.reset()
+                break
+
+            if self.fd_info.iterations >= len(self.fd_info.markers):
+                log.warning("exiting seek loop since limit reached (eof=%s)",
+                            self.fd_info.eof_pos)
+                offset = 0
+                self.fd_info.reset()
+                break
+
+        if not destructive:
+            self.fd_info.fd.reset()
+
+        log.debug("seek %s finished (skipped %d lines) current_pos=%s, "
+                  "offset=%s iterations=%s",
+                  self.fd_info.fd.name, offset,
+                  self.fd_info.fd.tell(), offset, self.fd_info.iterations)
+
+        return offset
+
+
+class SearchConstraintSearchSince(BinarySeekSearchBase):
+
+    def __init__(self, exprs=None, hours=None):
+        """
+        A search expression is provided that allows us to identify a datetime
+        on each line and check whether it is within a given time period. The
+        time period used defaults to 24 hours of USE_ALL_LOGS is false, 7 days
+        if it is true and MAX_LOGROTATE_DEPTH is default otherwise whatever
+        value provided. This can be overridden by providing a specific number
+        of hours.
+
+        @param exprs: a list of search/regex expressions used to identify a
+                      date/time in.
+        each line in the file we are applying this constraint to.
+        @param hours: override default period with number of hours
+        """
+        super().__init__()
+        if hours is not None and hours == 0:
+            log.warning("search constraint created with hours=%s", hours)
+
+        self.fd_info = None
+        self._line_pass = 0
+        self._line_fail = 0
+        self.exprs = exprs
+        self.hours = hours
+        self.date_format = '%Y-%m-%d %H:%M:%S'
+        self._results = {}
+
+    def extracted_datetime(self, line):
+        """
+        Validate if the given line falls within the provided constraint. In
+        this case that's whether it has a datetime that is >= to the "since"
+        date.
+
+        @param line: text line to extract a datetime from.
+        """
+        if type(line) == bytes:
+            # need this for e.g. gzipped files
+            line = line.decode("utf-8")
+
+        for expr in self.exprs:
+            # log.debug("attempting to extract from line using expr '%s'",
+            #           expr)
+            ret = re.search(expr, line)
+            if ret:
+                # log.debug("expr '%s' successful", expr)
+                break
+
+        if not ret:
+            # log.info("all exprs unsuccessful: %s", self.exprs)
+            return
+
+        str_date = ""
+        for g in ret.groups():
+            str_date += "{} ".format(g)
+
+        str_date = str_date.strip()
+        try:
+            return datetime.strptime(str_date, self.date_format)
+        except ValueError:
+            log.exception("")
+
+    @property
+    def _is_valid(self):
+        return self._since_date is not None
+
+    @cached_property
+    def _current_date(self):
+        current_date = CLIHelper().date(format="+{}".format(self.date_format))
+        if not current_date:
+            log.warning("date() returned unexpected value '%s'",
+                        current_date)
+            return None
+
+        return datetime.strptime(current_date, self.date_format)
+
+    @cached_property
+    def _since_date(self):
+        """
+        Reflects the date from which we will start to apply searches.
+        """
+        if not self._current_date:
+            return
+
+        days = 0
+        if self.hours is None:
+            days = 1
+            if HotSOSConfig.USE_ALL_LOGS:
+                days = HotSOSConfig.MAX_LOGROTATE_DEPTH
+
+        return self._current_date - timedelta(days=days, hours=self.hours or 0)
+
+    def _line_date_is_valid(self, extracted_datetime):
+        """
+        Validate if the given line falls within the provided constraint. In
+        this case that's whether it has a datetime that is >= to the "since"
+        date.
+        """
+        ts = extracted_datetime
+        if ts is None:
+            # log.info("s:%s: failed to extract datetime from "
+            #          "using expressions %s - assuming line is not valid",
+            #          unique_search_id, ', '.join(self.exprs))
+            return False
+
+        if ts < self._since_date:
+            # log.debug("%s < %s at (%s) i.e. False", ts, self._since_date,
+            #           line[-3:].strip())
+            return False
+
+        # log.debug("%s >= %s at (%s) i.e. True", ts, self._since_date,
+        #           line[-3:].strip())
+
+        return True
+
+    def apply_to_line(self, line):
+        if not self._is_valid:
+            log.warning("c:%s unable to apply constraint to line", self.id)
+            self._line_pass += 1
+            return True
+
+        extracted_datetime = self.extracted_datetime(line)
+        if not extracted_datetime:
+            self._line_pass += 1
+            return True
+
+        ret = self._line_date_is_valid(extracted_datetime)
+        if ret:
+            self._line_pass += 1
+        else:
+            self._line_fail += 1
+
+        return ret
+
+    def apply_to_file(self, fd, destructive=True):
+        self.fd_info = SeekInfo(fd)
+        if not self._is_valid:
+            log.warning("c:%s unable to apply constraint to %s", self.id,
+                        fd.name)
+            return
+
+        if fd.name in self._results:
+            return self._results[fd.name]
+
+        log.debug("s:%s: starting binary seek search to %s in file %s "
+                  "(destructive=True)", self.id, self._since_date, fd.name)
+        self._results[fd.name] = self._seek_to_first_valid(destructive)
+        log.debug("s:%s: finished binary seek search in file %s", self.id,
+                  fd.name)
+        return self._results[fd.name]
+
+    def stats(self):
+        _stats = {'line': {'pass': self._line_pass,
+                           'fail': self._line_fail}}
+        if self.fd_info:
+            _stats['file'] = {'name': self.fd_info.fd.name,
+                              'iterations': self.fd_info.iterations}
+        return _stats
+
+    def __repr__(self):
+        return ("id={}, since={}, current={}".
+                format(self.id, self._since_date, self._current_date))

--- a/hotsos/core/ycheck/engine/properties/conclusions.py
+++ b/hotsos/core/ycheck/engine/properties/conclusions.py
@@ -76,7 +76,7 @@ class YPropertyRaises(YPropertyOverrideBase):
         corresponding values from searchresult and use them to format the
         message. Returns formatted message.
 
-        @param searchresult: a searchtools.SearchResult object.
+        @param searchresult: a search.searchtools.SearchResult object.
         """
         if not self.format_groups:
             return self.message

--- a/hotsos/core/ycheck/engine/properties/input.py
+++ b/hotsos/core/ycheck/engine/properties/input.py
@@ -28,6 +28,9 @@ class YPropertyInputBase(object):
 
     @property
     def command(self):
+        if type(self.content) != dict:
+            return
+
         return self.content.get('command')
 
     def expand_paths(self, paths):

--- a/hotsos/core/ycheck/events.py
+++ b/hotsos/core/ycheck/events.py
@@ -57,7 +57,7 @@ class EventCheckResult(object):
         """
         @param defs_section: section name from yaml
         @param defs_event: event label/name from yaml
-        @param search_results: searchtools.SearchResultsCollection
+        @param search_results: search.searchtools.SearchResultsCollection
         @param search_tag: unique tag used to identify the results
         @param sequence_def: if set the search results are from a
                             searchtools.SequenceSearchDef and are therefore
@@ -238,7 +238,14 @@ class YEventCheckerBase(YHandlerBase, EventProcessingUtils):
                 self.__event_defs[section_name] = {}
 
             for path in event.input.paths:
-                event.search.load_searcher(self.searchobj, path)
+                if event.input.command:
+                    # don't apply constraints to command outputs
+                    allow_constraints = False
+                else:
+                    allow_constraints = True
+
+                event.search.load_searcher(self.searchobj, path,
+                                           allow_constraints=allow_constraints)
 
             emeta = {'passthrough': event.search.passthrough_results_opt,
                      'sequence': event.search.sequence_search,

--- a/hotsos/plugin_extensions/openstack/agent_event_checks.py
+++ b/hotsos/plugin_extensions/openstack/agent_event_checks.py
@@ -13,12 +13,14 @@ from hotsos.core.issues import (
     OpenstackWarning
 )
 from hotsos.core.log import log
-from hotsos.core.searchtools import FileSearcher
+from hotsos.core.search import FileSearcher
+from hotsos.core.search.constraints import SearchConstraintSearchSince
 from hotsos.core import utils
 from hotsos.core.plugins.openstack.common import (
     OpenstackChecksBase,
     OpenstackEventChecksBase,
 )
+from hotsos.core.plugins.openstack.openstack import OPENSTACK_LOGS_TS_EXPR
 from hotsos.core.plugins.openstack.neutron import NeutronHAInfo
 from hotsos.core.utils import sorted_dict
 
@@ -303,7 +305,8 @@ class AgentEventChecks(OpenstackChecksBase):
         if not self.openstack_installed:
             return
 
-        s = FileSearcher()
+        c = SearchConstraintSearchSince(exprs=[OPENSTACK_LOGS_TS_EXPR])
+        s = FileSearcher(constraint=c)
         check_objs = [c(searchobj=s) for c in checks]
         for check in check_objs:
             check.load()

--- a/hotsos/plugin_extensions/openstack/agent_exceptions.py
+++ b/hotsos/plugin_extensions/openstack/agent_exceptions.py
@@ -4,14 +4,17 @@ import re
 from hotsos.core.log import log
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.plugins.openstack.common import OpenstackChecksBase
-from hotsos.core.searchtools import FileSearcher, SearchDef
+from hotsos.core.plugins.openstack.openstack import OPENSTACK_LOGS_TS_EXPR
+from hotsos.core.search import FileSearcher, SearchDef
+from hotsos.core.search.constraints import SearchConstraintSearchSince
 
 
 class AgentExceptionChecks(OpenstackChecksBase):
 
     def __init__(self):
         super().__init__()
-        self.searchobj = FileSearcher()
+        c = SearchConstraintSearchSince(exprs=[OPENSTACK_LOGS_TS_EXPR])
+        self.searchobj = FileSearcher(constraint=c)
         # The following are expected to be WARNING
         self._agent_warnings = {
             'nova': ['MessagingTimeout',

--- a/hotsos/plugin_extensions/openstack/nova_external_events.py
+++ b/hotsos/plugin_extensions/openstack/nova_external_events.py
@@ -1,9 +1,11 @@
 from hotsos.core.ycheck.events import CallbackHelper
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     SearchDef,
     FileSearcher,
 )
+from hotsos.core.search.constraints import SearchConstraintSearchSince
 from hotsos.core.plugins.openstack.common import OpenstackEventChecksBase
+from hotsos.core.plugins.openstack.openstack import OPENSTACK_LOGS_TS_EXPR
 
 EXT_EVENT_META = {'network-vif-plugged': {'stages_keys':
                                           ['Preparing', 'Received',
@@ -36,7 +38,8 @@ class NovaExternalEventChecks(OpenstackEventChecksBase):
         events = {}
         events_found = {}
 
-        s = FileSearcher()
+        c = SearchConstraintSearchSince(exprs=[OPENSTACK_LOGS_TS_EXPR])
+        s = FileSearcher(constraint=c)
         for result in event.results:
             instance_id = result.get(1)
             event_id = result.get(3)

--- a/hotsos/plugin_extensions/openstack/vm_info.py
+++ b/hotsos/plugin_extensions/openstack/vm_info.py
@@ -5,11 +5,15 @@ from datetime import datetime
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.ycheck.events import CallbackHelper
 from hotsos.core.analytics import LogEventStats
-from hotsos.core.searchtools import (
+from hotsos.core.search import (
     FileSearcher,
     SearchDef,
 )
-from hotsos.core.plugins.openstack.openstack import OpenstackConfig
+from hotsos.core.search.constraints import SearchConstraintSearchSince
+from hotsos.core.plugins.openstack.openstack import (
+    OpenstackConfig,
+    OPENSTACK_LOGS_TS_EXPR,
+)
 from hotsos.core.plugins.openstack.common import (
     OpenstackChecksBase,
     OpenstackEventChecksBase,
@@ -94,9 +98,10 @@ class OpenstackInstanceChecks(OpenstackChecksBase):
 class NovaServerMigrationAnalysis(OpenstackEventChecksBase):
 
     def __init__(self, *args, **kwargs):
+        c = SearchConstraintSearchSince(exprs=[OPENSTACK_LOGS_TS_EXPR])
         super().__init__(EVENTCALLBACKS, *args,
                          yaml_defs_group='nova.migrations',
-                         searchobj=FileSearcher(),
+                         searchobj=FileSearcher(constraint=c),
                          **kwargs)
 
     def migration_seq_info(self, event, resource_idx, info_idxs,

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -1,9 +1,13 @@
 import re
 
 from hotsos.core.ycheck.events import CallbackHelper
-from hotsos.core.searchtools import FileSearcher
+from hotsos.core.search import FileSearcher
+from hotsos.core.search.constraints import SearchConstraintSearchSince
 from hotsos.core.issues import IssuesManager, OpenvSwitchWarning
-from hotsos.core.plugins.openvswitch.common import OpenvSwitchEventChecksBase
+from hotsos.core.plugins.openvswitch.common import (
+    OPENVSWITCH_LOGS_TS_EXPR,
+    OpenvSwitchEventChecksBase
+)
 from hotsos.core.plugins.openvswitch.ovs import OpenvSwitchBase
 from hotsos.core.utils import sorted_dict
 
@@ -13,8 +17,9 @@ EVENTCALLBACKS = CallbackHelper()
 class OVSEventChecks(OpenvSwitchEventChecksBase):
 
     def __init__(self):
+        c = SearchConstraintSearchSince(exprs=[OPENVSWITCH_LOGS_TS_EXPR])
         super().__init__(EVENTCALLBACKS, yaml_defs_group='ovs',
-                         searchobj=FileSearcher())
+                         searchobj=FileSearcher(constraint=c))
         self.ovs = OpenvSwitchBase()
 
     @property
@@ -180,8 +185,9 @@ class OVSEventChecks(OpenvSwitchEventChecksBase):
 class OVNEventChecks(OpenvSwitchEventChecksBase):
 
     def __init__(self):
+        c = SearchConstraintSearchSince(exprs=[OPENVSWITCH_LOGS_TS_EXPR])
         super().__init__(EVENTCALLBACKS, yaml_defs_group='ovn',
-                         searchobj=FileSearcher())
+                         searchobj=FileSearcher(constraint=c))
 
     @property
     def summary_subkey(self):

--- a/hotsos/plugin_extensions/storage/ceph_event_checks.py
+++ b/hotsos/plugin_extensions/storage/ceph_event_checks.py
@@ -2,8 +2,12 @@ import re
 
 from hotsos.core.issues import IssuesManager, CephOSDError
 from hotsos.core.ycheck.events import CallbackHelper
-from hotsos.core.plugins.storage.ceph import CephEventChecksBase
-from hotsos.core.searchtools import FileSearcher
+from hotsos.core.plugins.storage.ceph import (
+    CEPH_LOGS_TS_EXPR,
+    CephEventChecksBase,
+)
+from hotsos.core.search import FileSearcher
+from hotsos.core.search.constraints import SearchConstraintSearchSince
 
 EVENTCALLBACKS = CallbackHelper()
 CEPH_ID_FROM_LOG_PATH_EXPR = r'.+ceph-osd\.(\d+)\.log'
@@ -12,8 +16,9 @@ CEPH_ID_FROM_LOG_PATH_EXPR = r'.+ceph-osd\.(\d+)\.log'
 class CephDaemonLogChecks(CephEventChecksBase):
 
     def __init__(self):
+        c = SearchConstraintSearchSince(exprs=[CEPH_LOGS_TS_EXPR])
         super().__init__(EVENTCALLBACKS, yaml_defs_group='ceph',
-                         searchobj=FileSearcher())
+                         searchobj=FileSearcher(constraint=c))
 
     @EVENTCALLBACKS.callback(event_group='ceph')
     def slow_requests(self, event):

--- a/tests/unit/fake_data_root/storage/ceph-mon/var/log/ceph/ceph.log.1
+++ b/tests/unit/fake_data_root/storage/ceph-mon/var/log/ceph/ceph.log.1
@@ -1,11 +1,5 @@
 # THE FOLLOWING HAVE BEEN MANUALLY ADDED FOR CEPH-MON TESTING
 
-2022-02-09 19:17:40.444646 mon.juju-0f7010-18-lxd-1 (mon.0) 1329992 : cluster [WRN] Health check update: Long heartbeat ping times on front interface seen, longest is 1852.572 msec (OSD_SLOW_PING_TIME_FRONT)
-2022-02-09 19:18:41.755085 mon.juju-0f7010-18-lxd-1 (mon.0) 1330033 : cluster [WRN] Health check update: Long heartbeat ping times on back interface seen, longest is 1443.817 msec (OSD_SLOW_PING_TIME_BACK)
-2022-02-09 19:18:41.755288 mon.juju-0f7010-18-lxd-1 (mon.0) 1330034 : cluster [WRN] Health check update: Long heartbeat ping times on front interface seen, longest is 1828.995 msec (OSD_SLOW_PING_TIME_FRONT)
-2022-02-09 19:19:01.599828 mon.juju-0f7010-18-lxd-1 (mon.0) 1330051 : cluster [WRN] Health check update: Long heartbeat ping times on front interface seen, longest is 1829.084 msec (OSD_SLOW_PING_TIME_FRONT)
-
-
 2022-02-08 06:25:01.980878 mon.ceph1 (mon.0) 187359 : cluster [DBG] osd.41 reported failed by osd.89
 2022-02-08 06:25:02.066523 mon.ceph1 (mon.0) 187360 : cluster [DBG] osd.41 reported failed by osd.54
 2022-02-08 06:25:02.244413 mon.ceph1 (mon.0) 187362 : cluster [DBG] osd.41 reported failed by osd.51
@@ -33,6 +27,12 @@
 2022-02-08 06:25:03.892938 mon.ceph1 (mon.0) 187386 : cluster [DBG] osd.41 reported failed by osd.97
 2022-02-08 06:25:03.914537 mon.ceph1 (mon.0) 187387 : cluster [DBG] osd.41 reported failed by osd.28
 2022-02-08 06:25:03.943606 mon.ceph1 (mon.0) 187388 : cluster [DBG] osd.41 reported failed by osd.105
+
+
+2022-02-09 19:17:40.444646 mon.juju-0f7010-18-lxd-1 (mon.0) 1329992 : cluster [WRN] Health check update: Long heartbeat ping times on front interface seen, longest is 1852.572 msec (OSD_SLOW_PING_TIME_FRONT)
+2022-02-09 19:18:41.755085 mon.juju-0f7010-18-lxd-1 (mon.0) 1330033 : cluster [WRN] Health check update: Long heartbeat ping times on back interface seen, longest is 1443.817 msec (OSD_SLOW_PING_TIME_BACK)
+2022-02-09 19:18:41.755288 mon.juju-0f7010-18-lxd-1 (mon.0) 1330034 : cluster [WRN] Health check update: Long heartbeat ping times on front interface seen, longest is 1828.995 msec (OSD_SLOW_PING_TIME_FRONT)
+2022-02-09 19:19:01.599828 mon.juju-0f7010-18-lxd-1 (mon.0) 1330051 : cluster [WRN] Health check update: Long heartbeat ping times on front interface seen, longest is 1829.084 msec (OSD_SLOW_PING_TIME_FRONT)
 
 
 2022-02-09 20:23:23.884 7f028efb6700 -1 osd.4 92473 heartbeat_check: no reply from 10.109.12.175:6824 osd.0 since back 2022-02-09 20:23:23.414503 front 2022-02-09 20:23:02.007594 (oldest deadline 2022-02-09 20:23:23.107095)

--- a/tests/unit/storage/test_ceph_mgr.py
+++ b/tests/unit/storage/test_ceph_mgr.py
@@ -10,7 +10,7 @@ from hotsos.core.issues import IssuesManager
 from hotsos.core.ycheck.scenarios import YScenarioChecker
 
 CEPH_MGR_DATA_ROOT = os.path.join(utils.TESTS_DIR,
-                                  'fake_data_root/storage/ceph-mgr')
+                                  'fake_data_root/storage/ceph-mon')
 
 OVERLAPPING_ROOTS = """
 2022-09-02T09:08:00+0100 7f641f7e3700  0 [pg_autoscaler ERROR root] pool 14 has overlapping roots: {-1, -2}
@@ -33,7 +33,8 @@ class TestStorageScenarioChecksCephMgr(StorageCephMgrTestsBase):
                                         'autoscaler_overlap_roots.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.SystemdHelper.services',
                 {'ceph-mgr': SystemdService('ceph-mgr', 'enabled')})
-    @utils.create_data_root({'var/log/ceph/ceph-mgr.log': OVERLAPPING_ROOTS})
+    @utils.create_data_root({'var/log/ceph/ceph-mgr.log': OVERLAPPING_ROOTS},
+                            copy_from_original=['sos_commands/date/date'])
     def test_pg_autoscaler_overlapping_roots(self):
         YScenarioChecker()()
         msg = ("PG autoscaler found overlapping roots for pool(s). As a "

--- a/tests/unit/storage/test_ceph_osd.py
+++ b/tests/unit/storage/test_ceph_osd.py
@@ -206,7 +206,11 @@ class TestOSDCephEventChecks(StorageCephOSDTestsBase):
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('osd/osdlogs.yaml'))
-    def test_get_ceph_daemon_log_checker(self):
+    @mock.patch('hotsos.core.search.constraints.CLIHelper')
+    def test_get_ceph_daemon_log_checker(self, mock_cli):
+        mock_cli.return_value = mock.MagicMock()
+        # ensure log file contents are within allowed timeframe ("since")
+        mock_cli.return_value.date.return_value = "2021-01-01 00:00:00"
         result = {'crc-err-bluestore': {'2021-02-12': 5, '2021-02-13': 1},
                   'crc-err-rocksdb': {'2021-02-12': 7}}
         inst = ceph_event_checks.CephDaemonLogChecks()

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -4,7 +4,7 @@ from . import utils
 
 from hotsos.core import analytics
 from hotsos.core.config import HotSOSConfig
-from hotsos.core.searchtools import FileSearcher, SearchDef
+from hotsos.core.search import FileSearcher, SearchDef
 
 
 SEQ_TEST_1 = """2021-07-19 09:01:58.498 iteration:0 start

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -298,7 +298,8 @@ class TestKernelScenarioChecks(TestKernelBase):
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('network.yaml'))
-    @utils.create_data_root({'var/log/kern.log': KERNLOG_NF_CONNTRACK_FULL})
+    @utils.create_data_root({'var/log/kern.log': KERNLOG_NF_CONNTRACK_FULL},
+                            copy_from_original=['sos_commands/date/date'])
     def test_nf_conntrack_full(self):
         YScenarioChecker()()
         msg = ("1 reports of 'nf_conntrack: table full' detected in "
@@ -346,7 +347,8 @@ class TestKernelScenarioChecks(TestKernelBase):
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('network.yaml'))
-    @utils.create_data_root({'var/log/kern.log': EVENTS_KERN_LOG})
+    @utils.create_data_root({'var/log/kern.log': EVENTS_KERN_LOG},
+                            copy_from_original=['sos_commands/date/date'])
     def test_over_mtu_dropped_packets(self):
         with mock.patch('hotsos.core.host_helpers.HostNetworkingHelper.'
                         'host_interfaces_all',
@@ -362,7 +364,8 @@ class TestKernelScenarioChecks(TestKernelBase):
     @mock.patch('hotsos.core.plugins.kernel.kernlog.common.CLIHelper')
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('network.yaml'))
-    @utils.create_data_root({'var/log/kern.log': EVENTS_KERN_LOG_W_OVS_PORTS})
+    @utils.create_data_root({'var/log/kern.log': EVENTS_KERN_LOG_W_OVS_PORTS},
+                            copy_from_original=['sos_commands/date/date'])
     def test_over_mtu_dropped_packets_w_ovs_ports(self, mock_cli, mock_log):
         mock_cli.return_value = mock.MagicMock()
         # include trailing newline since cli would give that
@@ -423,7 +426,8 @@ class TestKernelScenarioChecks(TestKernelBase):
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('disk_failure.yaml'))
-    @utils.create_data_root({'var/log/kern.log': DISK_FAILING_KERN_LOG})
+    @utils.create_data_root({'var/log/kern.log': DISK_FAILING_KERN_LOG},
+                            copy_from_original=['sos_commands/date/date'])
     def test_failing_disk(self):
         YScenarioChecker()()
         msg = ('critical medium error detected in '
@@ -435,7 +439,8 @@ class TestKernelScenarioChecks(TestKernelBase):
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('qla2xxx.yaml'))
     @utils.create_data_root({'var/log/kern.log':
-                             KERN_LOG_QLA2XXX_SKIPPING_SCSI_SCAN_HOST})
+                             KERN_LOG_QLA2XXX_SKIPPING_SCSI_SCAN_HOST},
+                            copy_from_original=['sos_commands/date/date'])
     def test_qla2xxx_skipped_scsi_scan_host(self):
         YScenarioChecker()()
         msg = ("The qla2xxx driver did not perform SCSI scan on host/port "

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -100,8 +100,8 @@ class TestMySQLScenarios(MySQLTestsBase):
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('mysql/bugs.yaml'))
-    @utils.create_data_root({'var/log/mysql/error.log':
-                             FREE_BLOCKS_DIFFICULT})
+    @utils.create_data_root({'var/log/mysql/error.log': FREE_BLOCKS_DIFFICULT},
+                            copy_from_original=['sos_commands/date/date'])
     def test_372017_invoked(self):
         YScenarioChecker()()
         expected = {

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -14,7 +14,7 @@ from hotsos.core.issues.utils import IssuesStore
 from hotsos.core.config import setup_config, HotSOSConfig
 from hotsos.core.ycheck.scenarios import YScenarioChecker
 from hotsos.core.host_helpers.systemd import SystemdService
-from hotsos.core.searchtools import FileSearcher
+from hotsos.core.search import FileSearcher
 from hotsos.plugin_extensions.openstack import (
     vm_info,
     nova_external_events,
@@ -1165,7 +1165,8 @@ class TestOpenstackScenarioChecks(TestOpenstackBase):
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('nova/bugs.yaml'))
     @utils.create_data_root({'var/log/nova/nova-compute.log':
-                             LP_1904580})
+                             LP_1904580},
+                            copy_from_original=['sos_commands/date/date'])
     def test_1904580(self):
         YScenarioChecker()()
         expected = {'bugs-detected':
@@ -1264,8 +1265,8 @@ class TestOpenstackScenarioChecks(TestOpenstackBase):
     @mock.patch('hotsos.core.host_helpers.packaging.CLIHelper')
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('octavia/bugs.yaml'))
-    @utils.create_data_root({'var/log/octavia/octavia-worker.log':
-                             LP_2008099})
+    @utils.create_data_root({'var/log/octavia/octavia-worker.log': LP_2008099},
+                            copy_from_original=['sos_commands/date/date'])
     def test_2008099(self, mock_helper):
         mock_helper.return_value = mock.MagicMock()
         mock_helper.return_value.dpkg_l.return_value = \

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -244,7 +244,8 @@ class TestOpenvswitchEventChecks(TestOpenvswitchBase):
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('bfd.yaml'))
     @utils.create_data_root({'var/log/openvswitch/ovs-vswitchd.log':
-                             BFD_STATE_CHANGES})
+                             BFD_STATE_CHANGES},
+                            copy_from_original=['sos_commands/date/date'])
     def test_ovs_bfd_state_changes(self):
         expected = {'ovs-vswitchd': {
                     'bfd-state-changes': {
@@ -295,7 +296,8 @@ class TestOpenvswitchScenarioChecks(TestOpenvswitchBase):
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ovn_bugs.yaml'))
-    @utils.create_data_root({'var/log/ovn/ovn-controller.log': LP1917475_LOG})
+    @utils.create_data_root({'var/log/ovn/ovn-controller.log': LP1917475_LOG},
+                            copy_from_original=['sos_commands/date/date'])
     def test_1917475(self):
         YScenarioChecker()()
         expected = {'bugs-detected':
@@ -426,7 +428,8 @@ class TestOpenvswitchScenarioChecks(TestOpenvswitchBase):
     @utils.create_data_root({'var/log/neutron/neutron-server.log':
                              OVS_DB_RECONNECT_ERROR,
                              'sos_commands/dpkg/dpkg_-l':
-                             'ii  python3-openvswitch 2.17.0 amd64'})
+                             'ii  python3-openvswitch 2.17.0 amd64'},
+                            copy_from_original=['sos_commands/date/date'])
     def test_ovsdb_reconnect_error(self):
         YScenarioChecker()()
         msg = ("Installed package 'python3-openvswitch' with version "

--- a/tests/unit/test_rabbitmq.py
+++ b/tests/unit/test_rabbitmq.py
@@ -155,8 +155,8 @@ class TestRabbitmqScenarioChecks(TestRabbitmqBase):
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('rabbitmq_bugs.yaml'))
-    @utils.create_data_root({'var/log/rabbitmq/rabbit@test.log':
-                             LP_1943937})
+    @utils.create_data_root({'var/log/rabbitmq/rabbit@test.log': LP_1943937},
+                            copy_from_original=['sos_commands/date/date'])
     def test_1943937(self):
         YScenarioChecker()()
         msg = ('Known RabbitMQ issue where queues get stuck and clients '
@@ -195,7 +195,8 @@ class TestRabbitmqScenarioChecks(TestRabbitmqBase):
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('cluster_logchecks.yaml'))
     @utils.create_data_root({'var/log/rabbitmq/rabbit@test.log':
-                             RABBITMQ_LOGS})
+                             RABBITMQ_LOGS},
+                            copy_from_original=['sos_commands/date/date'])
     def test_scenarios_cluster_logchecks(self):
         YScenarioChecker()()
         msg1 = ('Messages were discarded because transient mirrored '

--- a/tests/unit/test_ycheck.py
+++ b/tests/unit/test_ycheck.py
@@ -10,7 +10,7 @@ from . import utils
 from hotsos.core.issues import IssuesManager
 from hotsos.core.issues.utils import IssuesStore
 from hotsos.core.config import setup_config, HotSOSConfig
-from hotsos.core.searchtools import FileSearcher, SearchDef
+from hotsos.core.search import FileSearcher, SearchDef
 from hotsos.core.host_helpers.config import SectionalConfigBase
 from hotsos.core.ycheck import (
     events,


### PR DESCRIPTION
    Adds support for setting search constraints in the
    filesearcher. When a search expression is registered
    it can also have one or more constraints to define
    the limitations or parameters of the search. Currently
    we support a SearchSince constraint which supports
    skipping log file lines that are not on or after a set
    datetime (a delta from the current date). This can also
    be applied globally to all searches. To achieve this
    with minimal impact a binary pre-search is performed on
    the file to seek to a valid start point. This will
    avoid searches on data that is not within a required
    time interval. If valid datetimes cannot be matched in
    the file the constraint is not applied.
