### PR TITLE
[Ceph] Check if civetweb is being as rgw frontend

### DIFF
--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -84,6 +84,10 @@ class CephMgrError(IssueTypeBase):
     pass
 
 
+class CephRGWWarning(IssueTypeBase):
+    pass
+
+
 class CephDaemonWarning(IssueTypeBase):
     pass
 

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -316,6 +316,21 @@ class CephCrushMap(object):
         pools = self.ceph_report['osdmap']['pools']
         return [p for p in pools if p.get('pg_autoscale_mode') != 'on']
 
+    @cached_property
+    def is_rgw_using_civetweb(self):
+        if not self.ceph_report:
+            return []
+
+        try:
+            rgws = self.ceph_report['servicemap']['services']['rgw']['daemons']
+            for _, outer_d in rgws.items():
+                if isinstance(outer_d, dict):
+                    if outer_d['metadata']['frontend_type#0'] == 'civetweb':
+                        return True
+        except(ValueError, KeyError):
+            pass
+        return False
+
 
 class CephCluster(object):
     OSD_META_LIMIT_PERCENT = 5

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/rgw_frontend.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/rgw_frontend.yaml
@@ -1,0 +1,31 @@
+checks:
+  node_is_ceph_rgw_and_beast_supported_version:
+    apt:
+      librgw2:
+        - min: 14.2.0
+          max: 100.0.0
+  rgw_outdated_frontend:
+    config:
+      handler: hotsos.core.plugins.storage.ceph.CephConfig
+      assertions:
+        - key: rgw_frontends
+          ops: [[ne, null]]
+        - key: rgw_frontends
+          ops: [[contains, civetweb]]
+  is_rgw_using_civetweb:
+    property:
+      path: hotsos.core.plugins.storage.ceph.CephCrushMap.is_rgw_using_civetweb
+conclusions:
+  rgw_outdated_frontend:
+    decision:
+      - node_is_ceph_rgw_and_beast_supported_version
+      - or:
+        - is_rgw_using_civetweb
+        - rgw_outdated_frontend
+    raises:
+      type: CephRGWWarning
+      message: >-
+        Ceph RGW is using the 'civetweb' frontend. You are recommended to switch to 'beast'
+        which provides better performance (civetweb has been removed from Ceph Pacific
+        (16.2.0) onwards). Upgrading the ceph-radosgw charm (from stable/21.10 or newer) will
+        switch to use the beast frontend.

--- a/hotsos/defs/scenarios/storage/ceph/ceph-rgw/rgw_frontend_rgw.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-rgw/rgw_frontend_rgw.yaml
@@ -1,0 +1,1 @@
+../ceph-mon/rgw_frontend.yaml

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/rgw_frontend_mon.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/rgw_frontend_mon.yaml
@@ -1,0 +1,55 @@
+target-name: rgw_frontend.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii  librgw2  15.2.14-0ubuntu0.20.04.1   amd64
+    sos_commands/ceph_mon/ceph_report: |
+      { "servicemap": {
+        "epoch": 448225,
+        "modified": "2023-03-06T09:55:01.348690+0000",
+        "services": {
+            "rgw": {
+                "daemons": {
+                    "summary": "",
+                    "hostname_xyz": {
+                        "start_epoch": 448150,
+                        "start_stamp": "2023-03-06T06:00:18.992140+0000",
+                        "gid": 572814700,
+                        "addr": "172.25.80.91:0/2078728304",
+                        "metadata": {
+                            "arch": "x86_64",
+                            "ceph_release": "octopus",
+                            "ceph_version": "ceph version 15.2.14 (cd3bb7e87a2f62c1b862ff3fd8b1eec13391a5be) octopus (stable)",
+                            "ceph_version_short": "15.2.14",
+                            "cpu": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+                            "distro": "ubuntu",
+                            "distro_description": "Ubuntu 20.04.3 LTS",
+                            "distro_version": "20.04",
+                            "frontend_config#0": "civetweb port=423",
+                            "frontend_type#0": "civetweb",
+                            "hostname": "hostname_xyz",
+                            "kernel_description": "#100-Ubuntu SMP Fri Sep 24 14:50:10 UTC 2021",
+                            "kernel_version": "5.4.0-89-generic",
+                            "mem_swap_kb": "31248380",
+                            "mem_total_kb": "196685076",
+                            "num_handles": "1",
+                            "os": "Linux",
+                            "pid": "2617246",
+                            "zone_id": "ec68b007-968b-4e1a-a928-27f7aff4a558",
+                            "zone_name": "xyz",
+                            "zonegroup_id": "e8fdad5a-e096-4eb0-b3bf-844d65b15a8b",
+                            "zonegroup_name": "default"
+                        },
+                        "task_status": {}
+                    }}}}}}
+
+  copy-from-original:
+    - sos_commands/date/date
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+raised-issues:
+  CephRGWWarning: >-
+    Ceph RGW is using the 'civetweb' frontend. You are recommended to switch to 'beast'
+    which provides better performance (civetweb has been removed from Ceph Pacific
+    (16.2.0) onwards). Upgrading the ceph-radosgw charm (from stable/21.10 or newer) will
+    switch to use the beast frontend.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-rgw/rgw_frontend_conf.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-rgw/rgw_frontend_conf.yaml
@@ -1,0 +1,19 @@
+target-name: rgw_frontend.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii  librgw2  15.2.14-0ubuntu0.20.04.1   amd64
+    etc/ceph/ceph.conf: |
+      [client.rgw.xyz]
+      host = xyz
+      rgw frontends = civetweb port=423
+  copy-from-original:
+    - sos_commands/date/date
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+raised-issues:
+  CephRGWWarning: >-
+    Ceph RGW is using the 'civetweb' frontend. You are recommended to switch to 'beast'
+    which provides better performance (civetweb has been removed from Ceph Pacific
+    (16.2.0) onwards). Upgrading the ceph-radosgw charm (from stable/21.10 or newer) will
+    switch to use the beast frontend.


### PR DESCRIPTION
beast is the default since Nautilus and is the recommended frontend if supported. If civetweb is still used, it either needs to switch the frontend or upgrade the rgw charm if the cluster is managed by Juju.

Fixed #537.