### PR TITLE
Fix ceph-mon version test

### DIFF
--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -658,7 +658,8 @@ class CephCluster(object):
                 if daemon_type in exclude_daemons:
                     continue
 
-            unique_versions[daemon_type] = list(set(versions[daemon_type]))
+            unique_versions[daemon_type] = sorted(
+                list(set(versions[daemon_type])))
 
         return unique_versions
 

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -239,8 +239,8 @@ class TestCoreCephCluster(CephMonTestsBase):
                              CEPH_VERSIONS_MISMATCHED_MINOR_MONS_UNALIGNED})
     def test_ceph_daemon_versions_unique_not(self):
         result = {'mgr': ['15.2.11'],
-                  'mon': ['15.2.11',
-                          '15.2.10'],
+                  'mon': ['15.2.10',
+                          '15.2.11'],
                   'osd': ['15.2.11',
                           '15.2.13']}
         cluster = ceph_core.CephCluster()


### PR DESCRIPTION
This test is failing on Python 3.11 because of a sorting issue.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>