### PR TITLE
[plugin/ceph] Use the total used device size

### DIFF
--- a/defs/scenarios/storage/ceph/ceph-mon/bluefs_size.yaml
+++ b/defs/scenarios/storage/ceph/ceph-mon/bluefs_size.yaml
@@ -11,11 +11,11 @@ conclusions:
       type: CephTrackerBug
       bug-id: 45903
       message: >-
-        Found {num_bad_meta_osds} Ceph OSDs with metadata usage > {limit_percent}% of its
-        total device usage. This could be the result of a compaction failure. Possibly related
+        Found OSDs {bad_meta_osds} with metadata usage > {limit_percent}% of its total
+        device usage. This could be the result of a compaction failure. Possibly related
         to the bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually
         compact the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
       format-dict:
-        num_bad_meta_osds: '@checks.bluefs_osds_have_oversize_metadata.requires.value_actual:len'
+        bad_meta_osds: '@checks.bluefs_osds_have_oversize_metadata.requires.value_actual:comma_join'
         limit_percent: hotsos.core.plugins.storage.ceph.CephCluster.OSD_META_LIMIT_PERCENT
 

--- a/defs/scenarios/storage/ceph/ceph-mon/bluefs_size.yaml
+++ b/defs/scenarios/storage/ceph/ceph-mon/bluefs_size.yaml
@@ -11,8 +11,8 @@ conclusions:
       type: CephTrackerBug
       bug-id: 45903
       message: >-
-        Found {num_bad_meta_osds} Ceph OSDs with metadata size > {limit_percent}% of its
-        device size. This could be the result of a compaction failure. Possibly related
+        Found {num_bad_meta_osds} Ceph OSDs with metadata usage > {limit_percent}% of its
+        total device usage. This could be the result of a compaction failure. Possibly related
         to the bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually
         compact the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
       format-dict:

--- a/examples/hotsos-example-storage.short.summary.yaml
+++ b/examples/hotsos-example-storage.short.summary.yaml
@@ -10,9 +10,9 @@ potential-issues:
         (origin=storage.auto_scenario_check)
 bugs-detected:
   storage:
-    - desc: Found 3 Ceph OSDs with metadata usage > 5% of its total device usage.
-        This could be the result of a compaction failure. Possibly related to the
-        bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually compact
-        the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
+    - desc: Found OSDs osd.0, osd.1, osd.2 with metadata usage > 5% of its total device
+        usage. This could be the result of a compaction failure. Possibly related
+        to the bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually
+        compact the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
       id: https://tracker.ceph.com/issues/45903
       origin: storage.auto_scenario_check

--- a/examples/hotsos-example-storage.short.summary.yaml
+++ b/examples/hotsos-example-storage.short.summary.yaml
@@ -8,3 +8,11 @@ potential-issues:
     CephWarnings:
       - Ceph cluster is in 'HEALTH_WARN' state. Please check 'ceph status' for details.
         (origin=storage.auto_scenario_check)
+bugs-detected:
+  storage:
+    - desc: Found 3 Ceph OSDs with metadata usage > 5% of its total device usage.
+        This could be the result of a compaction failure. Possibly related to the
+        bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually compact
+        the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
+      id: https://tracker.ceph.com/issues/45903
+      origin: storage.auto_scenario_check

--- a/examples/hotsos-example-storage.summary.yaml
+++ b/examples/hotsos-example-storage.summary.yaml
@@ -103,6 +103,13 @@ storage:
           - glance (2)
           - cinder-ceph (3)
           - nova (4)
+  bugs-detected:
+    - desc: Found 3 Ceph OSDs with metadata usage > 5% of its total device usage.
+        This could be the result of a compaction failure. Possibly related to the
+        bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually compact
+        the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
+      id: https://tracker.ceph.com/issues/45903
+      origin: storage.auto_scenario_check
   potential-issues:
     CephWarnings:
       - Ceph cluster is in 'HEALTH_WARN' state. Please check 'ceph status' for details.

