### PR TITLE
Fix SystemdHelper process detection for Jammy

### DIFF
--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -226,6 +226,12 @@ class SystemdHelper(object):
         ps_filtered = []
         path = os.path.join(HotSOSConfig.data_root,
                             'sys/fs/cgroup/unified/system.slice')
+        if not os.path.exists(path):
+            # Seems that this path changed between Ubuntu Focal and Jammy
+            # releases.
+            path = os.path.join(HotSOSConfig.data_root,
+                                'sys/fs/cgroup/system.slice')
+
         for svc in self.services:
             for svc in self.get_services_expanded(svc):
                 _path = os.path.join(path, "{}.service".format(svc),


### PR DESCRIPTION
The location used to store cgroup info on systemd running processes has changed between Focal and Jammy so we need to support that. This fixes the ability to indentify what processes are associated with a running service unit.

Resolves: #560