### PR TITLE
Support helper factory objects with no attribute

### DIFF
--- a/defs/README.md
+++ b/defs/README.md
@@ -96,25 +96,28 @@ normally be imported as follows:
 
 ```
 from mymod import myclass
-val = myclass.myprop
+obj = myclass.myprop
+val = obj.myattr
 ```
 
 A factory is used as follows:
 
 ```
 from mymod import myfactoryclass
-val = myfactoryclass.inputval.myprop
+val = myfactoryclass.inattr.fattr
 ```
 
-Which would result in a new object created using *inputval* as input and then
-*myprop* is called on that object.
+Which would result in a new object created using *inattr* as input and then
+*fattr* is called on that object.
 
 This allows us to define a property for import in [vars](#vars) as follows:
 
 ```
-val: '@mymod.myfactoryclass.myprop:inputval'
+val: '@mymod.myfactoryclass.fattr:inattr'
 ```
 
+One benefit of this being that *inattr* can be a string containing any
+characters incl. ones that would not be valid in a property name.
 
 #### MappedProperties
 

--- a/hotsos/core/host_helpers/common.py
+++ b/hotsos/core/host_helpers/common.py
@@ -51,6 +51,13 @@ class HostHelpersBase(abc.ABC):
 
 
 class HostHelperFactoryBase(abc.ABC):
+    """
+    Provide a common way to implement factory objects for host helpers.
+
+    The basic idea is that implementations of this class are instantiated and
+    then content is generated using attrs as input. This provides a way e.g. to
+    defer operations on a set of data that need only be retrieved once.
+    """
 
     @abc.abstractmethod
     def __getattr__(self, name):

--- a/hotsos/core/ycheck/engine/properties/vars.py
+++ b/hotsos/core/ycheck/engine/properties/vars.py
@@ -41,6 +41,7 @@ class YPropertyVarDef(YPropertyMappedOverrideBase):
         """
         val = self.raw_value
         if self._is_import_path(val):
+            # NOTE: this path can be a property or a factory.
             val = self.get_property(val[1:])
 
         return val

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -177,11 +177,11 @@ class TestUptimeHelper(utils.BaseTestCase):
 
 class TestSysctlHelper(utils.BaseTestCase):
 
-    def test_systctlhelper(self):
-        self.assertEqual(getattr(host_helpers.SYSCtlFactory().net,
-                                 'core.somaxconn'), '4096')
+    def test_sysctlhelper(self):
+        self.assertEqual(getattr(host_helpers.SYSCtlFactory(),
+                                 'net.core.somaxconn'), '4096')
 
-    def test_systctlconfhelper(self):
+    def test_sysctlconfhelper(self):
         path = os.path.join(HotSOSConfig.DATA_ROOT, 'etc/sysctl.d')
         path = os.path.join(path, '50-nova-compute.conf')
         sysctl = host_helpers.SYSCtlConfHelper(path)

--- a/tests/unit/test_ycheck.py
+++ b/tests/unit/test_ycheck.py
@@ -542,7 +542,7 @@ vars:
   fromprop: '@tests.unit.test_ycheck.TestProperty.myattr'
   fromfact: '@hotsos.core.host_helpers.systemd.ServiceFactory.start_time_secs:snapd'
   fromfact2: '@hotsos.core.host_helpers.filestat.FileFactory.mtime:myfile.txt'
-  fromsysctl: '@hotsos.core.host_helpers.sysctl.SYSCtlFactory.somaxconn:net.core'
+  fromsysctl: '@hotsos.core.host_helpers.sysctl.SYSCtlFactory:net.core.somaxconn'
   boolvar: false
 checks:
   aptcheck:
@@ -598,7 +598,7 @@ conclusions:
         varval: '@checks.isbar.requires.value'
   fromprop:
     decision:
-      or: [fromprop, boolvar, fromfact, fromfact2, fromsysctl]
+      and: [fromprop, boolvar, fromfact, fromfact2, fromsysctl]
     raises:
       type: SystemWarning
       message: fromprop! ({varname}={varval})


### PR DESCRIPTION
The current implementation of factory objects assumes that an attribute will be called on the generated object but this is not always desired so now we all generating an object that will not have an attr called on it. This allows us to simpligy the sysctl helper factory which is applied here.

Also cleans up the factory docs entry.