### PR TITLE
Enable cli binary command caching

### DIFF
--- a/hotsos/client.py
+++ b/hotsos/client.py
@@ -372,7 +372,7 @@ class HotSOSClient(object):
         os.makedirs(os.path.join(global_tmp_dir, 'locks'))
 
     def teardown_global_env(self):
-        log.debug("tearing down gloval env")
+        log.debug("tearing down global env")
         if os.path.exists(HotSOSConfig.global_tmp_dir):
             shutil.rmtree(HotSOSConfig.global_tmp_dir)
 

--- a/scripts/hotsos
+++ b/scripts/hotsos
@@ -1,3 +1,3 @@
 #!/bin/bash
-export PYTHONPATH=$(dirname $0)/..
+export PYTHONPATH=$PYTHONPATH:$(dirname $0)/..
 $(dirname $0)/../hotsos/cli.py $@


### PR DESCRIPTION
Repeated execution of binary commands can lead to unecessary load of the host or cluster so we now cache their output and read from a file copy for successive calls to the same command. We currently only cache commands that are executed without args.

Resolves: #541