### PR TITLE
Check for ovs client stable db warnings

### DIFF
--- a/defs/scenarios/openstack/neutron/ovn_stale_db.yaml
+++ b/defs/scenarios/openstack/neutron/ovn_stale_db.yaml
@@ -1,0 +1,58 @@
+vars:
+  msg_common: >-
+    is reporting frequent reconnections to the ovn
+    southbound database due to "stale data" and this may require taking
+    action to resolve. One cause is if you have recently rebuilt your
+    southbound database. See the linked bug for more information. One
+    suggested workaround is to
+checks:
+  is_neutron_server:
+    apt: neutron-server
+  is_neutron_ovn_metadata_agent:
+    apt: neutron-ovn-metadata-agent
+  has_1829109_neutron_log:
+    input:
+      - var/log/neutron/neutron-server.log
+      - var/log/neutron/neutron-ovn-metadata-agent.log
+    expr: '(\S+\s+[\d:]+).\S+ .+ ovsdbapp.backend.ovs_idl.vlog \[-\] ssl:\S+:16642: clustered database server has stale data; trying another server'
+    constraints:
+      search-result-age-hours: 6
+  has_1829109_ovn_controller_log:
+    input: var/log/ovn/ovn-controller.log
+    expr: '([0-9-]+)T([0-9:\.]+)Z.+\|ovsdb_idl\|WARN\|tcp:\S+:6642: clustered database server has stale data; trying another server'
+    constraints:
+      search-result-age-hours: 6
+conclusions:
+  has_1960319_neutron_server:
+    decision:
+      - is_neutron_server
+      - has_1829109_neutron_log
+    raises:
+      type: Bugzilla
+      bug-id: 1829109
+      message: >-
+        neutron ovsdbapp {msg_common} restart neutron-server.
+      format-dict:
+        msg_common: $msg_common
+  has_1960319_neutron_ovn_metadata:
+    decision:
+      - is_neutron_ovn_metadata_agent
+      - has_1829109_neutron_log
+    raises:
+      type: Bugzilla
+      bug-id: 1829109
+      message: >-
+        neutron ovsdbapp {msg_common} restart neutron-ovn-metadata-agent.
+      format-dict:
+        msg_common: $msg_common
+  has_1960319_ovn_controller:
+    decision: has_1829109_ovn_controller_log
+    raises:
+      type: Bugzilla
+      bug-id: 1829109
+      message: >-
+        ovn-controller {msg_common} run 'ovn-appctl -t ovn-controller
+        sb-cluster-state-reset'.
+      format-dict:
+        msg_common: $msg_common
+

--- a/defs/tests/scenarios/openstack/neutron/ovn_stale_db_neutron_ovn_metadata.yaml
+++ b/defs/tests/scenarios/openstack/neutron/ovn_stale_db_neutron_ovn_metadata.yaml
@@ -1,0 +1,25 @@
+target-name: ovn_stale_db.yaml
+data-root:
+  files:
+    var/log/neutron/neutron-ovn-metadata-agent.log: |
+      2022-02-10 12:52:24.652 317561 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.20:16642: connected
+      2022-02-10 12:52:24.696 317561 WARNING ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.20:16642: clustered database server has stale data; trying another server
+      2022-02-10 12:52:24.698 317561 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.20:16642: connection closed by client
+      2022-02-10 12:52:24.819 317559 INFO ovsdbapp.backend.ovs_idl.vlog [req-6a330106-9631-45d2-8449-194dac0adbf3 - - - - -] ssl:10.5.3.204:16642: connected
+      2022-02-10 12:52:24.863 317559 WARNING ovsdbapp.backend.ovs_idl.vlog [req-6a330106-9631-45d2-8449-194dac0adbf3 - - - - -] ssl:10.5.3.204:16642: clustered database server has stale data; trying another server
+      2022-02-10 12:52:24.865 317559 INFO ovsdbapp.backend.ovs_idl.vlog [req-6a330106-9631-45d2-8449-194dac0adbf3 - - - - -] ssl:10.5.3.204:16642: connection closed by client
+      2022-02-10 12:52:26.269 317562 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.204:16642: connected
+      2022-02-10 12:52:26.310 317562 WARNING ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.204:16642: clustered database server has stale data; trying another server
+      2022-02-10 12:52:26.311 317562 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.204:16642: connection closed by client
+    sos_commands/dpkg/dpkg_-l: |
+      ii  neutron-ovn-metadata-agent           2:16.4.2-0ubuntu4                                    all          Neutron is a virtual network service for Openstack - OVN metadata agent
+  copy-from-original:
+    - uptime
+    - sos_commands/date/date
+raised-bugs:
+  https://bugzilla.redhat.com/show_bug.cgi?id=1829109: >-
+    neutron ovsdbapp is reporting frequent reconnections to the ovn southbound
+    database due to "stale data" and this may require taking action to resolve.
+    One cause is if you have recently rebuilt your southbound database. See the
+    linked bug for more information. One suggested workaround is to restart
+    neutron-ovn-metadata-agent.

