### PR TITLE
Support enabling debug logs for unit tests

### DIFF
--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -372,7 +372,8 @@ class BaseTestCase(unittest.TestCase):
         HotSOSConfig.global_tmp_dir = self.global_tmp_dir
         HotSOSConfig.plugin_tmp_dir = self.plugin_tmp_dir
         setup_logging()
-        log.setLevel(logging.INFO)
+        if os.environ.get('TESTS_LOG_LEVEL_DEBUG', 'no') != 'yes':
+            log.setLevel(logging.INFO)
 
     def tearDown(self):
         HotSOSConfig.reset()

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ pyfiles =
     {toxinidir}/setup.py
     {toxinidir}/hotsos/
     {[testenv]unit_tests}
+passenv = TESTS_LOG_LEVEL_DEBUG
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
          TERM=linux


### PR DESCRIPTION
Can now set TESTS_LOG_LEVEL_DEBUG=yes if we want debug log level in unit tests.