### PR TITLE
Add `markdown` and `html` output formats

### DIFF
--- a/.github/workflows/snapfunctionaltest.yaml
+++ b/.github/workflows/snapfunctionaltest.yaml
@@ -11,11 +11,24 @@ jobs:
       - uses: actions/checkout@v3
       - uses: snapcore/action-build@v1
         id: snapcraft
-      - name: Run snap
+      - name: Install snap
         run: |
           sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
-          hotsos
-      - uses: actions/upload-artifact@v3
+      - name: Run snap (functional test)
+        run: hotsos > output.yaml
+      - name: Run snap (JSON output)
+        run: hotsos --format json tests/unit/fake_data_root/openstack > output.json
+      - name: Run snap (HTML output)
+        run: hotsos --format html tests/unit/fake_data_root/openstack > output.html
+      - name: Run snap (Markdown output)
+        run: hotsos --format markdown tests/unit/fake_data_root/openstack > output.md
+      - name: Upload snap
+        uses: actions/upload-artifact@v3
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
+      - name: Upload outputs
+        uses: actions/upload-artifact@v3
+        with:
+          name: functional-test-outputs
+          path: output.*

--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -175,9 +175,11 @@ def main():
     @click.option('--html-escape', default=False, is_flag=True,
                   help=('Apply html escaping to the output so that it is safe '
                         'to display in html.'))
-    @click.option('--format', default='yaml',
-                  help=('Output format. Supported formats are yaml and json. '
-                        'Default is yaml.'))
+    @click.option('--format',
+                  type=click.Choice(['yaml', 'json', 'markdown', 'html']),
+                  default='yaml',
+                  show_default=True,
+                  help=('Output format.'))
     @click.option('--save', '-s', default=False, is_flag=True,
                   help=('Save output to a file.'))
     @click.option('--quiet', default=False, is_flag=True,

--- a/hotsos/client.py
+++ b/hotsos/client.py
@@ -255,8 +255,8 @@ class OutputManager(object):
         log.warning("Unknown minimalmode '%s'", mode)
         return summary
 
-    def get(self, format=None, html_escape=False, minimal_mode=None,
-            plugin=None):
+    def get(self, format='yaml', html_escape=False, minimal_mode=None,
+            plugin=None, max_level=2):
         if plugin:
             filtered = {plugin: self._summary[plugin]}
         else:
@@ -265,12 +265,18 @@ class OutputManager(object):
         if minimal_mode:
             filtered = self.minimise(filtered, minimal_mode)
 
-        if format == 'json':
-            log.debug('Converting master yaml file to %s', format)
-            filtered = json.dumps(filtered, indent=2, sort_keys=True)
-        else:
+        if format == 'yaml':
             filtered = plugintools.yaml_dump(filtered)
-
+        else:
+            log.debug('Converting master yaml file to %s', format)
+            if format == 'json':
+                filtered = json.dumps(filtered, indent=2, sort_keys=True)
+            elif format == 'markdown':
+                filtered = plugintools.markdown_dump(filtered)
+            elif format == 'html':
+                filtered = plugintools.html_dump(filtered, max_level=max_level)
+            else:
+                raise Exception(f'unknown format {format}')
         if html_escape:
             log.debug('Encoding output file to html')
             filtered = html.escape(filtered)

--- a/hotsos/core/plugintools.py
+++ b/hotsos/core/plugintools.py
@@ -38,6 +38,231 @@ def yaml_dump(data):
                      default_flow_style=False).rstrip("\n")
 
 
