### PR TITLE
Implement build versions

### DIFF
--- a/.github/workflows/snapbuild.py
+++ b/.github/workflows/snapbuild.py
@@ -1,0 +1,20 @@
+on:
+  workflow_run:
+    workflows: [Test]
+    branches: [main]
+    types: [completed]
+name: Build and publish Snap
+jobs:
+  build:
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snapcore/action-build@v1
+      id: build
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: edge

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ if [[ $build_type == snap ]]; then
     snapcraft upload hotsos_1.0_amd64.snap
 elif [[ $build_type == pypi ]]; then
     git rev-parse --short HEAD > hotsos/.repo-info
+    export GIT_BUILD_VERSION=`git describe --tags`
     python3 -m build
     #python3 -m twine upload dist/hotsos*
 fi

--- a/hotsos/__init__.py
+++ b/hotsos/__init__.py
@@ -1,0 +1,7 @@
+import os
+if 'GIT_BUILD_VERSION' in os.environ:
+    __version__ =  os.environ['GIT_BUILD_VERSION']
+elif 'SNAPCRAFT_PART_BUILD' in os.environ:
+    path =  os.environ['SNAPCRAFT_PART_BUILD']
+    __version__ = open(os.path.join(path, 'git_build_version'))
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "hotsos"
 description = "Software analysis toolkit. Define checks in high-level language and leverage library to perform analysis of common Cloud applications."
 requires-python = ">=3.8"
-version = "0.1.12"
+dynamic = ["version"]
 dependencies = [
     'importlib-metadata; python_version >= "3.8"',
     'click',
@@ -21,3 +21,6 @@ dependencies = [
 
 [project.scripts]
 hotsos = "hotsos.cli:main"
+
+[tool.setuptools.dynamic]
+version = {attr = "hotsos.__version__"}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: hotsos
-version: '1.0'
+adopt-info: hotsos-cli 
 summary: Collect application operational information.
 description:
   Software analysis toolkit. Define checks in high-level
@@ -28,6 +28,11 @@ parts:
   hotsos-cli:
     plugin: dump
     source: .
+    override-pull: |
+      tag=$(git describe --tags)
+      count=$(git rev-list $tag.. --count)
+      snapcraftctl set-version $tag+$count
+      snapcraftctl pull
     override-build: |
       rm -rf tests
       git rev-parse --short HEAD > repo-info
@@ -53,6 +58,9 @@ parts:
       - requirements.txt
     build-environment:
       - "CRYPTOGRAPHY_DONT_BUILD_RUST": "1"
+    override-build: |
+      git describe --tag > git_build_version
+      snapcraftctl build
     filesets:
       # need to exclude these files since they are dangling symlinks
       # that cause the snapstore to reject the upload.


### PR DESCRIPTION
Implements build versions. Both snap and pypi builds will use a version generated from git tag. Since the snap is typically built on each push, the version includes a count of the number of commits since the last tagged release.