### PR TITLE
[plugin/ceph] Fine tune suboptimal PG count warning

### DIFF
--- a/defs/scenarios/storage/ceph/ceph-mon/pg_imbalance.yaml
+++ b/defs/scenarios/storage/ceph/ceph-mon/pg_imbalance.yaml
@@ -9,6 +9,14 @@ checks:
       property:
         path: hotsos.core.plugins.storage.ceph.CephCluster.osds_pgs_suboptimal
         ops: [[length_hint], [gt, 0]]
+  cluster_has_non_empty_pools:
+    requires:
+      property:
+        path: hotsos.core.plugins.storage.ceph.CephCluster.cluster_has_non_empty_pools
+  autoscaler_disabled_for_any_pool:
+    requires:
+      property:
+        path: hotsos.core.plugins.storage.ceph.CephCrushMap.autoscaler_disabled_for_any_pool
 conclusions:
   cluster-osds-with-pgs-above-max:
     decision: cluster_has_osds_with_pgs_above_max
@@ -21,7 +29,11 @@ conclusions:
       format-dict:
         limit: hotsos.core.plugins.storage.ceph.CephCluster.OSD_PG_MAX_LIMIT
   cluster-osds-with-suboptimal-pgs:
-    decision: cluster_has_osds_with_suboptimal_pgs
+    decision:
+      and:
+        - cluster_has_osds_with_suboptimal_pgs
+        - cluster_has_non_empty_pools
+        - autoscaler_disabled_for_any_pool
     raises:
       type: CephCrushWarning
       message: >-

--- a/hotsos/core/host_helpers/cli.py
+++ b/hotsos/core/host_helpers/cli.py
@@ -525,6 +525,17 @@ class CLIHelper(object):
                  FileCmd('sos_commands/ceph_mon/json_output/'
                          'ceph_osd_dump_--format_json-pretty',
                          json_decode=True)],
+            'ceph_df_json_decoded':
+                [BinCmd('ceph df --format json-pretty',
+                        json_decode=True),
+                 # sosreport < 4.2
+                 FileCmd('sos_commands/ceph/json_output/'
+                         'ceph_df_--format_json-pretty',
+                         json_decode=True),
+                 # sosreport >= 4.2
+                 FileCmd('sos_commands/ceph_mon/json_output/'
+                         'ceph_df_--format_json-pretty',
+                         json_decode=True)],
             'ceph_osd_df_tree_json_decoded':
                 [BinCmd('ceph osd df tree --format json-pretty',
                         json_decode=True),

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -768,6 +768,10 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
         self.assertEqual([issue['desc'] for issue in issues], [msg])
 
     @mock.patch('hotsos.core.plugins.storage.ceph.CLIHelper')
+    @mock.patch('hotsos.core.plugins.storage.ceph.CephCrushMap.'
+                'autoscaler_disabled_for_any_pool', True)
+    @mock.patch('hotsos.core.plugins.storage.ceph.CephCluster.'
+                'cluster_has_non_empty_pools', True)
     @mock.patch('hotsos.core.ycheck.YDefsLoader._is_def',
                 new=utils.is_def_filter('ceph-mon/pg_imbalance.yaml'))
     @mock.patch('hotsos.core.host_helpers.systemd.ServiceChecksBase.services',


### PR DESCRIPTION
The suboptimal PGs per PSD warning can at times be false.
A specific case is when a cluster is newly deployed. In
that case, there wouldn't much data, and so, either the
admin hasn't scaled the PGs yet or if the PG autoscaler
is enabled, then it doesn't think PGs need to be scaled
for the current utilisation.

So we now warn on suboptimal PGs if:
  - autoscaler isn't enabled, and
  - *every* pool in the cluster is utilised under 2%

The suboptimal PGs will still be reported in the summary - just the warning won't issued now unless it meets the (above noted) criteria.

Fixes #404.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>