### PR TITLE
ceph-mon: Detect empty cluster log

### DIFF
--- a/hotsos/core/host_helpers/filestat.py
+++ b/hotsos/core/host_helpers/filestat.py
@@ -27,6 +27,16 @@ class FileObj(object):
         log.debug("mtime %s=%s", self.filename, mt)
         return mt
 
+    @property
+    def size(self):
+        if not os.path.exists(self.filename):
+            log.debug("size %s - file not found", self.filename)
+            return -1
+
+        size = os.path.getsize(self.filename)
+        log.debug("size %s=%d", self.filename, size)
+        return size
+
 
 class FileFactory(FactoryBase):
     """

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/empty_clog.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/empty_clog.yaml
@@ -1,0 +1,24 @@
+vars:
+  clog_size: '@hotsos.core.host_helpers.filestat.FileFactory.size:var/log/ceph/ceph.log'
+
+checks:
+  empty_clog_size:
+    varops: [[$clog_size], [eq, 0]]
+
+conclusions:
+  empty_clog:
+    decision:
+      - empty_clog_size
+    raises:
+      type: CephTrackerBug
+      bug-id: 55383
+      message: >-
+        The ceph.log file is empty, this is likely because the version of
+        ceph-mon on this node does not re-open
+        /var/log/ceph/{ceph.log,ceph.audit.log} after log rotation. This leaves
+        ceph.log empty and the logs are written to a deleted file. This will prevent
+        you from seeing the cluster log and hotsos checks for information from these
+        logs will not trigger. This issue is fixed in 17.2.5. You can work around
+        this issue temporarily by setting
+        `ceph config set global mon_cluster_log_to_journald false` and running
+        `killall -HUP ceph-mon`.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/empty_clog.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/empty_clog.yaml
@@ -1,0 +1,45 @@
+data-root:
+  files:
+    var/log/ceph/ceph.log: ''
+    sos_commands/systemd/systemctl_list-units: |
+      var-lib-ceph-osd-ceph\x2d0.mount                                            loaded active mounted   /var/lib/ceph/osd/ceph-0                                                      
+      ceph-crash.service                                                          loaded active running   Ceph crash dump collector                                                     
+      ceph-osd@0.service                                                          loaded active running   Ceph object storage daemon osd.0                                              
+      system-ceph\x2dosd.slice                                                    loaded active active    system-ceph\x2dosd.slice                                                      
+      system-ceph\x2dvolume.slice                                                 loaded active active    system-ceph\x2dvolume.slice                                                   
+      ceph-mds.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mds@.service instances at once    
+      ceph-mgr.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mgr@.service instances at once    
+      ceph-mon.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mon@.service instances at once    
+      ceph-osd.target                                                             loaded active active    ceph target allowing to start/stop all ceph-osd@.service instances at once    
+      ceph-radosgw.target                                                         loaded active active    ceph target allowing to start/stop all ceph-radosgw@.service instances at once
+      ceph.target                                                                 loaded active active    ceph target allowing to start/stop all ceph*@.service instances at once  
+    sos_commands/systemd/systemctl_list-unit-files: |
+      ceph-crash.service                              enabled         enabled      
+      ceph-mds@.service                               disabled        enabled      
+      ceph-mgr@.service                               disabled        enabled      
+      ceph-mon.service                                disabled        enabled      
+      ceph-mon@.service                               disabled        enabled      
+      ceph-osd@.service                               indirect        enabled      
+      ceph-radosgw@.service                           disabled        enabled      
+      ceph-volume@.service                            indirect        enabled      
+      ceph-mds.target                                 enabled         enabled      
+      ceph-mgr.target                                 enabled         enabled      
+      ceph-mon.target                                 enabled         enabled      
+      ceph-osd.target                                 enabled         enabled      
+      ceph-radosgw.target                             enabled         enabled      
+      ceph.target                                     enabled         enabled 
+  copy-from-original:
+    - uptime
+    - sos_commands/date/date
+    - sos_commands/dpkg/dpkg_-l
+raised-bugs:
+  https://tracker.ceph.com/issues/55383: >-
+    The ceph.log file is empty, this is likely because the version of
+    ceph-mon on this node does not re-open
+    /var/log/ceph/{ceph.log,ceph.audit.log} after log rotation. This leaves
+    ceph.log empty and the logs are written to a deleted file. This will prevent
+    you from seeing the cluster log and hotsos checks for information from these
+    logs will not trigger. This issue is fixed in 17.2.5. You can work around
+    this issue temporarily by setting
+    `ceph config set global mon_cluster_log_to_journald false` and running
+    `killall -HUP ceph-mon`.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/empty_clog_missing.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/empty_clog_missing.yaml
@@ -1,0 +1,34 @@
+target-name: empty_clog.yaml
+data-root:
+  files:
+    sos_commands/systemd/systemctl_list-units: |
+      var-lib-ceph-osd-ceph\x2d0.mount                                            loaded active mounted   /var/lib/ceph/osd/ceph-0                                                      
+      ceph-crash.service                                                          loaded active running   Ceph crash dump collector                                                     
+      ceph-osd@0.service                                                          loaded active running   Ceph object storage daemon osd.0                                              
+      system-ceph\x2dosd.slice                                                    loaded active active    system-ceph\x2dosd.slice                                                      
+      system-ceph\x2dvolume.slice                                                 loaded active active    system-ceph\x2dvolume.slice                                                   
+      ceph-mds.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mds@.service instances at once    
+      ceph-mgr.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mgr@.service instances at once    
+      ceph-mon.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mon@.service instances at once    
+      ceph-osd.target                                                             loaded active active    ceph target allowing to start/stop all ceph-osd@.service instances at once    
+      ceph-radosgw.target                                                         loaded active active    ceph target allowing to start/stop all ceph-radosgw@.service instances at once
+      ceph.target                                                                 loaded active active    ceph target allowing to start/stop all ceph*@.service instances at once  
+    sos_commands/systemd/systemctl_list-unit-files: |
+      ceph-crash.service                              enabled         enabled      
+      ceph-mds@.service                               disabled        enabled      
+      ceph-mgr@.service                               disabled        enabled      
+      ceph-mon.service                                disabled        enabled      
+      ceph-mon@.service                               disabled        enabled      
+      ceph-osd@.service                               indirect        enabled      
+      ceph-radosgw@.service                           disabled        enabled      
+      ceph-volume@.service                            indirect        enabled      
+      ceph-mds.target                                 enabled         enabled      
+      ceph-mgr.target                                 enabled         enabled      
+      ceph-mon.target                                 enabled         enabled      
+      ceph-osd.target                                 enabled         enabled      
+      ceph-radosgw.target                             enabled         enabled      
+      ceph.target                                     enabled         enabled 
+  copy-from-original:
+    - uptime
+    - sos_commands/date/date
+    - sos_commands/dpkg/dpkg_-l

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/empty_clog_withdata.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/empty_clog_withdata.yaml
@@ -1,0 +1,36 @@
+target-name: empty_clog.yaml
+data-root:
+  files:
+    var/log/ceph/ceph.log: 'test data so the file is not empty'
+    sos_commands/systemd/systemctl_list-units: |
+      var-lib-ceph-osd-ceph\x2d0.mount                                            loaded active mounted   /var/lib/ceph/osd/ceph-0                                                      
+      ceph-crash.service                                                          loaded active running   Ceph crash dump collector                                                     
+      ceph-osd@0.service                                                          loaded active running   Ceph object storage daemon osd.0                                              
+      system-ceph\x2dosd.slice                                                    loaded active active    system-ceph\x2dosd.slice                                                      
+      system-ceph\x2dvolume.slice                                                 loaded active active    system-ceph\x2dvolume.slice                                                   
+      ceph-mds.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mds@.service instances at once    
+      ceph-mgr.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mgr@.service instances at once    
+      ceph-mon.target                                                             loaded active active    ceph target allowing to start/stop all ceph-mon@.service instances at once    
+      ceph-osd.target                                                             loaded active active    ceph target allowing to start/stop all ceph-osd@.service instances at once    
+      ceph-radosgw.target                                                         loaded active active    ceph target allowing to start/stop all ceph-radosgw@.service instances at once
+      ceph.target                                                                 loaded active active    ceph target allowing to start/stop all ceph*@.service instances at once  
+    sos_commands/systemd/systemctl_list-unit-files: |
+      ceph-crash.service                              enabled         enabled      
+      ceph-mds@.service                               disabled        enabled      
+      ceph-mgr@.service                               disabled        enabled      
+      ceph-mon.service                                disabled        enabled      
+      ceph-mon@.service                               disabled        enabled      
+      ceph-osd@.service                               indirect        enabled      
+      ceph-radosgw@.service                           disabled        enabled      
+      ceph-volume@.service                            indirect        enabled      
+      ceph-mds.target                                 enabled         enabled      
+      ceph-mgr.target                                 enabled         enabled      
+      ceph-mon.target                                 enabled         enabled      
+      ceph-osd.target                                 enabled         enabled      
+      ceph-radosgw.target                             enabled         enabled      
+      ceph.target                                     enabled         enabled 
+  copy-from-original:
+    - uptime
+    - sos_commands/date/date
+    - sos_commands/dpkg/dpkg_-l
+raised-bugs: {}


### PR DESCRIPTION
Detect and report when the ceph cluster log /var/log/ceph/ceph.log is
empty, likely due to Ceph log rotation Bug #55383

https://tracker.ceph.com/issues/55383
