### PR TITLE
Fix support for defining search as list of exprs

### DIFF
--- a/hotsos/core/ycheck/engine/properties/search.py
+++ b/hotsos/core/ycheck/engine/properties/search.py
@@ -60,10 +60,15 @@ class YPropertySearchOpt(YPropertyOverrideBase):
     def __bool__(self):
         return bool(self.content)
 
+    @property
+    def expr(self):
+        """ Can be string or list. """
+        return self.content
+
     def __str__(self):
         # should use bool() for passthrough-results
-        invalid = 'passthrough-results'
-        valid = [k for k in self._override_keys() if k != invalid]
+        invalid = ['passthrough-results', 'expr']
+        valid = [k for k in self._override_keys() if k not in invalid]
         if self._override_name not in valid:
             raise Exception("__str__ only valid for {} (not {})".
                             format(','.join(valid),
@@ -204,9 +209,14 @@ class YPropertySearchBase(YPropertyMappedOverrideBase):
     @property
     def search_pattern(self):
         if self.expr:
-            return str(self.expr)
+            return self.expr.expr
 
-        return str(self)
+        # can be supplied as a single string or list of strings
+        patterns = list(self.content.keys())
+        if len(patterns) == 1:
+            return patterns[0]
+        else:
+            return patterns
 
     @property
     def is_sequence_search(self):

--- a/tests/unit/test_ycheck.py
+++ b/tests/unit/test_ycheck.py
@@ -336,6 +336,36 @@ myplugin:
 """  # noqa
 
 
+SCENARIO_W_EXPR_LIST = r"""
+input:
+  path: {path}
+checks:
+  listsearch1:
+    expr: ['hello y', 'hello x']
+  listsearch2:
+    search: ['hello y', 'hello x']
+  listsearch3:
+    search:
+       expr: ['hello y', 'hello x']
+conclusions:
+  listsearch1worked:
+    decision: listsearch1
+    raises:
+      type: SystemWarning
+      message: yay list search
+  listsearch2worked:
+    decision: listsearch2
+    raises:
+      type: SystemWarning
+      message: yay list search
+  listsearch3worked:
+    decision: listsearch3
+    raises:
+      type: SystemWarning
+      message: yay list search
+"""  # noqa
+
+
 SCENARIO_W_ERROR = r"""
 scenarioA:
   checks:
@@ -623,6 +653,21 @@ class TestYamlChecks(utils.BaseTestCase):
                          ['my-sequence-search',
                           'my-passthrough-search',
                           'my-pass-search'])
+
+    @init_test_scenario(SCENARIO_W_EXPR_LIST.
+                        format(path=os.path.basename('data.txt')))
+    @utils.create_test_files({'data.txt': 'hello x\n'})
+    def test_yaml_def_expr_list(self):
+        scenarios.YScenarioChecker()()
+        issues = list(IssuesStore().load().values())
+        self.assertEqual(len(issues[0]), 3)
+        i_types = [i['type'] for i in issues[0]]
+        self.assertEqual(sorted(i_types),
+                         sorted(['SystemWarning', 'SystemWarning',
+                                 'SystemWarning']))
+        for issue in issues[0]:
+            msg = ("yay list search")
+            self.assertEqual(issue['desc'], msg)
 
     @mock.patch('hotsos.core.ycheck.engine.properties.requires.types.apt.'
                 'APTPackageChecksBase')


### PR DESCRIPTION
The search property supports different ways of defining a search
expression which can be provided as a string or list of strings.
The latter form was no longer working so this patch fixes that.