### PR TITLE
Switch to new shared-memory plug for /dev/shm

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,6 @@ environment:
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
   PYTHONPATH: $SNAP/lib/python3.8/site-packages
-  LD_PRELOAD: $SNAP/libpreload-semaphores.so
 
 # dpkg won't work without this
 layout:
@@ -63,7 +62,7 @@ parts:
         - -lib/systemd/system/cryptdisks.service
     stage:
       - $exclude-systemd-files
-  sem-open-preload:
-    source: https://github.com/snapcore/snapcraft-preloads.git
-    source-subdir: semaphores
-    plugin: make
+
+plugs:
+  shared-memory:
+    private: true


### PR DESCRIPTION
Python multiprocessing requires access to files in /dev/shm to work.

Previously snapd only allowed access to /dev/shm files prefixed with the snap name which most applications don't support natively so a snapcraft-preloads LD_PRELOAD hack was used to override and re-write the path being used.

This is now replaced in snapd by a new shared-memory plug that uses a private /dev/shm directory for each snap. This is less clunky and also removes one of the problems for arm64 snaps that were built on amd64 as the LD_PRELOAD was architecture specific. Although we should continue to build arm64 snaps on arm64 using snapcraft remote/hosted builds as per the snapcraft docs.