### PR TITLE
Fix keystone ldap check for LP 1896125

### DIFF
--- a/defs/README.md
+++ b/defs/README.md
@@ -690,8 +690,8 @@ CACHE_KEYS
 ```
 
 #### config
-A dictionary containing the information required to perform some
-config checks.
+A dictionary containing the information required to perform some config checks. 
+Supports applying assertion rules to the contents of one or more config file.
 
 format:
 
@@ -700,7 +700,8 @@ handler: <path>
   Import path to an implementation of core.host_helpers.SectionalConfigBase.
 
 path: <path>
-  Optional path (e.g. config file) to use as argument to handler.
+  Optional path or list of paths used as input when creating config
+  handlers. Each path must be a file or glob path (wildcard).
 
 assertions: ASSERTION
   One or more ASSERTION can be defined and optionally grouped using

--- a/defs/scenarios/openstack/keystone/bugs.yaml
+++ b/defs/scenarios/openstack/keystone/bugs.yaml
@@ -1,7 +1,7 @@
 checks:
   has_1896125:
     apt:
-      python3-keystone:
+      keystone:
         # Train
         - min: 2:16.0.0
           max: 2:16.0.1
@@ -11,6 +11,15 @@ checks:
         # Victoria
         - min: 2:18.0.0
           max: 2:18.0.0-99
+    config:
+      handler: hotsos.core.plugins.openstack.OpenstackConfig
+      # keystone ldap config be defined globally or per-domain
+      path: [etc/keystone/keystone.conf, etc/keystone/domains/*]
+      assertions:
+        - key: url
+          section: ldap
+          ops: [[truth]]  # i.e. does the setting have a value
+          allow-unset: False
 conclusions:
   lp1896125:
     decision: has_1896125

--- a/defs/tests/scenarios/openstack/keystone/bugs.yaml
+++ b/defs/tests/scenarios/openstack/keystone/bugs.yaml
@@ -2,10 +2,16 @@ target-name: bugs.yaml
 data-root:
   files:
     sos_commands/dpkg/dpkg_-l: |
-      ii  python3-keystone 2:17.0.0-0ubuntu0.20.04.1 amd64
+      ii  keystone 2:17.0.0-0ubuntu0.20.04.1 amd64
+    etc/keystone/keystone.conf: |
+      [DEBUG]
+      debug = True
+    etc/keystone/domains/domainX.conf: |
+      [ldap]
+      url = ldap://10.0.0.1
 raised-bugs:
   https://bugs.launchpad.net/bugs/1896125: >-
-    Installed package 'python3-keystone' with version 2:17.0.0-0ubuntu0.20.04.1 has a known bug
+    Installed package 'keystone' with version 2:17.0.0-0ubuntu0.20.04.1 has a known bug
     that causes memory leak over time and causes LDAP logins to fail. It
     is recommended to upgrade to the next point release available for the
     package. To workaround LDAP login failure problem, disable LDAP pooling


### PR DESCRIPTION
python3-keystone is installed as a dep for all openstack services so we need to check for package "keystone" to know this is a keystone host and we also now check that ldap is actually in use.