+def markdown_expand_dict_key(data, level):
+    """Expand the data object.
+
+    Parameters:
+    data -- The data object. This can be a dict, list, or a flat type such as
+    int or str.
+    level -- The current header level
+
+    Returns:
+    A string expansion formatted in markdown of the data object.
+    """
+    level_prefix = ''.join(['#' for i in range(level)])
+    markdown_output = ''
+    if isinstance(data, (int, float, str)):
+        markdown_output += f'\n{data}\n'
+    elif isinstance(data, dict):
+        for key in data:
+            markdown_output += f'\n{level_prefix} {key}\n'
+            markdown_output += markdown_expand_dict_key(data[key], level + 1)
+    elif isinstance(data, list):
+        markdown_output += '\n'
+        for item in data:
+            markdown_output += f'- {item}\n'
+    return markdown_output
+
+
+def _get_indent(indent, shift):
+    """Get a string with a few spaces.
+
+    Parameters:
+    indent -- The current indentation string
+    shift -- The additional shift
+
+    Returns:
+    A string with the indentation string.
+    """
+    return indent + ''.join([' ' * shift])
+
+
+def html_expand_dict_key(data, level, indent, max_level=0):
+    """Expand the data object.
+
+    Parameters:
+    data -- The data object. This can be a dict, list, or a flat type such as
+    int or str.
+    level -- The current header level
+    indent -- A string with spaces for indentation
+    max_level -- The HTML will be collapsible up to max_level
+
+    Returns:
+    A string expansion formatted in HTML of the data object.
+    """
+    markup_output = ''
+    if isinstance(data, (int, float, str)):
+        markup_output += f'{indent}{data}\n'
+    elif isinstance(data, dict):
+        add_class = ''
+        collapsible = level < max_level
+        if level == 1:
+            add_class = ' class="tree"'
+        markup_output += f'{indent}<ul{add_class}>\n'
+        for key in data.keys():
+            markup_output += f'{_get_indent(indent, 4)}<li>\n'
+            if collapsible:
+                markup_output += f'{_get_indent(indent, 8)}<details>\n'
+                markup_output += \
+                    f'{_get_indent(indent, 12)}<summary>{key}</summary>\n'
+                additional_indent = 12
+            else:
+                markup_output += f'{_get_indent(indent, 8)}<b>{key}</b>\n'
+                additional_indent = 8
+            markup_output += \
+                html_expand_dict_key(data[key], level + 1,
+                                     _get_indent(indent, additional_indent),
+                                     max_level=max_level)
+            if collapsible:
+                markup_output += f'{_get_indent(indent, 8)}</details>\n'
+            markup_output += f'{_get_indent(indent, 4)}</li>\n'
+        markup_output += f'{indent}</ul>\n'
+    elif isinstance(data, list):
+        markup_output += f'{indent}<ul>\n'
+        for item in data:
+            markup_output += f'{indent}    <li>\n'
+            markup_output += html_expand_dict_key(item, level,
+                                                  indent + '        ',
+                                                  max_level=max_level)
+            markup_output += f'{indent}    </li>\n'
+        markup_output += f'{indent}</ul>\n'
+    return markup_output
+
+
+def markdown_dump(data):
+    """Convert the data (dict) into a markdown document.
+
+    Parameters:
+    data: dict --- The data
+
+    Returns:
+    str -- The markdown document
+    """
+    markdown = '# hotsos summary\n'
+    markdown += markdown_expand_dict_key(data, 2)
+    return markdown.rstrip('\n')
+
+
+def get_html_header():
+    return '''<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="generator" content="hotsos" />
+    <title>hotsos report</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        .tree{
+          --spacing : 1.5rem;
+          --radius  : 10px;
+        }
+
+        .tree li{
+          display      : block;
+          position     : relative;
+          padding-left : calc(2 * var(--spacing) - var(--radius) - 2px);
+        }
+
+        .tree ul{
+          margin-left  : calc(var(--radius) - var(--spacing));
+          padding-left : 0;
+        }
+
+        .tree ul li{
+          border-left : 2px solid #ddd;
+        }
+
+        .tree ul li:last-child{
+          border-color : transparent;
+        }
+
+        .tree ul li::before{
+          content      : '';
+          display      : block;
+          position     : absolute;
+          top          : calc(var(--spacing) / -2);
+          left         : -2px;
+          width        : calc(var(--spacing) + 2px);
+          height       : calc(var(--spacing) + 1px);
+          border       : solid #ddd;
+          border-width : 0 0 2px 2px;
+        }
+
+        .tree summary{
+          display : block;
+          cursor  : pointer;
+        }
+
+        .tree summary::marker,
+        .tree summary::-webkit-details-marker{
+          display : none;
+        }
+
+        .tree summary:focus{
+          outline : none;
+        }
+
+        .tree summary:focus-visible{
+          outline : 1px dotted #000;
+        }
+
+        .tree li::after,
+        .tree summary::before{
+          content       : '';
+          display       : block;
+          position      : absolute;
+          top           : calc(var(--spacing) / 2 - var(--radius));
+          left          : calc(var(--spacing) - var(--radius) - 1px);
+          width         : calc(2 * var(--radius));
+          height        : calc(2 * var(--radius));
+          border-radius : 50%;
+          background    : #ddd;
+        }
+
+        .tree summary::before{
+          content     : '+';
+          z-index     : 1;
+          background  : #696;
+          color       : #fff;
+          line-height : calc(2 * var(--radius) - 2px);
+          text-align  : center;
+        }
+
+        .tree details[open] > summary::before{
+          content : '−';
+        }
+    </style>
+</head>
+
+<body>
+'''
+
+
+def get_html_footer():
+    return '''</body>
+
+</html>
+'''
+
+
+def html_dump(data, max_level=2):
+    """Convert the data (dict) into an html document.
+
+    Taken from https://iamkate.com/code/tree-views/
+
+    Parameters:
+    data: dist -- The data
+    max_level -- The HTML will be collapsible up to max_level
+
+    Returns:
+    str -- The html document
+    """
+    html_output = get_html_header()
+    html_output += html_expand_dict_key(data, 1, '    ', max_level=max_level)
+    html_output += get_html_footer()
+    return html_output
+
+
 class ApplicationBase(object):
 
     @property

--- a/tests/unit/test_plugintools.py
+++ b/tests/unit/test_plugintools.py
@@ -96,3 +96,236 @@ class TestPluginTools(utils.BaseTestCase):
         filtered = OutputManager(summary).get(format='json')
         self.assertEqual(filtered, json.dumps(summary, indent=2,
                                               sort_keys=True))
