### PR TITLE
[plugin/ceph] Fix laggy PGs check

### DIFF
--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -429,11 +429,11 @@ class CephCluster(object):
             return []
 
         laggy_pgs = []
+        # The states we consider problematic for network related issues
+        laggy_like_states = ['laggy', 'wait']
         for pg in self.pg_dump['pg_map']['pg_stats']:
-            for state in ['laggy', 'wait']:
-                if state in pg['state']:
-                    laggy_pgs.append(pg)
-                    break
+            if any(x in pg['state'].split('+') for x in laggy_like_states):
+                laggy_pgs.append(pg)
 
         return laggy_pgs
 


### PR DESCRIPTION
Laggy PG check incorrectly consider backfill_wait,
snaptrim_wait, etc due to a bug in the check which
we exclude here.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>