### PR TITLE
Add new allow_constraints_for_unverifiable_logs config

### DIFF
--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -121,6 +121,8 @@ def get_prefix(user_summary, data_root):
 
 def main():
     @click.command(name='hotsos')
+    @click.option('--allow-constraints-for-unverifiable-logs', default=False,
+                  is_flag=True)
     @click.option('--output-path', default=None,
                   help=('Optional path to use for saving output (with '
                         '--save).'))
@@ -198,6 +200,7 @@ def main():
             format, html_escape, user_summary, short, very_short,
             force, full, agent_error_key_by_time, max_logrotate_depth,
             max_parallel_tasks, list_plugins, machine_readable, output_path,
+            allow_constraints_for_unverifiable_logs,
             **kwargs):
         """
         Run this tool on a host or against an unpacked sosreport to perform
@@ -253,6 +256,8 @@ def main():
                          max_logrotate_depth=max_logrotate_depth,
                          max_parallel_tasks=max_parallel_tasks,
                          machine_readable=machine_readable)
+        HotSOSConfig.allow_constraints_for_unverifiable_logs = \
+            allow_constraints_for_unverifiable_logs
 
         if debug and quiet:
             sys.stderr.write('ERROR: cannot use both --debug and --quiet\n')

--- a/hotsos/core/config.py
+++ b/hotsos/core/config.py
@@ -112,6 +112,28 @@ class SearchtoolsConfigOpts(ConfigOptGroupBase):
                                         'log files, this is used to limit the '
                                         'logrotate history in days.'),
                            default_value=7))
+        self.add(ConfigOpt(name='allow_constraints_for_unverifiable_logs',
+                           description=('Search constraints use a binary '
+                                        'search that sometimes needs to '
+                                        'seek backwards to find a last '
+                                        'known good line i.e. in log files '
+                                        "that contain lines that don't start "
+                                        'with a timestamp we treat those as '
+                                        'unverifiable and so have to find the '
+                                        'most recent verifiable line which '
+                                        'can be ahead or behind the current '
+                                        'position. Seeking backwards seems to '
+                                        'force a SEEK_SET in the kernel '
+                                        'regardless of what whence is set to '
+                                        'which for large files becomes very '
+                                        'slow as it will start from 0 each '
+                                        'time. Backwards seeking is now not '
+                                        'supported by default and requires '
+                                        'setting this option to True '
+                                        'to enable search constraints for '
+                                        'files that contain unverifiable '
+                                        'lines.'),
+                           default_value=False))
 
     @property
     def name(self):

--- a/hotsos/core/search/constraints.py
+++ b/hotsos/core/search/constraints.py
@@ -348,6 +348,13 @@ class BinarySeekSearchBase(ConstraintBase):
         log.debug("seek %s", state)
         newpos = self._check_line(state)
         if newpos == -1:
+            if not HotSOSConfig.allow_constraints_for_unverifiable_logs:
+                log.info("file contains unverifiable lines and "
+                         "allow_constraints_for_unverifiable_logs is False  "
+                         "- aborting constraints for this file.")
+                state.rc = state.RC_ERROR
+                return state
+
             # until we get out of a skip range we want to leave the pos at the
             # start but we rely on the caller to enforce this so that we don't
             # have to seek(0) after every skip.

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -347,7 +347,8 @@ class BaseTestCase(unittest.TestCase):
                               'global_tmp_dir': None,
                               'plugin_tmp_dir': None,
                               'use_all_logs': True,
-                              'machine_readable': True}
+                              'machine_readable': True,
+                              'allow_constraints_for_unverifiable_logs': True}
 
     def part_output_to_actual(self, output):
         actual = {}


### PR DESCRIPTION
Disables constraints for files that contain unverifiable lines and adds a config option to re-enable them. This is until we have a way to apply constraints for files containing lines that dont have timestamps without it being really slow for large files.

Resolves: #498