### PR TITLE
Add `tox` environment for `mypy`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,6 +37,9 @@ jobs:
     - name: Run bashate
       run: tox -e bashate
       if: matrix.python-version == '3.10'
+    - name: Run static type checking
+      run: tox -e mypy
+      if: matrix.python-version == '3.10'
     - name: Run functional
       run: tox -e functional
       if: matrix.python-version == '3.10'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,8 @@
 bashate
 flake8
 mock
-stestr
+mypy
 pylint==2.8.3
 rpdb
+stestr
 testtools

--- a/tox.ini
+++ b/tox.ini
@@ -32,3 +32,6 @@ commands = bashate --verbose {toxinidir}/build.sh {toxinidir}/tools/test/functes
 
 [testenv:functional]
 commands = {toxinidir}/tools/test/functest.sh
+
+[testenv:mypy]
+commands = -mypy --install-types --non-interactive hotsos


### PR DESCRIPTION
[Mypy](http://mypy-lang.org/) is a static type checker for Python.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
