### PR TITLE
[ceph] only check mon elections min 1 hour after boot

### DIFF
--- a/defs/README.md
+++ b/defs/README.md
@@ -524,6 +524,10 @@ CONSTRAINTS:
     Minimum number of search results required. If a search period is
     defined, these must occur within that period. Default is 1.
 
+  min-hours-since-last-boot: <int>
+    Search result must be at least this number of hours after the last
+    boot time.
+
 CACHE_KEYS
   simple_search
   sequence_search

--- a/defs/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
+++ b/defs/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
@@ -9,6 +9,7 @@ checks:
         min-results: 5
         search-period-hours: 24
         search-result-age-hours: 48
+        min-hours-since-last-boot: 1
   ceph_interfaces_have_errors:
     requires:
       property: hotsos.core.plugins.storage.ceph.CephChecksBase.has_interface_errors

--- a/hotsos/core/host_helpers/__init__.py
+++ b/hotsos/core/host_helpers/__init__.py
@@ -21,3 +21,6 @@ from .systemd import (  # noqa: F403,F401
     SystemdHelper,
     SVC_EXPR_TEMPLATES,
 )
+from .uptime import (  # noqa: F403,F401
+    UptimeHelper,
+)

--- a/hotsos/core/host_helpers/uptime.py
+++ b/hotsos/core/host_helpers/uptime.py
@@ -1,0 +1,72 @@
+import re
+
+from hotsos.core.log import log
+from hotsos.core.host_helpers import CLIHelper
+from hotsos.core.utils import cached_property
+
+
+class UptimeHelper(object):
+    def __init__(self):
+        # unfortunately sosreports dont have proc/uptime otherwise we would use
+        # that.
+        self.uptime = CLIHelper().uptime() or ""
+        # this needs to take into account the different formats supported by
+        # https://gitlab.com/procps-ng/procps/-/blob/newlib/library/uptime.c
+        etime_expr = r"(?:([\d:]+)|(\d+\s+\S+,\s+[\d:]+)|(\d+\s+\S+)),"
+        expr = r"\s*[\d:]+ up {}.+ load average: (.+)".format(etime_expr)
+        ret = re.compile(expr).match(self.uptime)
+        self.subgroups = {}
+        if ret:
+            self.subgroups['hour'] = {'value': ret.group(1),
+                                      'expr': r'(\d+):(\d+)'}
+            self.subgroups['day'] = {'value': ret.group(2),
+                                     'expr': r"(\d+)\s+\S+,\s+(\d+):(\d+)"}
+            self.subgroups['min'] = {'value': ret.group(3),
+                                     'expr': r"(\d+)\s+(\S+)"}
+            self.subgroups['loadavg'] = {'value': ret.group(4)}
+
+    @cached_property
+    def minutes(self):
+        if not self.subgroups:
+            log.info("uptime not available")
+            return
+
+        if self.subgroups['hour']['value']:
+            expr = self.subgroups['hour']['expr']
+            ret = re.match(expr, self.subgroups['hour']['value'])
+            if ret:
+                return (int(ret.group(1)) * 60) + int(ret.group(2))
+        elif self.subgroups['day']['value']:
+            expr = self.subgroups['day']['expr']
+            ret = re.match(expr, self.subgroups['day']['value'])
+            if ret:
+                count = int(ret.group(1))
+                hours = int(ret.group(2))
+                mins = int(ret.group(3))
+                day_mins = 24 * 60
+                sum = count * day_mins
+                sum += hours * 60
+                sum += mins
+                return sum
+        elif self.subgroups['min']['value']:
+            expr = self.subgroups['min']['expr']
+            ret = re.match(expr, self.subgroups['min']['value'])
+            if ret:
+                return int(ret.group(1))
+
+        log.warning("unknown uptime format in %s", self.uptime)
+
+    @property
+    def seconds(self):
+        if self.minutes:
+            return self.minutes * 60
+
+    @property
+    def hours(self):
+        if self.minutes:
+            return int(self.minutes / 60)
+
+    @property
+    def loadavg(self):
+        if self.subgroups:
+            return self.subgroups['loadavg']['value']

--- a/hotsos/core/plugins/system/system.py
+++ b/hotsos/core/plugins/system/system.py
@@ -170,14 +170,6 @@ class SystemBase(object):
         return 0
 
     @cached_property
-    def loadavg(self):
-        uptime = CLIHelper().uptime()
-        if uptime:
-            ret = re.compile(r".+load average:\s+(.+)").match(uptime)
-            if ret:
-                return ret[1]
-
-    @cached_property
     def unattended_upgrades_enabled(self):
         apt_config_dump = CLIHelper().apt_config_dump()
         if not apt_config_dump:

