### PR TITLE
Fix Invalid cross-device link error moving logfile

### DIFF
--- a/hotsos/client.py
+++ b/hotsos/client.py
@@ -342,8 +342,8 @@ class OutputManager(object):
         if log.handlers and isinstance(log.handlers[0], logging.FileHandler):
             log.handlers[0].close()
             # no logging after this point
-            os.rename(log.handlers[0].baseFilename,
-                      os.path.join(output_root, name, 'hotsos.log'))
+            shutil.move(log.handlers[0].baseFilename,
+                        os.path.join(output_root, name, 'hotsos.log'))
 
         return output_root
 


### PR DESCRIPTION
If $TMPDIR and the target output directory are on a different
filesystem, os.rename() may fail with:
[Errno 18] Invalid cross-device link

Use shutil.move instead to support this scenario.
