### PR TITLE
Add a --force option

### DIFF
--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -109,6 +109,15 @@ def main():
                         'grouped by date. This option will result in '
                         'grouping by date and time which may be more useful '
                         'for cross-referencing with other logs.'))
+    @click.option('--force', default=False, is_flag=True,
+                  help=('By default plugins will only run if their '
+                        'pre-requisites are met (i.e. they are "runnable").'
+                        'It might sometimes be the case that not all '
+                        'pre-requisites are available but we still want to '
+                        'try running plugins. An example would be where an '
+                        "application is not installed but we have it's logs. "
+                        'Using this option can obviously produce '
+                        'unexpected results so should be used with caution.'))
     @click.option('--full', default=False, is_flag=True,
                   help=('[DEPRECATED] This is the default and tells hotsos to '
                         'generate a full summary. If you want to save both a '
@@ -153,7 +162,7 @@ def main():
     @click.argument('data_root', required=False, type=click.Path(exists=True))
     def cli(data_root, version, defs_path, all_logs, quiet, debug, save,
             format, html_escape, user_summary, short, very_short,
-            full, agent_error_key_by_time, max_logrotate_depth,
+            force, full, agent_error_key_by_time, max_logrotate_depth,
             max_parallel_tasks, list_plugins, machine_readable, output_path,
             **kwargs):
         """
@@ -189,6 +198,7 @@ def main():
         elif very_short:
             minimal_mode = 'very-short'
 
+        setup_config(FORCE_MODE=force)
         repo_info = get_repo_info()
         if repo_info:
             setup_config(REPO_INFO=repo_info)

--- a/hotsos/client.py
+++ b/hotsos/client.py
@@ -53,8 +53,12 @@ class HotSOSSummary(plugintools.PluginPartBase):
 
     @property
     def summary(self):
-        return {'version': HotSOSConfig.HOTSOS_VERSION,
-                'repo-info': HotSOSConfig.REPO_INFO}
+        out = {'version': HotSOSConfig.HOTSOS_VERSION,
+               'repo-info': HotSOSConfig.REPO_INFO}
+        if HotSOSConfig.FORCE_MODE:
+            out['force'] = True
+
+        return out
 
 
 # Ensure that plugins are always run in this order so as to get consistent

--- a/hotsos/core/plugintools.py
+++ b/hotsos/core/plugintools.py
@@ -259,7 +259,7 @@ class PluginRunner(object):
             for cls in part_info['objects']:
                 inst = cls()
                 # Only run plugin if it declares itself runnable.
-                if not inst.plugin_runnable:
+                if not HotSOSConfig.FORCE_MODE and not inst.plugin_runnable:
                     log.debug("%s.%s.%s not runnable - skipping",
                               HotSOSConfig.PLUGIN_NAME, name, cls.__name__)
                     continue

--- a/hotsos/core/ycheck/events.py
+++ b/hotsos/core/ycheck/events.py
@@ -1,4 +1,5 @@
 from hotsos.core.log import log
+from hotsos.core.config import HotSOSConfig
 from hotsos.core.utils import sorted_dict
 from hotsos.core.ycheck.engine import (
     YDefsLoader,
@@ -212,7 +213,8 @@ class YEventCheckerBase(YHandlerBase, EventProcessingUtils):
                   len(group.leaf_sections))
 
         for event in group.leaf_sections:
-            if event.requires and not event.requires.passes:
+            if (not HotSOSConfig.FORCE_MODE and event.requires and not
+                    event.requires.passes):
                 log.error("event '%s' pre-requisites not met - "
                           "skipping", event.name)
                 return

--- a/hotsos/core/ycheck/scenarios.py
+++ b/hotsos/core/ycheck/scenarios.py
@@ -36,7 +36,8 @@ class YScenarioChecker(YHandlerBase):
             return
 
         yscenarios = YDefsSection(HotSOSConfig.PLUGIN_NAME, plugin_content)
-        if yscenarios.requires and not yscenarios.requires.passes:
+        if (not HotSOSConfig.FORCE_MODE and yscenarios.requires and not
+                yscenarios.requires.passes):
             log.debug("plugin '%s' scenarios pre-requisites not met - "
                       "skipping", HotSOSConfig.PLUGIN_NAME)
             return


### PR DESCRIPTION
This supports forcing plugins to run and ignore any pre-requisites. This can be useful if e.g. we have an application's logs but it appears not to be installed. Should be used with caution since will likely produce unexpected results.