--- a/hotsos/core/search/constraints.py
+++ b/hotsos/core/search/constraints.py
@@ -389,7 +389,7 @@ class SearchConstraintSearchSince(BinarySeekSearchBase):
         """
         A search expression is provided that allows us to identify a datetime
         on each line and check whether it is within a given time period. The
-        time period used defaults to 24 hours of USE_ALL_LOGS is false, 7 days
+        time period used defaults to 24 hours if USE_ALL_LOGS is false, 7 days
         if it is true and MAX_LOGROTATE_DEPTH is default otherwise whatever
         value provided. This can be overridden by providing a specific number
         of hours.
@@ -400,7 +400,7 @@ class SearchConstraintSearchSince(BinarySeekSearchBase):
         @param hours: override default period with number of hours
         """
         super().__init__()
-        if hours is not None and hours == 0:
+        if hours == 0:
             log.warning("search constraint created with hours=%s", hours)
 
         self.fd_info = None

--- a/hotsos/plugin_extensions/system/summary.py
+++ b/hotsos/plugin_extensions/system/summary.py
@@ -1,7 +1,7 @@
 import re
 
 from hotsos.core.plugintools import summary_entry_offset as idx
-from hotsos.core.host_helpers import CLIHelper
+from hotsos.core.host_helpers import CLIHelper, UptimeHelper
 from hotsos.core.plugins.system import SystemChecksBase
 
 
@@ -23,8 +23,8 @@ class SystemSummary(SystemChecksBase):
 
     @idx(3)
     def __summary_load(self):
-        if self.loadavg:
-            return self.loadavg
+        if UptimeHelper().loadavg:
+            return UptimeHelper().loadavg
 
     @idx(4)
     def __summary_virtualisation(self):

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -495,12 +495,15 @@ class TestStorageScenarioChecksCephMon(StorageCephMonTestsBase):
     @mock.patch('hotsos.core.ycheck.YDefsLoader._is_def',
                 new=utils.is_def_filter(
                                        'ceph-mon/mon_elections_flapping.yaml'))
+    @mock.patch('hotsos.core.ycheck.engine.properties.search.UptimeHelper')
     @mock.patch('hotsos.core.plugins.storage.ceph.CephChecksBase')
     @mock.patch('hotsos.core.host_helpers.systemd.SystemdHelper.services',
                 {'ceph-mon': SystemdService('ceph-mon', 'enabled')})
     @utils.create_data_root({'var/log/ceph/ceph.log': MON_ELECTION_LOGS},
                             copy_from_original=['sos_commands/date/date'])
-    def test_scenario_mon_reelections(self, mock_cephbase):
+    def test_scenario_mon_reelections(self, mock_cephbase, mock_uptime):
+        mock_uptime.return_value = mock.MagicMock()
+        mock_uptime.return_value.hours = 49
         mock_cephbase.return_value = mock.MagicMock()
         mock_cephbase.return_value.plugin_runnable = True
         mock_cephbase.return_value.has_interface_errors = True

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -8,6 +8,8 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core import host_helpers
 from hotsos.core.host_helpers.filestat import FileFactory
 
+UPTIME_LONG_FORMAT = ' 14:51:10 up 1 day,  6:27,  1 user,  load average: 0.55, 0.73, 0.70'  # noqa, pylint: disable=C0301
+
 
 class TestHostNetworkingHelper(utils.BaseTestCase):
 
@@ -155,3 +157,19 @@ class TestFileStatHelper(utils.BaseTestCase):
 
         fileobj = FileFactory().noexist
         self.assertEqual(fileobj.mtime, 0)
+
+
+class TestUptimeHelper(utils.BaseTestCase):
+
+    def test_loadavg(self):
+        self.assertEqual(host_helpers.UptimeHelper().loadavg,
+                         "3.58, 3.27, 2.58")
+
+    def test_uptime(self):
+        self.assertEqual(host_helpers.UptimeHelper().seconds, 63660)
+        self.assertEqual(host_helpers.UptimeHelper().hours, 17)
+
+    @utils.create_data_root({'uptime': UPTIME_LONG_FORMAT})
+    def test_uptime_alt_format(self):
+        self.assertEqual(host_helpers.UptimeHelper().seconds, 109620)
+        self.assertEqual(host_helpers.UptimeHelper().hours, 30)


### PR DESCRIPTION
We expect some re-elections are a boot/reboot especially when a cluster is first deployed so ignore the first hour after a boot.

Resolves: #433