### PR TITLE
Fix test for masked services

### DIFF
--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -175,7 +175,7 @@ class SystemdHelper(ServiceManagerBase):
         if not self.services:
             return []
 
-        return self._service_info.get('masked', [])
+        return sorted(self._service_info.get('masked', []))
 
     def get_services_expanded(self, name):
         _expanded = []

--- a/hotsos/core/plugins/openstack/common.py
+++ b/hotsos/core/plugins/openstack/common.py
@@ -215,7 +215,7 @@ class OpenstackChecksBase(OpenstackBase, plugintools.PluginPartBase):
             return []
 
         expected_masked = self.ost_projects.default_masked_services
-        return list(masked.difference(expected_masked))
+        return sorted(list(masked.difference(expected_masked)))
 
     @cached_property
     def openstack_installed(self):

--- a/hotsos/core/plugins/openstack/openstack.py
+++ b/hotsos/core/plugins/openstack/openstack.py
@@ -473,7 +473,7 @@ class OSTProjectCatalog(object):
         for p in self.all.values():
             masked += p.systemd_masked_services
 
-        return masked
+        return sorted(masked)
 
     def add(self, name, *args, **kwargs):
         self._projects[name] = OSTProject(name, *args, **kwargs)

--- a/hotsos/defs/tests/scenarios/openstack/systemd_masked_services.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/systemd_masked_services.yaml
@@ -1,21 +1,21 @@
 data-root:
   files:
     sos_commands/systemd/systemctl_list-unit-files: |
-      neutron-dhcp-agent.service                masked          enabled      
-      neutron-l3-agent.service                  masked          enabled      
-      neutron-metadata-agent.service            masked          enabled      
-      neutron-metering-agent.service            masked          enabled      
-      neutron-openvswitch-agent.service         masked          enabled      
+      neutron-dhcp-agent.service                masked          enabled
+      neutron-l3-agent.service                  masked          enabled
+      neutron-metadata-agent.service            masked          enabled
+      neutron-metering-agent.service            masked          enabled
+      neutron-openvswitch-agent.service         masked          enabled
       neutron-ovs-cleanup.service               enabled         enabled
-      apache-htcacheclean.service               disabled       
-      apache-htcacheclean@.service              disabled       
-      apache2.service                           masked        
-      apache2@.service                          disabled       
-      jujud-unit-octavia-0.service              enabled        
-      jujud-unit-octavia-hacluster-5.service    enabled        
-      octavia-api.service                       masked         
-      octavia-health-manager.service            enabled        
-      octavia-housekeeping.service              enabled        
+      apache-htcacheclean.service               disabled
+      apache-htcacheclean@.service              disabled
+      apache2.service                           masked
+      apache2@.service                          disabled
+      jujud-unit-octavia-0.service              enabled
+      jujud-unit-octavia-hacluster-5.service    enabled
+      octavia-api.service                       masked
+      octavia-health-manager.service            enabled
+      octavia-housekeeping.service              enabled
       octavia-worker.service                    enabled
 mock:
   patch:
@@ -24,8 +24,7 @@ mock:
         new: true
 raised-issues:
   OpenstackWarning: >-
-    The following Openstack systemd services are masked:
-    neutron-dhcp-agent, neutron-metering-agent,
-    neutron-metadata-agent, apache2, neutron-openvswitch-agent,
-    neutron-l3-agent. Please ensure that this is intended
-    otherwise these services may be unavailable.
+    The following Openstack systemd services are masked: apache2,
+    neutron-dhcp-agent, neutron-l3-agent, neutron-metadata-agent,
+    neutron-metering-agent, neutron-openvswitch-agent. Please ensure that this
+    is intended otherwise these services may be unavailable.


### PR DESCRIPTION
This test fails with Python 3.11 because of a difference in the sort
order.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>