### PR TITLE
Add scenario checks for TCP and UDP mempages usage

### DIFF
--- a/defs/scenarios/kernel/network/tcp.yaml
+++ b/defs/scenarios/kernel/network/tcp.yaml
@@ -22,6 +22,9 @@ vars:
   rcvqd_pcent: '@hotsos.core.plugins.kernel.net.NetStatTCP.TCPRcvQDropPcentInSegs'
   rqfulld: '@hotsos.core.plugins.kernel.net.NetStatTCP.TCPReqQFullDrop'
   rqfullcook: '@hotsos.core.plugins.kernel.net.NetStatTCP.TCPReqQFullDoCookies'
+  memusage_pages_inuse: '@hotsos.core.plugins.kernel.net.SockStat.GlobTcpSocksTotalMemPages'
+  memusage_pages_max: '@hotsos.core.plugins.kernel.net.SockStat.SysctlTcpMemMax'
+  memusage_pct: '@hotsos.core.plugins.kernel.net.SockStat.TCPMemUsagePct'
 checks:
   incsumerr_high:
     or:
@@ -59,6 +62,10 @@ checks:
     varops: [[$rqfulld], [gt, 500]]
   rqfullcook:
     varops: [[$rqfullcook], [gt, 500]]
+  memusage_pct_high:
+    varops: [[$memusage_pct], [gt, 85]]
+  memusage_pct_exhausted:
+    varops: [[$memusage_pct], [ge, 100]]
 conclusions:
   # retransmissions
   incsumerr_high:
@@ -189,4 +196,28 @@ conclusions:
       format-dict:
         num: $spurrtx
         pcent: $spurrtx_pcent
+  memusage_pct_high:
+    decision:
+      - memusage_pct_high
+      - not: memusage_pct_exhausted
+    raises:
+      type: KernelWarning
+      message: >-
+        TCP memory page usage is high ({pct}%), ({pa} out of {pm} mem pages are in use).
+        Kernel will start to drop TCP frames if all pages are exhausted.
+      format-dict:
+        pa: $memusage_pages_inuse
+        pm: $memusage_pages_max
+        pct: $memusage_pct
+  memusage_pct_exhausted:
+    decision: memusage_pct_exhausted
+    raises:
+      type: KernelWarning
+      message: >-
+        All TCP memory pages are exhausted! ({pa} out of {pm} mem pages are in use).
+        Kernel will drop TCP packets, expect packet losses on ALL TCP transport!
+      format-dict:
+        pa: $memusage_pages_inuse
+        pm: $memusage_pages_max
+        pct: $memusage_pct
 

--- a/defs/scenarios/kernel/network/udp.yaml
+++ b/defs/scenarios/kernel/network/udp.yaml
@@ -7,6 +7,9 @@ vars:
   sndbuferrors_pcent: '@hotsos.core.plugins.kernel.net.SNMPUdp.SndbufErrorsPcentOutDatagrams'
   incsumerrors: '@hotsos.core.plugins.kernel.net.SNMPUdp.InCsumErrors'
   incsumerrors_pcent: '@hotsos.core.plugins.kernel.net.SNMPUdp.InCsumErrorsPcentInDatagrams'
+  memusage_pages_inuse: '@hotsos.core.plugins.kernel.net.SockStat.GlobUdpSocksTotalMemPages'
+  memusage_pages_max: '@hotsos.core.plugins.kernel.net.SockStat.SysctlUdpMemMax'
+  memusage_pct: '@hotsos.core.plugins.kernel.net.SockStat.UDPMemUsagePct'
 checks:
   rcvbuferrors_high:
     or:
@@ -24,6 +27,10 @@ checks:
     or:
       - varops: [[$incsumerrors], [gt, 500]]
       - varops: [[$incsumerrors_pcent], [gt, 1]]
+  memusage_pct_high:
+    varops: [[$memusage_pct], [gt, 85]]
+  memusage_pct_exhausted:
+    varops: [[$memusage_pct], [ge, 100]]
 conclusions:
   inerrs_high_pcent_or_above_limit:
     decision: inerrs_high_pcent_or_above_limit
@@ -62,4 +69,28 @@ conclusions:
       format-dict:
         count: $sndbuferrors
         pcent: $sndbuferrors_pcent
+  memusage_pct_high:
+    decision:
+      - memusage_pct_high
+      - not: memusage_pct_exhausted
+    raises:
+      type: KernelWarning
+      message: >-
+        UDP memory page usage is high ({pct}%), ({pa} out of {pm} mem pages are in use).
+        Kernel will start to drop UDP frames if all pages are exhausted.
+      format-dict:
+        pa: $memusage_pages_inuse
+        pm: $memusage_pages_max
+        pct: $memusage_pct
+  memusage_pct_exhausted:
+    decision: memusage_pct_exhausted
+    raises:
+      type: KernelWarning
+      message: >-
+        All UDP memory pages are exhausted! ({pa} out of {pm} mem pages are in use).
+        Kernel will drop UDP packets, expect packet losses on ALL UDP transport!
+      format-dict:
+        pa: $memusage_pages_inuse
+        pm: $memusage_pages_max
+        pct: $memusage_pct
 

--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -41,7 +41,7 @@ class SystemdService(object):
                 last = ret.group(1)
 
         if last:
-            return datetime.strptime(last, "%Y-%m-%dT%H:%M:%S+%f")
+            return datetime.strptime(last, "%Y-%m-%dT%H:%M:%S%z")
         else:
             log.debug("no start time identified for svc %s", self.name)
 


### PR DESCRIPTION
This MP introduces new TCP/UDP scenario warnings for high mempages usage. Also, fixes a small bug in systemd start_time parsing. 

Resolves: #445 