### PR TITLE
Build snap in GitHub CI

### DIFF
--- a/.github/workflows/snapfunctionaltest.yaml
+++ b/.github/workflows/snapfunctionaltest.yaml
@@ -1,0 +1,20 @@
+name: Build snap
+on:
+  - push
+  - pull_request
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: snapcore/action-build@v1
+        id: snapcraft
+      - name: Run snap
+        run: |
+          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
+          hotsos
+      - uses: actions/upload-artifact@v3
+        with:
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}


### PR DESCRIPTION
This change builds and stores the snap on amd64 and offers the snap as a build
artifact for download and testing.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>