+
+    def test_apply_output_formatting_markdown(self):
+        summary = {
+            'item-1':
+                {
+                    'level-2': [
+                        'value-1',
+                        'value-2',
+                        'value-3',
+                        'value-4',
+                    ],
+                    'level-3': 'plain value',
+                },
+            'item-2':
+                ['a', 'b', 'c'],
+            }
+        expected = '''# hotsos summary
+
+## item-1
+
+### level-2
+
+- value-1
+- value-2
+- value-3
+- value-4
+
+### level-3
+
+plain value
+
+## item-2
+
+- a
+- b
+- c'''
+        filtered = OutputManager(summary).get(format='markdown')
+        self.assertEqual(filtered, expected)
+
+    def test_apply_output_formatting_html_1(self):
+        summary = {
+            'item-1':
+                {
+                    'level-2': [
+                        'value-1',
+                        'value-2',
+                        'value-3',
+                        'value-4',
+                    ],
+                    'level-3': 'plain value',
+                },
+            'item-2':
+                ['a', 'b', 'c'],
+            }
+        expected = plugintools.get_html_header() + '''    <ul class="tree">
+        <li>
+            <details>
+                <summary>item-1</summary>
+                <ul>
+                    <li>
+                        <details>
+                            <summary>level-2</summary>
+                            <ul>
+                                <li>
+                                    value-1
+                                </li>
+                                <li>
+                                    value-2
+                                </li>
+                                <li>
+                                    value-3
+                                </li>
+                                <li>
+                                    value-4
+                                </li>
+                            </ul>
+                        </details>
+                    </li>
+                    <li>
+                        <details>
+                            <summary>level-3</summary>
+                            plain value
+                        </details>
+                    </li>
+                </ul>
+            </details>
+        </li>
+        <li>
+            <details>
+                <summary>item-2</summary>
+                <ul>
+                    <li>
+                        a
+                    </li>
+                    <li>
+                        b
+                    </li>
+                    <li>
+                        c
+                    </li>
+                </ul>
+            </details>
+        </li>
+    </ul>
+''' + plugintools.get_html_footer()
+        filtered = OutputManager(summary).get(format='html', max_level=100)
+        self.assertEqual(filtered, expected)
+
+    def test_apply_output_formatting_html_2(self):
+        summary = {
+            'item-1':
+                {
+                    'level-2': [
+                        'value-1',
+                        'value-2',
+                        'value-3',
+                        'value-4',
+                    ],
+                    'level-3': 'plain value',
+                },
+            'item-2':
+                ['a', 'b', 'c'],
+            }
+        expected = plugintools.get_html_header() + '''    <ul class="tree">
+        <li>
+            <b>item-1</b>
+            <ul>
+                <li>
+                    <b>level-2</b>
+                    <ul>
+                        <li>
+                            value-1
+                        </li>
+                        <li>
+                            value-2
+                        </li>
+                        <li>
+                            value-3
+                        </li>
+                        <li>
+                            value-4
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <b>level-3</b>
+                    plain value
+                </li>
+            </ul>
+        </li>
+        <li>
+            <b>item-2</b>
+            <ul>
+                <li>
+                    a
+                </li>
+                <li>
+                    b
+                </li>
+                <li>
+                    c
+                </li>
+            </ul>
+        </li>
+    </ul>
+''' + plugintools.get_html_footer()
+        filtered = OutputManager(summary).get(format='html', max_level=1)
+        self.assertEqual(filtered, expected)
+
+    def test_apply_output_formatting_html_3(self):
+        summary = {
+            'item-1':
+                {
+                    'level-2': [
+                        'value-1',
+                        'value-2',
+                        'value-3',
+                        'value-4',
+                    ],
+                    'level-3': 'plain value',
+                },
+            'item-2':
+                ['a', 'b', 'c'],
+            }
+        expected = plugintools.get_html_header() + '''    <ul class="tree">
+        <li>
+            <details>
+                <summary>item-1</summary>
+                <ul>
+                    <li>
+                        <b>level-2</b>
+                        <ul>
+                            <li>
+                                value-1
+                            </li>
+                            <li>
+                                value-2
+                            </li>
+                            <li>
+                                value-3
+                            </li>
+                            <li>
+                                value-4
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        <b>level-3</b>
+                        plain value
+                    </li>
+                </ul>
+            </details>
+        </li>
+        <li>
+            <details>
+                <summary>item-2</summary>
+                <ul>
+                    <li>
+                        a
+                    </li>
+                    <li>
+                        b
+                    </li>
+                    <li>
+                        c
+                    </li>
+                </ul>
+            </details>
+        </li>
+    </ul>
+''' + plugintools.get_html_footer()
+        filtered = OutputManager(summary).get(format='html', max_level=2)
+        self.assertEqual(filtered, expected)


### PR DESCRIPTION
The new formatters will produce `markdown` or `html` formatted output. For example, the following output in `yaml`:

```yaml
hotsos:
  version: development
  repo-info: 772515fe
system:
  hostname: compute4
  os: ubuntu focal
```

will be formatted as

```markdown
# hotsos summary

## hotsos

### version

development

### repo-info

772515fe

## system

### hostname

compute4

### os

ubuntu focal
```

The `html` output can be viewed directly in a browser.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>