### PR TITLE
Qla2xxx skipping scsi scan host

### DIFF
--- a/defs/scenarios/kernel/qla2xxx.yaml
+++ b/defs/scenarios/kernel/qla2xxx.yaml
@@ -1,0 +1,15 @@
+checks:
+  qla2xxx_skipping_scsi_scan_host:
+    input:
+      path: 'var/log/kern.log'
+    expr: '.+ qla2xxx (\S+): skipping scsi_scan_host\(\) for non-initiator port'
+conclusions:
+  qla2xxx_skipped_scsi_scan_host:
+    decision: qla2xxx_skipping_scsi_scan_host
+    raises:
+      type: KernelWarning
+      message: >-
+        The qla2xxx driver did not perform SCSI scan on host/port {}.
+        Some SCSI disks/paths might not be present. (Module option
+        'qla2xxx.qlini_mode')
+      search-result-format-groups: [1]

--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -40,6 +40,10 @@ class KernelError(IssueTypeBase):
     pass
 
 
+class KernelWarning(IssueTypeBase):
+    pass
+
+
 class MemoryWarning(IssueTypeBase):
     pass
 


### PR DESCRIPTION
After linux kernel commit (currently in scsi-staging [1])
`scsi: qla2xxx: Log message "skipping scsi_scan_host()" as informational`

makes it to distro kernels, we can check whether systems didn't perform
SCSI scan (e.g., `qla2xxx` driver configured in target-only/non-initiator
mode), which is not currently used in Canonical deployments (no storage
with Fibre Channel SCSI Targets) and was actually a support ticket, due
to a forgotten config file/option).

With the following in `/var/log/kern.log`:
```
Sep 12 19:01:31 mfo-t470 kernel: [649534.924685] qla2xxx [0000:04:00.0]-0122:1: skipping scsi_scan_host() for non-initiator port
Sep 12 19:01:31 mfo-t470 kernel: [649535.132764] qla2xxx [0000:04:00.1]-0122:10: skipping scsi_scan_host() for non-initiator port
```

Test:
```
mfo@mfo-t470:~/git/hotsos$ ./scripts/hotsos --kernel
...
kernel:
...
  potential-issues:
    KernelWarnings:
      - The qla2xxx driver did not perform SCSI scan on host/port [0000:04:00.0]-0122:1.
        Some SCSI disks/paths might not be present. (Module option 'qla2xxx.qlini_mode')
        (origin=kernel.auto_scenario_check)
...
```

[1] https://git.kernel.org/pub/scm/linux/kernel/git/mkp/scsi.git/commit/?h=6.1/scsi-staging&id=eee8bb4a2b58212843aec92dd6c8c1cc193209e0