### PR TITLE
summary: add ubuntu `pro status` to the output

### DIFF
--- a/examples/hotsos-example-juju.summary.yaml
+++ b/examples/hotsos-example-juju.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2      308585260 25514372 267326276   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 16:19:17 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   juju-charm-sysctl-mismatch:
     kernel.pid_max:
       conf: 50-ceph-osd-charm.conf

--- a/examples/hotsos-example-kernel.summary.yaml
+++ b/examples/hotsos-example-kernel.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2      308585260 25514372 267326276   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 16:19:17 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   juju-charm-sysctl-mismatch:
     kernel.pid_max:
       conf: 50-ceph-osd-charm.conf

--- a/examples/hotsos-example-kubernetes.summary.yaml
+++ b/examples/hotsos-example-kubernetes.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda1       40470732 3590360  36863988   9% /
   unattended-upgrades: ENABLED
   date: Fri 11 Feb 19:23:39 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   potential-issues:
     SystemWarnings:
       - Unattended upgrades are enabled which can lead to uncontrolled changes to

--- a/examples/hotsos-example-lxd.summary.yaml
+++ b/examples/hotsos-example-lxd.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2      308585260 25514372 267326276   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 16:19:17 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   juju-charm-sysctl-mismatch:
     kernel.pid_max:
       conf: 50-ceph-osd-charm.conf

--- a/examples/hotsos-example-maas.summary.yaml
+++ b/examples/hotsos-example-maas.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2      308585260 25514372 267326276   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 16:19:17 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   juju-charm-sysctl-mismatch:
     kernel.pid_max:
       conf: 50-ceph-osd-charm.conf

--- a/examples/hotsos-example-mysql.summary.yaml
+++ b/examples/hotsos-example-mysql.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2        308585260 24171768 268668880   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 09:51:32 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   potential-issues:
     SystemWarnings:
       - Unattended upgrades are enabled which can lead to uncontrolled changes to

--- a/examples/hotsos-example-openstack.summary.yaml
+++ b/examples/hotsos-example-openstack.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2      308585260 25514372 267326276   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 16:19:17 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   juju-charm-sysctl-mismatch:
     kernel.pid_max:
       conf: 50-ceph-osd-charm.conf

--- a/examples/hotsos-example-openvswitch.summary.yaml
+++ b/examples/hotsos-example-openvswitch.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2      308585260 25514372 267326276   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 16:19:17 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   juju-charm-sysctl-mismatch:
     kernel.pid_max:
       conf: 50-ceph-osd-charm.conf

--- a/examples/hotsos-example-pacemaker.summary.yaml
+++ b/examples/hotsos-example-pacemaker.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2        308585260 24171768 268668880   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 09:51:32 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   potential-issues:
     SystemWarnings:
       - Unattended upgrades are enabled which can lead to uncontrolled changes to

--- a/examples/hotsos-example-rabbitmq.summary.yaml
+++ b/examples/hotsos-example-rabbitmq.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2        308585260 24695924 268144724   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 09:39:52 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   potential-issues:
     SystemWarnings:
       - Unattended upgrades are enabled which can lead to uncontrolled changes to

--- a/examples/hotsos-example-sosreport.summary.yaml
+++ b/examples/hotsos-example-sosreport.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2      308585260 25514372 267326276   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 16:19:17 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   juju-charm-sysctl-mismatch:
     kernel.pid_max:
       conf: 50-ceph-osd-charm.conf

--- a/examples/hotsos-example-storage.summary.yaml
+++ b/examples/hotsos-example-storage.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2        308585260 24784824 268055824   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 09:47:16 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   sysctl-mismatch:
     kernel.pid_max:
       actual: '4194304'

--- a/examples/hotsos-example-system.summary.yaml
+++ b/examples/hotsos-example-system.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2      308585260 25514372 267326276   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 16:19:17 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   juju-charm-sysctl-mismatch:
     kernel.pid_max:
       conf: 50-ceph-osd-charm.conf

--- a/examples/hotsos-example-vault.summary.yaml
+++ b/examples/hotsos-example-vault.summary.yaml
@@ -10,6 +10,8 @@ system:
   rootfs: /dev/vda2        308585260 24171768 268668880   9% /
   unattended-upgrades: ENABLED
   date: Thu 10 Feb 09:51:32 UTC 2022
+  ubuntu-pro:
+    status: not-attached
   potential-issues:
     SystemWarnings:
       - Unattended upgrades are enabled which can lead to uncontrolled changes to

