### PR TITLE
Parse datetimes as UTC

### DIFF
--- a/hotsos/core/plugins/openstack/common.py
+++ b/hotsos/core/plugins/openstack/common.py
@@ -182,7 +182,7 @@ class OpenstackChecksBase(OpenstackBase, plugintools.PluginPartBase):
         if self.release_name != 'unknown':
             eol = OST_EOL_INFO.get(self.release_name)
             if eol is not None:
-                today = datetime.fromtimestamp(int(CLIHelper().date()))
+                today = datetime.utcfromtimestamp(int(CLIHelper().date()))
                 delta = (eol - today).days
                 return delta
             else:

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -915,7 +915,7 @@ class CephChecksBase(StorageBase):
     def days_to_eol(self):
         if self.release_name != 'unknown':
             eol = CEPH_EOL_INFO[self.release_name]
-            today = datetime.fromtimestamp(int(CLIHelper().date()))
+            today = datetime.utcfromtimestamp(int(CLIHelper().date()))
             delta = (eol - today).days
             return delta
 


### PR DESCRIPTION
Parse datetimes as UTC so that they are read consistently on different
systems. Without this, in some timezones (e.g. GMT+8 after 2PM) running
the test suite results in a failure because ceph is EOL in 2999 days
instead of 3000 days.
