### PR TITLE
Fix exception when incorrect date is encountered

### DIFF
--- a/hotsos/core/search.py
+++ b/hotsos/core/search.py
@@ -35,6 +35,7 @@ class SearchConstraintSearchSince(_SearchConstraintSearchSince):
         if not current_date or type(current_date) != str:
             log.error("current date '%s' being provided to search "
                       "constraints is not valid.", current_date)
+            return
 
         super().__init__(*args,
                          current_date=current_date,


### PR DESCRIPTION
Add a return SearchConstraintSearchSince when an invalid date is encountered, else it will throw an exception. Closes issue #562.