### PR TITLE
os-exceptions: perform ost warn/exceptions search with hyperscan

### DIFF
--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -240,11 +240,14 @@ def main():
                   help='Path to yaml definitions (ydefs).')
     @click.option('--version', '-v', default=False, is_flag=True,
                   help='Show the version.')
+    @click.option('--use-hyperscan', default=True, is_flag=True,
+                  help="Use hyperscan/vectorscan instead of python's `re` for "
+                       "searches.")
     @set_plugin_options
     @click.argument('data_root', required=False, type=click.Path(exists=True))
-    def cli(data_root, version, defs_path, templates_path, all_logs, debug,
-            quiet, save, output_format, html_escape, short, very_short,
-            force, event_tally_granularity, max_logrotate_depth,
+    def cli(data_root, use_hyperscan, version, defs_path, templates_path,
+            all_logs, debug, quiet, save, output_format, html_escape, short,
+            very_short, force, event_tally_granularity, max_logrotate_depth,
             max_parallel_tasks, list_plugins, machine_readable, output_path,
             command_timeout, sos_unpack_dir, scenario, event, **kwargs):
         """
@@ -288,7 +291,8 @@ def main():
                   'machine_readable': machine_readable,
                   'debug_mode': debug,
                   'scenario_filter': scenario,
-                  'event_filter': event}
+                  'event_filter': event,
+                  'use_hyperscan': use_hyperscan}
         HotSOSConfig.set(**config)
 
         with LoggingManager() as logmanager:

--- a/hotsos/core/config.py
+++ b/hotsos/core/config.py
@@ -126,6 +126,11 @@ class HotSOSConfigOpts(ConfigOptGroupBase):
                            default_value={'propertree': 'WARNING',
                                           'searchkit': 'DEBUG'},
                            value_type=dict))
+        self.add(ConfigOpt(name='use_hyperscan',
+                           description=("Use hyperscan/vectorscan for "
+                                        "all search operations instead of "
+                                        "Python's `re`."),
+                           default_value=True, value_type=bool))
 
     @property
     def name(self):

--- a/hotsos/core/host_helpers/apparmor.py
+++ b/hotsos/core/host_helpers/apparmor.py
@@ -1,11 +1,9 @@
 from functools import cached_property
 
-# NOTE: we import direct from searchkit rather than hotsos.core.search to
-#       avoid circular dependency issues.
-from searchkit import (
+from hotsos.core.search import (
     FileSearcher,
     SearchDef,
-    SequenceSearchDef,
+    SequenceSearchDef
 )
 from hotsos.core.factory import FactoryBase
 from hotsos.core.host_helpers.cli import CLIHelperFile

--- a/hotsos/core/host_helpers/network.py
+++ b/hotsos/core/host_helpers/network.py
@@ -2,12 +2,10 @@ import copy
 import os
 import re
 
-# NOTE: we import direct from searchkit rather than hotsos.core.search to
-#       avoid circular dependency issues.
-from searchkit import (
+from hotsos.core.search import (
     FileSearcher,
     SearchDef,
-    SequenceSearchDef,
+    SequenceSearchDef
 )
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers.cli import CLIHelper, CLIHelperFile

--- a/hotsos/core/search.py
+++ b/hotsos/core/search.py
@@ -3,13 +3,21 @@ import os
 from searchkit import (   # noqa: F403,F401, pylint: disable=W0611
     FileSearcher as _FileSearcher,
     ResultFieldInfo,
-    SearchDef,
     SequenceSearchDef,
+    HyperscanSearchDef,
 )
+from hotsos.core.config import HotSOSConfig
+if HotSOSConfig.use_hyperscan:
+    from searchkit import(   # noqa: F403,F401, pylint: disable=W0611
+        HyperscanSearchDef as SearchDef
+    ) 
+else:
+    from searchkit import (   # noqa: F403,F401, pylint: disable=W0611
+        SearchDef
+    )
 from searchkit.constraints import (
     SearchConstraintSearchSince as _SearchConstraintSearchSince
 )
-from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers.cli import CLIHelper
 from hotsos.core.log import log
 
@@ -50,7 +58,6 @@ class SearchConstraintSearchSince(_SearchConstraintSearchSince):
             log.info("skipping line constraint since data_root is not a "
                      "sosreport therefore files may be changing")
             return True
-
         return super().apply_to_line(*args, **kwargs)
 
     def apply_to_file(self, *args, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2
 progress
 propertree >= 1.1.0
 pyyaml
-searchkit >= 0.4.1.post5
+searchkit@git+https://github.com/mustafakemalgilor/searchkit.git@enhancement/hyperscan-search-def
 simplejson
 sphinx>=4.3.2
 python-dateutil


### PR DESCRIPTION
this is a proof-of-concept work. using "hyperscan" improves the runtime performance of hotsos by 5.32x(*) whilst keeping the functionality intact. 

before: 36m24,760s
after: 6m50,791s

(*): in a known large sosreport file