--- a/hotsos/core/host_helpers/cli.py
+++ b/hotsos/core/host_helpers/cli.py
@@ -833,6 +833,9 @@ class CLIHelper(HostHelpersBase):
                  # Older sosrepot uses 'wchan' option while newer ones use
                  # 'wchan:20' - thus the glob is to cover both
                  FileCmd(get_ps_axo_flags_available() or "")],
+            'pro_status':
+                [BinCmd('ua status'),
+                 FileCmd('sos_commands/ubuntu/ua_status')],
             'rabbitmqctl_report':
                 [BinCmd('rabbitmqctl report'),
                  FileCmd('sos_commands/rabbitmq/rabbitmqctl_report')],

--- a/hotsos/plugin_extensions/system/summary.py
+++ b/hotsos/plugin_extensions/system/summary.py
@@ -50,3 +50,7 @@ class SystemSummary(SystemChecksBase):
     @idx(7)
     def __summary_date(self):
         return self.date
+
+    @idx(8)
+    def __summary_ubuntu_pro(self):
+        return self.ubuntu_pro_status

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -7,7 +7,7 @@ from unittest import mock
 from . import utils
 
 from hotsos.core.config import HotSOSConfig
-from hotsos.core.plugins.system.system import NUMAInfo
+from hotsos.core.plugins.system.system import NUMAInfo, SystemBase
 from hotsos.plugin_extensions.system import (
     checks,
     summary,
@@ -28,6 +28,56 @@ node   0   1
 """.splitlines(keepends=True)  # noqa
 
 
+UBUNTU_PRO_ATTACHED = r"""SERVICE          ENTITLED  STATUS    DESCRIPTION
+esm-apps         yes       enabled   Expanded Security Maintenance for Applications
+esm-infra        yes       enabled   Expanded Security Maintenance for Infrastructure
+livepatch        yes       enabled   Canonical Livepatch service
+realtime-kernel  yes       disabled  Ubuntu kernel with PREEMPT_RT patches integrated
+
+Enable services with: pro enable <service>
+
+                Account: Canonical - staff
+           Subscription: Ubuntu Pro (Apps-only) - Virtual
+            Valid until: Sat Jan  1 02:59:59 4000 +03
+Technical support level: essential
+""".splitlines(keepends=True)  # noqa
+
+UBUNTU_PRO_NOT_ATTACHED = r"""SERVICE          AVAILABLE  DESCRIPTION
+esm-apps         yes        Expanded Security Maintenance for Applications
+esm-infra        yes        Expanded Security Maintenance for Infrastructure
+livepatch        yes        Canonical Livepatch service
+realtime-kernel  yes        Ubuntu kernel with PREEMPT_RT patches integrated
+
+This machine is not attached to an Ubuntu Pro subscription.
+See https://ubuntu.com/pro
+""".splitlines(keepends=True)  # noqa
+
+UA_NOT_ATTACHED = r"""SERVICE       AVAILABLE  DESCRIPTION
+esm-infra     yes        UA Infra: Extended Security Maintenance (ESM)
+fips          yes        NIST-certified FIPS modules
+fips-updates  yes        Uncertified security updates to FIPS modules
+livepatch     yes        Canonical Livepatch service
+
+This machine is not attached to a UA subscription.
+See https://ubuntu.com/advantage
+""".splitlines(keepends=True)  # noqa
+
+UA_ATTACHED = r"""SERVICE       ENTITLED  STATUS    DESCRIPTION
+esm-apps      yes       enabled   UA Apps: Extended Security Maintenance (ESM)
+esm-infra     yes       enabled   UA Infra: Extended Security Maintenance (ESM)
+fips          yes       n/a       NIST-certified FIPS modules
+fips-updates  yes       n/a       Uncertified security updates to FIPS modules
+livepatch     yes       n/a       Canonical Livepatch service
+
+Enable services with: ua enable <service>
+
+                Account: Canonical - staff
+           Subscription: Ubuntu Pro (Apps-only) - Virtual
+            Valid until: 3999-12-31 23:59:59
+Technical support level: essential
+""".splitlines(keepends=True)  # noqa
+
+
 class SystemTestsBase(utils.BaseTestCase):
 
     def setUp(self):
@@ -45,6 +95,7 @@ class TestSystemSummary(SystemTestsBase):
                     'os': 'ubuntu focal',
                     'rootfs': ('/dev/vda2      308585260 25514372 267326276 '
                                '  9% /'),
+                    'ubuntu-pro': {'status': 'not-attached'},
                     'virtualisation': 'kvm',
                     'unattended-upgrades': 'ENABLED'}
         inst = summary.SystemSummary()
@@ -136,6 +187,117 @@ class TestSYSCtlChecks(SystemTestsBase):
             inst = checks.SYSCtlChecks()
             actual = self.part_output_to_actual(inst.output)
             self.assertEqual(actual, expected)
+
+
+class TestUbuntuPro(SystemTestsBase):
+
+    @mock.patch('hotsos.core.plugins.system.system.CLIHelper')
+    def test_ubuntu_pro_attached(self, mock_helper):
+        mock_helper.return_value = mock.MagicMock()
+        mock_helper.return_value.pro_status.return_value = UBUNTU_PRO_ATTACHED
+        result = SystemBase().ubuntu_pro_status
+        self.assertNotEqual(result, None)
+        print(result)
+        self.assertNotEqual(result, False)
+
+        expected_result = {
+            "status": "attached",
+            "services": {
+                "esm-apps": {
+                    "entitled": "yes",
+                    "status": "enabled"
+                },
+                "esm-infra": {
+                    "entitled": "yes",
+                    "status": "enabled"
+                },
+                "livepatch": {
+                    "entitled": "yes",
+                    "status": "enabled"
+                },
+                "realtime-kernel": {
+                    "entitled": "yes",
+                    "status": "disabled"
+                }
+            },
+            "account": "Canonical - staff",
+            "subscription": "Ubuntu Pro (Apps-only) - Virtual",
+            "technical_support_level": "essential",
+            "valid_until": "Sat Jan  1 02:59:59 4000 +03"
+        }
+
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('hotsos.core.plugins.system.system.CLIHelper')
+    def test_ubuntu_pro_not_attached(self, mock_helper):
+        mock_helper.return_value = mock.MagicMock()
+        mock_helper.return_value.pro_status.return_value = UBUNTU_PRO_NOT_ATTACHED # noqa, pylint: disable=C0301
+        result = SystemBase().ubuntu_pro_status
+        expected_result = {
+            "status": "not-attached"
+        }
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('hotsos.core.plugins.system.system.CLIHelper')
+    def test_ubuntu_advantage_attached(self, mock_helper):
+        mock_helper.return_value = mock.MagicMock()
+        mock_helper.return_value.pro_status.return_value = UA_ATTACHED
+        result = SystemBase().ubuntu_pro_status
+        self.assertNotEqual(result, None)
+
+        expected_result = {
+            "status": "attached",
+            "services": {
+                "esm-apps": {
+                    "entitled": "yes",
+                    "status": "enabled"
+                },
+                "esm-infra": {
+                    "entitled": "yes",
+                    "status": "enabled"
+                },
+                "fips": {
+                    "entitled": "yes",
+                    "status": "n/a"
+                },
+                "fips-updates": {
+                    "entitled": "yes",
+                    "status": "n/a"
+                },
+                "livepatch": {
+                    "entitled": "yes",
+                    "status": "n/a"
+                }
+            },
+            "account": "Canonical - staff",
+            "subscription": "Ubuntu Pro (Apps-only) - Virtual",
+            "technical_support_level": "essential",
+            "valid_until": "3999-12-31 23:59:59"
+        }
+
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('hotsos.core.plugins.system.system.CLIHelper')
+    def test_ubuntu_advantage_not_attached(self, mock_helper):
+        mock_helper.return_value = mock.MagicMock()
+        mock_helper.return_value.pro_status.return_value = UA_NOT_ATTACHED
+        result = SystemBase().ubuntu_pro_status
+        expected_result = {
+            "status": "not-attached"
+        }
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('hotsos.core.plugins.system.system.CLIHelper')
+    def test_ubuntu_pro_invalid(self, mock_helper):
+        mock_helper.return_value = mock.MagicMock()
+        invalid_UBUNTU_PRO = UBUNTU_PRO_ATTACHED
+        invalid_UBUNTU_PRO[0] = "MERVICE          ENTITLED  STATUS    DESCRIPTION" # noqa, pylint: disable=C0301
+        mock_helper.return_value.pro_status.return_value = invalid_UBUNTU_PRO
+        result = SystemBase().ubuntu_pro_status
+        expected_result = {
+            "status": "error"
+        }
+        self.assertEqual(result, expected_result)
 
 
 @utils.load_templated_tests('scenarios/system')


### PR DESCRIPTION
- added the `pro_status` to command catalog.
- added `ubuntu_pro_status` function which parses the `<ua|pro> status` output into a dictionary
- added unit tests