### PR TITLE
Don't run bcache checks when inside a lxc container

### DIFF
--- a/defs/scenarios/storage/bcache/bcache.yaml
+++ b/defs/scenarios/storage/bcache/bcache.yaml
@@ -1,0 +1,6 @@
+requires:
+  # don't run these checks if we are inside a lxc container
+  property:
+    path: hotsos.core.plugins.system.system.SystemBase.virtualisation_type
+    ops: [[ne, lxc]]
+


### PR DESCRIPTION
Relates-to: #527