--- a/defs/tests/scenarios/openstack/neutron/ovn_stale_db_neutron_server.yaml
+++ b/defs/tests/scenarios/openstack/neutron/ovn_stale_db_neutron_server.yaml
@@ -1,0 +1,25 @@
+target-name: ovn_stale_db.yaml
+data-root:
+  files:
+    var/log/neutron/neutron-server.log: |
+      2022-02-10 12:52:24.652 317561 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.20:16642: connected
+      2022-02-10 12:52:24.696 317561 WARNING ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.20:16642: clustered database server has stale data; trying another server
+      2022-02-10 12:52:24.698 317561 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.20:16642: connection closed by client
+      2022-02-10 12:52:24.819 317559 INFO ovsdbapp.backend.ovs_idl.vlog [req-6a330106-9631-45d2-8449-194dac0adbf3 - - - - -] ssl:10.5.3.204:16642: connected
+      2022-02-10 12:52:24.863 317559 WARNING ovsdbapp.backend.ovs_idl.vlog [req-6a330106-9631-45d2-8449-194dac0adbf3 - - - - -] ssl:10.5.3.204:16642: clustered database server has stale data; trying another server
+      2022-02-10 12:52:24.865 317559 INFO ovsdbapp.backend.ovs_idl.vlog [req-6a330106-9631-45d2-8449-194dac0adbf3 - - - - -] ssl:10.5.3.204:16642: connection closed by client
+      2022-02-10 12:52:26.269 317562 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.204:16642: connected
+      2022-02-10 12:52:26.310 317562 WARNING ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.204:16642: clustered database server has stale data; trying another server
+      2022-02-10 12:52:26.311 317562 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.5.3.204:16642: connection closed by client
+    sos_commands/dpkg/dpkg_-l: |
+      ii  neutron-server                  2:16.4.2-0ubuntu4                 all          Neutron is a virtual network service for Openstack - server
+  copy-from-original:
+    - uptime
+    - sos_commands/date/date
+raised-bugs:
+  https://bugzilla.redhat.com/show_bug.cgi?id=1829109: >-
+    neutron ovsdbapp is reporting frequent reconnections to the ovn southbound
+    database due to "stale data" and this may require taking action to resolve.
+    One cause is if you have recently rebuilt your southbound database. See the
+    linked bug for more information. One suggested workaround is to restart
+    neutron-server.

--- a/defs/tests/scenarios/openstack/neutron/ovn_stale_db_ovn_controller.yaml
+++ b/defs/tests/scenarios/openstack/neutron/ovn_stale_db_ovn_controller.yaml
@@ -1,0 +1,21 @@
+target-name: ovn_stale_db.yaml
+data-root:
+  files:
+    var/log/ovn/ovn-controller.log: |
+      2022-02-10T13:01:54.786Z|00040|reconnect|INFO|tcp:10.5.0.3:6642: continuing to reconnect in the background but suppressing further logging
+      2022-02-10T13:02:02.787Z|00041|reconnect|INFO|tcp:10.5.0.4:6642: connected
+      2022-02-10T13:02:02.789Z|00042|ovsdb_idl|WARN|tcp:10.5.0.4:6642: clustered database server has stale data; trying another server
+      2022-02-10T13:02:10.795Z|00043|reconnect|INFO|tcp:10.5.0.5:6642: connected
+      2022-02-10T13:02:10.796Z|00044|ovsdb_idl|INFO|tcp:10.5.0.5:6642: clustered database server is disconnected from cluster; trying another server
+      2022-02-10T13:02:18.804Z|00045|reconnect|INFO|tcp:10.5.0.3:6642: connected                            
+  copy-from-original:
+    - uptime
+    - sos_commands/date/date
+raised-bugs:
+  https://bugzilla.redhat.com/show_bug.cgi?id=1829109: >-
+    ovn-controller is reporting frequent reconnections to the ovn
+    southbound database due to "stale data" and this may require
+    taking action to resolve. One cause is if you have recently
+    rebuilt your southbound database. See the linked bug for more
+    information. One suggested workaround is to run
+    'ovn-appctl -t ovn-controller sb-cluster-state-reset'.

--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -163,6 +163,17 @@ class LaunchpadBug(BugTypeBase):
         return "{}{}".format(self.base_url, self.id)
 
 
+class Bugzilla(BugTypeBase):
+
+    @property
+    def base_url(self):
+        return 'https://bugzilla.redhat.com/show_bug.cgi?id='
+
+    @property
+    def url(self):
+        return "{}{}".format(self.base_url, self.id)
+
+
 class StoryBoardBug(BugTypeBase):
 
     @property


### PR DESCRIPTION
If the OVN Southbound database has recently been rebuilt it may be necessary to restart clients and/or run a reset command.