--- a/examples/hotsos-example-storage.summary.yaml
+++ b/examples/hotsos-example-storage.summary.yaml
@@ -104,10 +104,10 @@ storage:
           - cinder-ceph (3)
           - nova (4)
   bugs-detected:
-    - desc: Found 3 Ceph OSDs with metadata usage > 5% of its total device usage.
-        This could be the result of a compaction failure. Possibly related to the
-        bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually compact
-        the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
+    - desc: Found OSDs osd.0, osd.1, osd.2 with metadata usage > 5% of its total device
+        usage. This could be the result of a compaction failure. Possibly related
+        to the bug https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. To manually
+        compact the metadata, use 'ceph-bluestore-tool' which is available since 14.2.0.
       id: https://tracker.ceph.com/issues/45903
       origin: storage.auto_scenario_check
   potential-issues:

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -512,7 +512,7 @@ class CephCluster(object):
                 if meta_kb > (self.OSD_META_LIMIT_PERCENT / 100.0 * total_kb):
                     _bad_meta_osds.append(device['name'])
 
-        return _bad_meta_osds
+        return sorted(_bad_meta_osds)
 
     @staticmethod
     def version_as_a_tuple(ver):

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -508,7 +508,7 @@ class CephCluster(object):
         for device in self.osd_df_tree['nodes']:
             if device['id'] >= 0:
                 meta_kb = device['kb_used_meta']
-                total_kb = device['kb_avail']
+                total_kb = device['kb_used']
                 if meta_kb > (self.OSD_META_LIMIT_PERCENT / 100.0 * total_kb):
                     _bad_meta_osds.append(device['name'])
 

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -724,12 +724,12 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
                 new=utils.is_def_filter('ceph-mon/bluefs_size.yaml'))
     def test_bluefs_size(self):
         YScenarioChecker()()
-        msg = ('Found 3 Ceph OSDs with metadata usage > 5% of its total '
-               'device usage. This could be the result of a compaction '
-               'failure. Possibly related to the bug '
-               'https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. '
-               'To manually compact the metadata, use \'ceph-bluestore-tool\' '
-               'which is available since 14.2.0.')
+        msg = ("Found OSDs osd.0, osd.1, osd.2 with metadata usage > 5% "
+               "of its total device usage. This could be the result of "
+               "a compaction failure. Possibly related to the bug "
+               "https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. "
+               "To manually compact the metadata, use 'ceph-bluestore-tool' "
+               "which is available since 14.2.0.")
 
         issues = list(IssuesManager().load_bugs().values())[0]
         self.assertEqual([issue['desc'] for issue in issues], [msg])

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -720,17 +720,16 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
         issues = list(IssuesManager().load_issues().values())[0]
         self.assertEqual([issue['desc'] for issue in issues], [msg])
 
-    @mock.patch('hotsos.core.plugins.storage.ceph.CephCluster.'
-                'OSD_META_LIMIT_PERCENT', 1)
     @mock.patch('hotsos.core.ycheck.YDefsLoader._is_def',
                 new=utils.is_def_filter('ceph-mon/bluefs_size.yaml'))
     def test_bluefs_size(self):
         YScenarioChecker()()
-        msg = ('Found 3 Ceph OSDs with metadata size > 1% of its device size. '
-               'This could be the result of a compaction failure. Possibly '
-               'related to the bug https://tracker.ceph.com/issues/45903 if '
-               'Ceph < 14.2.17. To manually compact the metadata, '
-               'use \'ceph-bluestore-tool\' which is available since 14.2.0.')
+        msg = ('Found 3 Ceph OSDs with metadata usage > 5% of its total '
+               'device usage. This could be the result of a compaction '
+               'failure. Possibly related to the bug '
+               'https://tracker.ceph.com/issues/45903 if Ceph < 14.2.17. '
+               'To manually compact the metadata, use \'ceph-bluestore-tool\' '
+               'which is available since 14.2.0.')
 
         issues = list(IssuesManager().load_bugs().values())[0]
         self.assertEqual([issue['desc'] for issue in issues], [msg])


### PR DESCRIPTION
The previous commit incorrectly used the total device
size instead of the total used size.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>