### PR TITLE
Ensure keystone exceptions are identified

### DIFF
--- a/hotsos/core/plugins/openstack/openstack.py
+++ b/hotsos/core/plugins/openstack/openstack.py
@@ -244,7 +244,7 @@ class OSTProject(object):
                 path = os.path.join(HotSOSConfig.DATA_ROOT, 'etc', name, path)
                 self.config[label] = OpenstackConfig(path)
 
-        self.systemd_extra_services = systemd_extra_services
+        self.systemd_extra_services = systemd_extra_services or []
         self.systemd_masked_services = systemd_masked_services or []
         self.systemd_deprecated_services = systemd_deprecated_services or []
         self.logs_path = os.path.join('var/log', name)


### PR DESCRIPTION
Fixes the agent exceptions extension to ensure that exceptions in keystone logs are identified. Also
ensure that extra regex used for keystone and apache services are only added when searching logs from
those servies.

Resolves: #477