### PR TITLE
Support date with numeric TZ

### DIFF
--- a/hotsos/core/host_helpers/cli.py
+++ b/hotsos/core/host_helpers/cli.py
@@ -4,7 +4,6 @@ import json
 import os
 import re
 import subprocess
-import sys
 import tempfile
 
 from hotsos.core.log import log
@@ -381,16 +380,17 @@ class DateFileCmd(FileCmd):
         if not no_format and format is None:
             format = '+%s'
 
-        # if date string contains timezone string we need to remove it
-        ret = re.match(r"^(\S+ \S*\s*[0-9]+ [0-9:]+ )[A-Z]*\s*([0-9]+)$",
+        ret = re.match(r"^(\S+ \S*\s*[0-9]+ [0-9:]+)\s*"
+                       r"([A-Z]*|[+-]?[0-9]*)?"
+                       r"\s*([0-9]+)$",
                        output)
 
         if ret is None:
-            sys.stderr.write("ERROR: {} has invalid date string '{}'\n".
-                             format(self.path, output))
+            log.error("%s has invalid date string '%s'", self.path, output)
             return ""
 
-        date = "{}{}".format(ret[1], ret[2])
+        # Include tz if available and then convert to utc
+        date = "{} {} {}".format(ret[1], ret[2], ret[3])
         cmd = ["date", "--utc", "--date={}".format(date)]
         if format:
             cmd.append(format)

--- a/tests/unit/test_clihelpers.py
+++ b/tests/unit/test_clihelpers.py
@@ -50,6 +50,18 @@ class TestCLIHelpers(utils.BaseTestCase):
         self.assertEqual(self.helper.date(), '1644509957')
 
     @utils.create_data_root({'sos_commands/date/date':
+                             'Thu Mar 25 10:55:05 2021'})
+    def test_get_date_no_tz(self):
+        helper = cli.CLIHelper()
+        self.assertEqual(helper.date(), '1616669705')
+
+    @utils.create_data_root({'sos_commands/date/date':
+                             'Thu Mar 25 10:55:05 -03 2021'})
+    def test_get_date_w_numeric_tz(self):
+        helper = cli.CLIHelper()
+        self.assertEqual(helper.date(), '1616680505')
+
+    @utils.create_data_root({'sos_commands/date/date':
                              'Thu Mar 25 10:55:05 UTC 2021'})
     def test_get_date_w_tz(self):
         helper = cli.CLIHelper()


### PR DESCRIPTION
The linux date command can specify a timezone
using a string or numeric offset. This ensures
we also support the latter. Also ensures that
original tz is included with --date input to
ensure correct conversion.

Resolves: #240