### PR TITLE
Kernlog search constraints

### DIFF
--- a/hotsos/core/plugins/juju/common.py
+++ b/hotsos/core/plugins/juju/common.py
@@ -1,11 +1,10 @@
 import os
 
+from searchkit.constraints import TimestampMatcherBase
+
 from hotsos.core import plugintools
 from hotsos.core.host_helpers import PebbleHelper, SystemdHelper
 from hotsos.core.plugins.juju.resources import JujuBase
-
-# matches date and time at start if log lines
-JUJU_UNIT_LOGS_TS_EXPR = r"^([\d-]+)\s+([\d:]+)"
 
 SVC_VALID_SUFFIX = r'[0-9a-zA-Z-_]*'
 JUJU_SVC_EXPRS = [r'mongod{}'.format(SVC_VALID_SUFFIX),
@@ -13,6 +12,20 @@ JUJU_SVC_EXPRS = [r'mongod{}'.format(SVC_VALID_SUFFIX),
                   # catch juju-db but filter out processes with juju-db in
                   # their args list.
                   r'(?:^|[^\s])juju-db{}'.format(SVC_VALID_SUFFIX)]
+
+
+class JujuTimestampMatcher(TimestampMatcherBase):
+    """
+    NOTE: remember to update
+          hotsos.core.ycheck.engine.properties.search.CommonTimestampMatcher
+          if necessary.
+    """
+
+    @property
+    def patterns(self):
+        # matches date and time at start of log lines
+        return [r'^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})+\s+'
+                r'(?P<hours>\d{2}):(?P<minutes>\d{2}):(?P<seconds>\d+)']
 
 
 class JujuChecksBase(plugintools.PluginPartBase, JujuBase):

--- a/hotsos/core/plugins/openstack/openstack.py
+++ b/hotsos/core/plugins/openstack/openstack.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import os
 
+from searchkit.constraints import TimestampMatcherBase
+
 from hotsos.core import host_helpers
 from hotsos.core.log import log
 from hotsos.core.config import HotSOSConfig
@@ -233,7 +235,18 @@ OST_EXCEPTIONS = {'barbican': BARBICAN_EXCEPTIONS + CASTELLAN_EXCEPTIONS,
                   'placement': PLACEMENT_EXCEPTIONS,
                   }
 
-OPENSTACK_LOGS_TS_EXPR = r"^([\d-]+\s+[\d:]+)"
+
+class OpenstackTimestampMatcher(TimestampMatcherBase):
+    """
+    NOTE: remember to update
+          hotsos.core.ycheck.engine.properties.search.CommonTimestampMatcher
+          if necessary.
+    """
+
+    @property
+    def patterns(self):
+        return [r'^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})+\s+'
+                r'(?P<hours>\d{2}):(?P<minutes>\d{2}):(?P<seconds>\d+)']
 
 
 class OpenstackConfig(host_helpers.SectionalConfigBase):

--- a/hotsos/core/plugins/openvswitch/common.py
+++ b/hotsos/core/plugins/openvswitch/common.py
@@ -1,3 +1,5 @@
+from searchkit.constraints import TimestampMatcherBase
+
 from hotsos.core import plugintools
 from hotsos.core.host_helpers import (
     APTPackageHelper,
@@ -22,7 +24,19 @@ OVS_PKGS_DEPS = ['libc-bin',
                  'openvswitch-switch-dpdk',
                  ]
 PY_CLIENT_PREFIX = r"python3?-{}\S*"
-OPENVSWITCH_LOGS_TS_EXPR = r"^([0-9-]+)T([0-9:]+)"
+
+
+class OVSTimestampMatcher(TimestampMatcherBase):
+    """
+    NOTE: remember to update
+          hotsos.core.ycheck.engine.properties.search.CommonTimestampMatcher
+          if necessary.
+    """
+
+    @property
+    def patterns(self):
+        return [(r'^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T'
+                 r'(?P<hours>\d{2}):(?P<minutes>\d{2}):(?P<seconds>\d+)')]
 
 
 class OpenvSwitchChecksBase(plugintools.PluginPartBase):

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -5,6 +5,8 @@ import subprocess
 
 from datetime import datetime
 
+from searchkit.constraints import TimestampMatcherBase
+
 from hotsos.core.factory import FactoryBase
 from hotsos.core.log import log
 from hotsos.core.utils import (
@@ -34,8 +36,6 @@ from hotsos.core.search import (
 )
 from hotsos.core.plugins.kernel.net import Lsof
 
-
-CEPH_LOGS_TS_EXPR = r"^([\d-]+)[\sT]([\d:]+)"
 CEPH_SERVICES_EXPRS = [r"ceph-[a-z0-9-]+",
                        r"rados[a-z0-9-:]+"]
 CEPH_PKGS_CORE = [r"ceph",
@@ -89,6 +89,19 @@ def csv_to_set(f):
         return set([])
 
     return csv_to_set_inner
+
+
+class CephTimestampMatcher(TimestampMatcherBase):
+    """
+    NOTE: remember to update
+          hotsos.core.ycheck.engine.properties.search.CommonTimestampMatcher
+          if necessary.
+    """
+
+    @property
+    def patterns(self):
+        return [r'^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})[\sT]'
+                r'(?P<hours>\d{2}):(?P<minutes>\d{2}):(?P<seconds>\d+)']
 
 
 class CephConfig(SectionalConfigBase):

--- a/hotsos/core/ycheck/engine/properties/checks.py
+++ b/hotsos/core/ycheck/engine/properties/checks.py
@@ -17,7 +17,7 @@ from hotsos.core.ycheck.engine.properties.requires.requires import (
 )
 from hotsos.core.ycheck.engine.properties.search import (
     YPropertySearch,
-    COMMON_LOG_DATETIME_EXPRS,
+    CommonTimestampMatcher,
 )
 from hotsos.core.ycheck.engine.properties.input import YPropertyInput
 
@@ -162,7 +162,7 @@ class YPropertyChecks(YPropertyOverrideBase):
         else:
             hours = 24
 
-        c = SearchConstraintSearchSince(exprs=COMMON_LOG_DATETIME_EXPRS,
+        c = SearchConstraintSearchSince(ts_matcher_cls=CommonTimestampMatcher,
                                         hours=hours)
         s = FileSearcher(constraint=c)
         # first load all the search definitions into the searcher

--- a/hotsos/defs/tests/scenarios/kernel/kernlog_calltrace_any.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/kernlog_calltrace_any.yaml
@@ -2,17 +2,17 @@ target-name: kernlog_calltrace.yaml
 data-root:
   files:
     var/log/kern.log: |
-      May  6 10:49:21 tututu kernel: [ 4965.415911] CPU: 1 PID: 4465 Comm: insmod Tainted: P           OE   4.13.0-rc5 #1
-      May  6 10:49:21 tututu kernel: [ 4965.415912] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1.fc26 04/01/2014
-      May  6 10:49:21 tututu kernel: [ 4965.415913] Call Trace:
-      May  6 10:49:21 tututu kernel: [ 4965.415920]  dump_stack+0x63/0x8b
-      May  6 10:49:21 tututu kernel: [ 4965.415923]  do_init_module+0x8d/0x1e9
-      May  6 10:49:21 tututu kernel: [ 4965.415926]  load_module+0x21bd/0x2b10
-      May  6 10:49:21 tututu kernel: [ 4965.415929]  SYSC_finit_module+0xfc/0x120
-      May  6 10:49:21 tututu kernel: [ 4965.415931]  ? SYSC_finit_module+0xfc/0x120
-      May  6 10:49:21 tututu kernel: [ 4965.415934]  SyS_finit_module+0xe/0x10
-      May  6 10:49:21 tututu kernel: [ 4965.415937]  entry_SYSCALL_64_fastpath+0x1a/0xa5
-      May  6 10:49:21 tututu kernel: [ 4965.415939] RIP: 0033:0x7fab36d717a9
+      Feb 04 10:49:21 tututu kernel: [ 4965.415911] CPU: 1 PID: 4465 Comm: insmod Tainted: P           OE   4.13.0-rc5 #1
+      Feb 04 10:49:21 tututu kernel: [ 4965.415912] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1.fc26 04/01/2014
+      Feb 04 10:49:21 tututu kernel: [ 4965.415913] Call Trace:
+      Feb 04 10:49:21 tututu kernel: [ 4965.415920]  dump_stack+0x63/0x8b
+      Feb 04 10:49:21 tututu kernel: [ 4965.415923]  do_init_module+0x8d/0x1e9
+      Feb 04 10:49:21 tututu kernel: [ 4965.415926]  load_module+0x21bd/0x2b10
+      Feb 04 10:49:21 tututu kernel: [ 4965.415929]  SYSC_finit_module+0xfc/0x120
+      Feb 04 10:49:21 tututu kernel: [ 4965.415931]  ? SYSC_finit_module+0xfc/0x120
+      Feb 04 10:49:21 tututu kernel: [ 4965.415934]  SyS_finit_module+0xe/0x10
+      Feb 04 10:49:21 tututu kernel: [ 4965.415937]  entry_SYSCALL_64_fastpath+0x1a/0xa5
+      Feb 04 10:49:21 tututu kernel: [ 4965.415939] RIP: 0033:0x7fab36d717a9
 raised-issues:
   KernelError: >-
     1 reports of stacktraces in kern.log - please check.

--- a/hotsos/defs/tests/scenarios/kernel/kernlog_calltrace_bcache_deadlock.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/kernlog_calltrace_bcache_deadlock.yaml
@@ -2,80 +2,80 @@ target-name: kernlog_calltrace.yaml
 data-root:
   files:
     var/log/kern.log: |
-      Jun 11 06:51:39 bronzor kernel: [  725.795102] INFO: task bcache-register:2330 blocked for more than 120 seconds.
-      Jun 11 06:51:39 bronzor kernel: [  726.146000]       Not tainted 4.15.0-176-generic #185
-      Jun 11 06:51:39 bronzor kernel: [  726.391338] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
-      Jun 11 06:51:39 bronzor kernel: [  726.771988] bcache-register D    0  2330   2328 0x00000320
-      Jun 11 06:51:39 bronzor kernel: [  726.771991] Call Trace:
-      Jun 11 06:51:39 bronzor kernel: [  726.771997]  __schedule+0x24e/0x890
-      Jun 11 06:51:39 bronzor kernel: [  726.771999]  schedule+0x2c/0x80
-      Jun 11 06:51:39 bronzor kernel: [  726.772024]  closure_sync+0x18/0x90 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772031]  bch_journal+0x123/0x380 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772036]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772042]  bch_journal_meta+0x47/0x70 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772045]  ? __switch_to+0x309/0x4e0
-      Jun 11 06:51:39 bronzor kernel: [  726.772046]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772047]  ? __switch_to_asm+0x41/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772048]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772050]  ? __schedule+0x256/0x890
-      Jun 11 06:51:39 bronzor kernel: [  726.772051]  ? _cond_resched+0x19/0x40
-      Jun 11 06:51:39 bronzor kernel: [  726.772053]  ? mutex_lock+0x12/0x40
-      Jun 11 06:51:39 bronzor kernel: [  726.772057]  bch_btree_set_root+0x1c2/0x1f0 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772074]  btree_split+0x69a/0x700 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772077]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772080]  ? __switch_to_asm+0x41/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772082]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772086]  ? __switch_to+0x309/0x4e0
-      Jun 11 06:51:39 bronzor kernel: [  726.772089]  ? __switch_to+0x309/0x4e0
-      Jun 11 06:51:39 bronzor kernel: [  726.772091]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772092]  ? __switch_to_asm+0x41/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772093]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772096]  bch_btree_insert_node+0x340/0x410 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772100]  btree_split+0x551/0x700 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772103]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772105]  ? __switch_to_asm+0x41/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772107]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772111]  ? __switch_to+0x309/0x4e0
-      Jun 11 06:51:39 bronzor kernel: [  726.772114]  ? __switch_to+0x309/0x4e0
-      Jun 11 06:51:39 bronzor kernel: [  726.772115]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772129]  ? __switch_to_asm+0x41/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772130]  ? __switch_to_asm+0x35/0x70
-      Jun 11 06:51:39 bronzor kernel: [  726.772137]  bch_btree_insert_node+0x340/0x410 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772144]  btree_insert_fn+0x24/0x40 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772151]  bch_btree_map_nodes_recurse+0x54/0x190 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772159]  ? bch_btree_insert_check_key+0x1f0/0x1f0 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772164]  ? _cond_resched+0x19/0x40
-      Jun 11 06:51:39 bronzor kernel: [  726.772167]  ? down_write+0x12/0x40
-      Jun 11 06:51:39 bronzor kernel: [  726.772175]  ? bch_btree_node_get+0x80/0x260 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772179]  ? up_read+0x30/0x30
-      Jun 11 06:51:39 bronzor kernel: [  726.772185]  bch_btree_map_nodes_recurse+0x112/0x190 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772190]  ? bch_btree_insert_check_key+0x1f0/0x1f0 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772198]  __bch_btree_map_nodes+0xf0/0x150 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772205]  ? bch_btree_insert_check_key+0x1f0/0x1f0 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772212]  bch_btree_insert+0xf9/0x170 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772215]  ? wait_woken+0x80/0x80
-      Jun 11 06:51:39 bronzor kernel: [  726.772222]  bch_journal_replay+0x220/0x2f0 [bcache]
-      Jun 11 06:51:39 bronzor kernel: [  726.772224]  ? try_to_wake_up+0x59/0x4b0
-      Jun 11 06:51:39 bronzor kernel: [  726.772229]  ? kthread_create_on_node+0x46/0x70
-      Jun 11 06:51:40 bronzor kernel: [  726.772238]  run_cache_set+0x5c6/0x970 [bcache]
-      Jun 11 06:51:40 bronzor kernel: [  726.772246]  register_bcache+0xd04/0x1110 [bcache]
-      Jun 11 06:51:40 bronzor kernel: [  726.772253]  ? register_bcache+0xd04/0x1110 [bcache]
-      Jun 11 06:51:40 bronzor kernel: [  726.772256]  kobj_attr_store+0x12/0x20
-      Jun 11 06:51:40 bronzor kernel: [  726.772257]  ? kobj_attr_store+0x12/0x20
-      Jun 11 06:51:40 bronzor kernel: [  726.772259]  sysfs_kf_write+0x3c/0x50
-      Jun 11 06:51:40 bronzor kernel: [  726.772261]  kernfs_fop_write+0x125/0x1a0
-      Jun 11 06:51:40 bronzor kernel: [  726.772263]  __vfs_write+0x1b/0x40
-      Jun 11 06:51:40 bronzor kernel: [  726.772265]  vfs_write+0xb1/0x1a0
-      Jun 11 06:51:40 bronzor kernel: [  726.772267]  SyS_write+0x5c/0xe0
-      Jun 11 06:51:40 bronzor kernel: [  726.772270]  do_syscall_64+0x73/0x130
-      Jun 11 06:51:40 bronzor kernel: [  726.772273]  entry_SYSCALL_64_after_hwframe+0x41/0xa6
-      Jun 11 06:51:40 bronzor kernel: [  726.772275] RIP: 0033:0x7efdb30af104
-      Jun 11 06:51:40 bronzor kernel: [  726.772276] RSP: 002b:00007fff9649a2b8 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
-      Jun 11 06:51:40 bronzor kernel: [  726.772278] RAX: ffffffffffffffda RBX: 000000000000000b RCX: 00007efdb30af104
-      Jun 11 06:51:40 bronzor kernel: [  726.772279] RDX: 000000000000000b RSI: 00005625a6c2c260 RDI: 0000000000000003
-      Jun 11 06:51:40 bronzor kernel: [  726.772281] RBP: 00005625a6c2c260 R08: 0000000000000000 R09: 000000000000000a
-      Jun 11 06:51:40 bronzor kernel: [  726.772282] R10: 00000000fffffff6 R11: 0000000000000246 R12: 00007fff9649a350
-      Jun 11 06:51:40 bronzor kernel: [  726.772283] R13: 000000000000000b R14: 00007efdb33872a0 R15: 00007efdb3386760
+      Feb 04 06:51:39 bronzor kernel: [  725.795102] INFO: task bcache-register:2330 blocked for more than 120 seconds.
+      Feb 04 06:51:39 bronzor kernel: [  726.146000]       Not tainted 4.15.0-176-generic #185
+      Feb 04 06:51:39 bronzor kernel: [  726.391338] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+      Feb 04 06:51:39 bronzor kernel: [  726.771988] bcache-register D    0  2330   2328 0x00000320
+      Feb 04 06:51:39 bronzor kernel: [  726.771991] Call Trace:
+      Feb 04 06:51:39 bronzor kernel: [  726.771997]  __schedule+0x24e/0x890
+      Feb 04 06:51:39 bronzor kernel: [  726.771999]  schedule+0x2c/0x80
+      Feb 04 06:51:39 bronzor kernel: [  726.772024]  closure_sync+0x18/0x90 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772031]  bch_journal+0x123/0x380 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772036]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772042]  bch_journal_meta+0x47/0x70 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772045]  ? __switch_to+0x309/0x4e0
+      Feb 04 06:51:39 bronzor kernel: [  726.772046]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772047]  ? __switch_to_asm+0x41/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772048]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772050]  ? __schedule+0x256/0x890
+      Feb 04 06:51:39 bronzor kernel: [  726.772051]  ? _cond_resched+0x19/0x40
+      Feb 04 06:51:39 bronzor kernel: [  726.772053]  ? mutex_lock+0x12/0x40
+      Feb 04 06:51:39 bronzor kernel: [  726.772057]  bch_btree_set_root+0x1c2/0x1f0 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772074]  btree_split+0x69a/0x700 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772077]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772080]  ? __switch_to_asm+0x41/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772082]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772086]  ? __switch_to+0x309/0x4e0
+      Feb 04 06:51:39 bronzor kernel: [  726.772089]  ? __switch_to+0x309/0x4e0
+      Feb 04 06:51:39 bronzor kernel: [  726.772091]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772092]  ? __switch_to_asm+0x41/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772093]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772096]  bch_btree_insert_node+0x340/0x410 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772100]  btree_split+0x551/0x700 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772103]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772105]  ? __switch_to_asm+0x41/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772107]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772111]  ? __switch_to+0x309/0x4e0
+      Feb 04 06:51:39 bronzor kernel: [  726.772114]  ? __switch_to+0x309/0x4e0
+      Feb 04 06:51:39 bronzor kernel: [  726.772115]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772129]  ? __switch_to_asm+0x41/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772130]  ? __switch_to_asm+0x35/0x70
+      Feb 04 06:51:39 bronzor kernel: [  726.772137]  bch_btree_insert_node+0x340/0x410 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772144]  btree_insert_fn+0x24/0x40 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772151]  bch_btree_map_nodes_recurse+0x54/0x190 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772159]  ? bch_btree_insert_check_key+0x1f0/0x1f0 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772164]  ? _cond_resched+0x19/0x40
+      Feb 04 06:51:39 bronzor kernel: [  726.772167]  ? down_write+0x12/0x40
+      Feb 04 06:51:39 bronzor kernel: [  726.772175]  ? bch_btree_node_get+0x80/0x260 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772179]  ? up_read+0x30/0x30
+      Feb 04 06:51:39 bronzor kernel: [  726.772185]  bch_btree_map_nodes_recurse+0x112/0x190 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772190]  ? bch_btree_insert_check_key+0x1f0/0x1f0 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772198]  __bch_btree_map_nodes+0xf0/0x150 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772205]  ? bch_btree_insert_check_key+0x1f0/0x1f0 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772212]  bch_btree_insert+0xf9/0x170 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772215]  ? wait_woken+0x80/0x80
+      Feb 04 06:51:39 bronzor kernel: [  726.772222]  bch_journal_replay+0x220/0x2f0 [bcache]
+      Feb 04 06:51:39 bronzor kernel: [  726.772224]  ? try_to_wake_up+0x59/0x4b0
+      Feb 04 06:51:39 bronzor kernel: [  726.772229]  ? kthread_create_on_node+0x46/0x70
+      Feb 04 06:51:40 bronzor kernel: [  726.772238]  run_cache_set+0x5c6/0x970 [bcache]
+      Feb 04 06:51:40 bronzor kernel: [  726.772246]  register_bcache+0xd04/0x1110 [bcache]
+      Feb 04 06:51:40 bronzor kernel: [  726.772253]  ? register_bcache+0xd04/0x1110 [bcache]
+      Feb 04 06:51:40 bronzor kernel: [  726.772256]  kobj_attr_store+0x12/0x20
+      Feb 04 06:51:40 bronzor kernel: [  726.772257]  ? kobj_attr_store+0x12/0x20
+      Feb 04 06:51:40 bronzor kernel: [  726.772259]  sysfs_kf_write+0x3c/0x50
+      Feb 04 06:51:40 bronzor kernel: [  726.772261]  kernfs_fop_write+0x125/0x1a0
+      Feb 04 06:51:40 bronzor kernel: [  726.772263]  __vfs_write+0x1b/0x40
+      Feb 04 06:51:40 bronzor kernel: [  726.772265]  vfs_write+0xb1/0x1a0
+      Feb 04 06:51:40 bronzor kernel: [  726.772267]  SyS_write+0x5c/0xe0
+      Feb 04 06:51:40 bronzor kernel: [  726.772270]  do_syscall_64+0x73/0x130
+      Feb 04 06:51:40 bronzor kernel: [  726.772273]  entry_SYSCALL_64_after_hwframe+0x41/0xa6
+      Feb 04 06:51:40 bronzor kernel: [  726.772275] RIP: 0033:0x7efdb30af104
+      Feb 04 06:51:40 bronzor kernel: [  726.772276] RSP: 002b:00007fff9649a2b8 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
+      Feb 04 06:51:40 bronzor kernel: [  726.772278] RAX: ffffffffffffffda RBX: 000000000000000b RCX: 00007efdb30af104
+      Feb 04 06:51:40 bronzor kernel: [  726.772279] RDX: 000000000000000b RSI: 00005625a6c2c260 RDI: 0000000000000003
+      Feb 04 06:51:40 bronzor kernel: [  726.772281] RBP: 00005625a6c2c260 R08: 0000000000000000 R09: 000000000000000a
+      Feb 04 06:51:40 bronzor kernel: [  726.772282] R10: 00000000fffffff6 R11: 0000000000000246 R12: 00007fff9649a350
+      Feb 04 06:51:40 bronzor kernel: [  726.772283] R13: 000000000000000b R14: 00007efdb33872a0 R15: 00007efdb3386760
   copy-from-original:
     - sos_commands/date/date
 mock:

--- a/hotsos/defs/tests/scenarios/kernel/kernlog_calltrace_fanotify.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/kernlog_calltrace_fanotify.yaml
@@ -2,32 +2,31 @@ target-name: kernlog_calltrace.yaml
 data-root:
   files:
     var/log/kern.log: |
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.259590] INFO: task controller:1428 blocked for more than 120 seconds.
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.260681]       Not tainted 4.4.0-142-generic #168-Ubuntu
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261199] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261737] controller      D ffff8800b8593af8     0  1428   1333 0x10000000
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261741]  ffff8800b8593af8 ffff8800348e5d10 ffff88023627d500 ffff8800ba573fc0
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261743]  ffff8800b8594000 ffff8800a4ab5980 ffff8800348e5dd8 ffff8800348e5d00
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261745]  ffff88022fc7b000 ffff8800b8593b10 ffffffff8185cb45 0000000000000000
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261746] Call Trace:
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261752]  [<ffffffff8185cb45>] schedule+0x35/0x80
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261755]  [<ffffffff8126321e>] fanotify_handle_event+0x18e/0x2d0
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261757]  [<ffffffff8125f795>] ? fsnotify+0x5/0x4b0
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261760]  [<ffffffff810ca000>] ? wake_atomic_t_function+0x60/0x60
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261761]  [<ffffffff8125fa77>] fsnotify+0x2e7/0x4b0
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261764]  [<ffffffff81358a71>] security_file_open+0x91/0xa0
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261767]  [<ffffffff81219512>] do_dentry_open+0x112/0x310
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261768]  [<ffffffff8121a794>] vfs_open+0x54/0x80
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261771]  [<ffffffff8122656b>] ? may_open+0x5b/0xf0
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261773]  [<ffffffff81229aaf>] path_openat+0x20f/0x1360
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261775]  [<ffffffff81062999>] ? kprobe_ftrace_handler+0x69/0x120
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261777]  [<ffffffff8122c7d1>] do_filp_open+0x91/0x100
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261779]  [<ffffffff8122c745>] ? do_filp_open+0x5/0x100
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261780]  [<ffffffff8122c745>] ? do_filp_open+0x5/0x100
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261782]  [<ffffffff81060c79>] kretprobe_trampoline_holder+0x9/0x9
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261784]  [<ffffffff8121aa35>] ? do_sys_open+0x5/0x2a0
-      May  3 15:40:27 DELRHIUCBM002V kernel: [ 1920.261785]  [<ffffffff81060c79>] kretprobe_trampoline_holder+0
-
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.259590] INFO: task controller:1428 blocked for more than 120 seconds.
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.260681]       Not tainted 4.4.0-142-generic #168-Ubuntu
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261199] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261737] controller      D ffff8800b8593af8     0  1428   1333 0x10000000
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261741]  ffff8800b8593af8 ffff8800348e5d10 ffff88023627d500 ffff8800ba573fc0
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261743]  ffff8800b8594000 ffff8800a4ab5980 ffff8800348e5dd8 ffff8800348e5d00
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261745]  ffff88022fc7b000 ffff8800b8593b10 ffffffff8185cb45 0000000000000000
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261746] Call Trace:
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261752]  [<ffffffff8185cb45>] schedule+0x35/0x80
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261755]  [<ffffffff8126321e>] fanotify_handle_event+0x18e/0x2d0
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261757]  [<ffffffff8125f795>] ? fsnotify+0x5/0x4b0
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261760]  [<ffffffff810ca000>] ? wake_atomic_t_function+0x60/0x60
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261761]  [<ffffffff8125fa77>] fsnotify+0x2e7/0x4b0
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261764]  [<ffffffff81358a71>] security_file_open+0x91/0xa0
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261767]  [<ffffffff81219512>] do_dentry_open+0x112/0x310
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261768]  [<ffffffff8121a794>] vfs_open+0x54/0x80
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261771]  [<ffffffff8122656b>] ? may_open+0x5b/0xf0
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261773]  [<ffffffff81229aaf>] path_openat+0x20f/0x1360
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261775]  [<ffffffff81062999>] ? kprobe_ftrace_handler+0x69/0x120
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261777]  [<ffffffff8122c7d1>] do_filp_open+0x91/0x100
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261779]  [<ffffffff8122c745>] ? do_filp_open+0x5/0x100
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261780]  [<ffffffff8122c745>] ? do_filp_open+0x5/0x100
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261782]  [<ffffffff81060c79>] kretprobe_trampoline_holder+0x9/0x9
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261784]  [<ffffffff8121aa35>] ? do_sys_open+0x5/0x2a0
+      Feb  4 15:40:27 DELRHIUCBM002V kernel: [ 1920.261785]  [<ffffffff81060c79>] kretprobe_trampoline_holder+0
 raised-issues:
   KernelError: >-
     1 reports of fanotify related hangs in kern.log. This may be related to antivirus software running in the system.

--- a/hotsos/defs/tests/scenarios/kernel/kernlog_calltrace_hungtasks.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/kernlog_calltrace_hungtasks.yaml
@@ -2,36 +2,35 @@ target-name: kernlog_calltrace.yaml
 data-root:
   files:
     var/log/kern.log: |
-      Jan 07 00:07:12 ic-hrvart4-s4anq599 kernel: o-hm0: dropped over-mtu packet: 2829 > 1500
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel: INFO: task df:1177107 blocked for more than 120 seconds.
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel:       Tainted: P           O      5.15.0-53-generic #59~20.04.1-Ubuntu
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel: "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel: task:df              state:D stack:    0 pid:1177107 ppid:  6953 flags:0x00004224
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel: Call Trace:
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel:  <TASK>
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel:  __schedule+0x2cd/0x890
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel:  schedule+0x69/0x110
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel:  request_wait_answer+0x136/0x210
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel:  ? wait_woken+0x60/0x60
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel:  fuse_simple_request+0x1ac/0x2f0
-      Jan 07 00:07:13 ic-hrvart4-s4anq599 kernel:  fuse_do_getattr+0xd7/0x340
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  fuse_getattr+0xa9/0x130
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  vfs_getattr_nosec+0xba/0xe0
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  vfs_getattr+0x37/0x50
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  vfs_statx+0x89/0x110
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  __do_sys_newstat+0x3e/0x80
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  __x64_sys_newstat+0x16/0x20
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  do_syscall_64+0x59/0xc0
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  ? exit_to_user_mode_prepare+0x9c/0x1c0
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  ? syscall_exit_to_user_mode+0x27/0x50
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  ? __x64_sys_newstat+0x16/0x20
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  ? do_syscall_64+0x69/0xc0
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  ? irqentry_exit_to_user_mode+0x9/0x20
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  ? irqentry_exit+0x1d/0x30
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  ? sysvec_apic_timer_interrupt+0x4e/0x90
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel:  entry_SYSCALL_64_after_hwframe+0x61/0xcb
-      Jan 07 00:07:14 ic-hrvart4-s4anq599 kernel: RIP: 0033:0x7f7004c274ba
-
+      Feb 04 00:07:12 ic-hrvart4-s4anq599 kernel: o-hm0: dropped over-mtu packet: 2829 > 1500
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel: INFO: task df:1177107 blocked for more than 120 seconds.
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel:       Tainted: P           O      5.15.0-53-generic #59~20.04.1-Ubuntu
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel: "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel: task:df              state:D stack:    0 pid:1177107 ppid:  6953 flags:0x00004224
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel: Call Trace:
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel:  <TASK>
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel:  __schedule+0x2cd/0x890
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel:  schedule+0x69/0x110
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel:  request_wait_answer+0x136/0x210
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel:  ? wait_woken+0x60/0x60
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel:  fuse_simple_request+0x1ac/0x2f0
+      Feb 04 00:07:13 ic-hrvart4-s4anq599 kernel:  fuse_do_getattr+0xd7/0x340
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  fuse_getattr+0xa9/0x130
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  vfs_getattr_nosec+0xba/0xe0
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  vfs_getattr+0x37/0x50
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  vfs_statx+0x89/0x110
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  __do_sys_newstat+0x3e/0x80
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  __x64_sys_newstat+0x16/0x20
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  do_syscall_64+0x59/0xc0
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  ? exit_to_user_mode_prepare+0x9c/0x1c0
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  ? syscall_exit_to_user_mode+0x27/0x50
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  ? __x64_sys_newstat+0x16/0x20
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  ? do_syscall_64+0x69/0xc0
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  ? irqentry_exit_to_user_mode+0x9/0x20
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  ? irqentry_exit+0x1d/0x30
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  ? sysvec_apic_timer_interrupt+0x4e/0x90
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel:  entry_SYSCALL_64_after_hwframe+0x61/0xcb
+      Feb 04 00:07:14 ic-hrvart4-s4anq599 kernel: RIP: 0033:0x7f7004c274ba
 raised-issues:
   KernelError: >-
     1 reports of hung tasks in kern.log - please check.

--- a/hotsos/plugin_extensions/openstack/agent/events.py
+++ b/hotsos/plugin_extensions/openstack/agent/events.py
@@ -22,7 +22,7 @@ from hotsos.core.plugins.openstack.common import (
     OpenstackChecksBase,
     OpenstackEventChecksBase,
 )
-from hotsos.core.plugins.openstack.openstack import OPENSTACK_LOGS_TS_EXPR
+from hotsos.core.plugins.openstack.openstack import OpenstackTimestampMatcher
 from hotsos.core.plugins.openstack.neutron import NeutronHAInfo
 from hotsos.core.utils import sorted_dict
 
@@ -308,7 +308,8 @@ class AgentEventChecks(OpenstackChecksBase):
         if not self.openstack_installed:
             return
 
-        c = SearchConstraintSearchSince(exprs=[OPENSTACK_LOGS_TS_EXPR])
+        c = SearchConstraintSearchSince(
+                                      ts_matcher_cls=OpenstackTimestampMatcher)
         s = FileSearcher(constraint=c)
         check_objs = [c(searchobj=s) for c in checks]
         for check in check_objs:

--- a/hotsos/plugin_extensions/openstack/agent/exceptions.py
+++ b/hotsos/plugin_extensions/openstack/agent/exceptions.py
@@ -6,7 +6,7 @@ from collections import UserDict
 from hotsos.core.log import log
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.plugins.openstack.common import OpenstackChecksBase
-from hotsos.core.plugins.openstack.openstack import OPENSTACK_LOGS_TS_EXPR
+from hotsos.core.plugins.openstack.openstack import OpenstackTimestampMatcher
 from hotsos.core.search import (
     FileSearcher,
     SearchDef,
@@ -114,7 +114,8 @@ class AgentExceptionChecks(OpenstackChecksBase):
     def __init__(self):
         super().__init__()
         self._agent_results = None
-        c = SearchConstraintSearchSince(exprs=[OPENSTACK_LOGS_TS_EXPR])
+        c = SearchConstraintSearchSince(
+                                      ts_matcher_cls=OpenstackTimestampMatcher)
         self.searchobj = FileSearcher(constraint=c)
         # The following are expected to be logged using WARNING log level.
         self._agent_warnings = {

--- a/hotsos/plugin_extensions/openstack/nova_external_events.py
+++ b/hotsos/plugin_extensions/openstack/nova_external_events.py
@@ -5,7 +5,7 @@ from hotsos.core.search import (
 )
 from hotsos.core.ycheck.events import CallbackHelper
 from hotsos.core.plugins.openstack.common import OpenstackEventChecksBase
-from hotsos.core.plugins.openstack.openstack import OPENSTACK_LOGS_TS_EXPR
+from hotsos.core.plugins.openstack.openstack import OpenstackTimestampMatcher
 
 EXT_EVENT_META = {'network-vif-plugged': {'stages_keys':
                                           ['Preparing', 'Received',
@@ -38,7 +38,8 @@ class NovaExternalEventChecks(OpenstackEventChecksBase):
         events = {}
         events_found = {}
 
-        c = SearchConstraintSearchSince(exprs=[OPENSTACK_LOGS_TS_EXPR])
+        c = SearchConstraintSearchSince(
+                                      ts_matcher_cls=OpenstackTimestampMatcher)
         s = FileSearcher(constraint=c)
         for result in event.results:
             instance_id = result.get(1)

--- a/hotsos/plugin_extensions/openstack/vm_info.py
+++ b/hotsos/plugin_extensions/openstack/vm_info.py
@@ -14,7 +14,7 @@ from hotsos.core.search import (
 )
 from hotsos.core.plugins.openstack.openstack import (
     OpenstackConfig,
-    OPENSTACK_LOGS_TS_EXPR,
+    OpenstackTimestampMatcher,
 )
 from hotsos.core.plugins.openstack.common import (
     OpenstackChecksBase,
@@ -148,7 +148,8 @@ class OpenstackInstanceChecks(OpenstackChecksBase):
 class NovaServerMigrationAnalysis(OpenstackEventChecksBase):
 
     def __init__(self, *args, **kwargs):
-        c = SearchConstraintSearchSince(exprs=[OPENSTACK_LOGS_TS_EXPR])
+        c = SearchConstraintSearchSince(
+                                      ts_matcher_cls=OpenstackTimestampMatcher)
         super().__init__(EVENTCALLBACKS, *args,
                          yaml_defs_group='nova.migrations',
                          searchobj=FileSearcher(constraint=c),

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -7,7 +7,7 @@ from hotsos.core.search import (
 from hotsos.core.ycheck.events import CallbackHelper
 from hotsos.core.issues import IssuesManager, OpenvSwitchWarning
 from hotsos.core.plugins.openvswitch.common import (
-    OPENVSWITCH_LOGS_TS_EXPR,
+    OVSTimestampMatcher,
     OpenvSwitchEventChecksBase
 )
 from hotsos.core.plugins.openvswitch.ovs import OpenvSwitchBase
@@ -19,7 +19,7 @@ EVENTCALLBACKS = CallbackHelper()
 class OVSEventChecks(OpenvSwitchEventChecksBase):
 
     def __init__(self):
-        c = SearchConstraintSearchSince(exprs=[OPENVSWITCH_LOGS_TS_EXPR])
+        c = SearchConstraintSearchSince(ts_matcher_cls=OVSTimestampMatcher)
         super().__init__(EVENTCALLBACKS, yaml_defs_group='ovs',
                          searchobj=FileSearcher(constraint=c))
         self.ovs = OpenvSwitchBase()
@@ -212,7 +212,7 @@ class OVSEventChecks(OpenvSwitchEventChecksBase):
 class OVNEventChecks(OpenvSwitchEventChecksBase):
 
     def __init__(self):
-        c = SearchConstraintSearchSince(exprs=[OPENVSWITCH_LOGS_TS_EXPR])
+        c = SearchConstraintSearchSince(ts_matcher_cls=OVSTimestampMatcher)
         super().__init__(EVENTCALLBACKS, yaml_defs_group='ovn',
                          searchobj=FileSearcher(constraint=c))
 

--- a/hotsos/plugin_extensions/storage/ceph_event_checks.py
+++ b/hotsos/plugin_extensions/storage/ceph_event_checks.py
@@ -3,7 +3,7 @@ import re
 from hotsos.core.issues import IssuesManager, CephOSDError
 from hotsos.core.ycheck.events import CallbackHelper
 from hotsos.core.plugins.storage.ceph import (
-    CEPH_LOGS_TS_EXPR,
+    CephTimestampMatcher,
     CephEventChecksBase,
 )
 from hotsos.core.search import (
@@ -17,7 +17,7 @@ CEPH_ID_FROM_LOG_PATH_EXPR = r'.+ceph-osd\.(\d+)\.log'
 class CephDaemonLogChecks(CephEventChecksBase):
 
     def __init__(self):
-        c = SearchConstraintSearchSince(exprs=[CEPH_LOGS_TS_EXPR])
+        c = SearchConstraintSearchSince(ts_matcher_cls=CephTimestampMatcher)
         super().__init__(EVENTCALLBACKS, yaml_defs_group='ceph',
                          searchobj=FileSearcher(constraint=c))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ jinja2
 # More info on issue: https://github.com/canonical/hotsos/issues/326
 # [TODO] Bump cryptography to more recent release
 cryptography==3.4.8
-searchkit >= 0.2.5
+searchkit >= 0.2.6
 propertree
 fasteners

--- a/tests/unit/test_ycheck.py
+++ b/tests/unit/test_ycheck.py
@@ -980,7 +980,6 @@ class TestYamlChecks(utils.BaseTestCase):
 
         self.assertEqual(IssuesManager().load_issues(), {})
 
-    @mock.patch('hotsos.core.ycheck.engine.properties.search.CLIHelper')
     @init_test_scenario(SCENARIO_CHECKS)
     @utils.create_data_root({'foo.log':
                              ('2021-04-01 00:31:00.000 an event\n'
@@ -992,9 +991,7 @@ class TestYamlChecks(utils.BaseTestCase):
                                         ' load average: 3.58, 3.27, 2.58'),
                              'sos_commands/date/date':
                                  'Thu Mar 31 16:19:17 UTC 2021'})
-    def test_yaml_def_scenario_checks_expr(self, mock_cli):
-        mock_cli.return_value = mock.MagicMock()
-        mock_cli.return_value.date.return_value = "2021-04-03 00:00:00"
+    def test_yaml_def_scenario_checks_expr(self):
         checker = scenarios.YScenarioChecker()
         checker.load()
         self.assertEqual(len(checker.scenarios), 1)


### PR DESCRIPTION
Implement search constraints for kern.log checks. This patch makes use of the new searchkit.constraints.TimestampMatcherBase class to allow timestamps of any type/format to be matched and updates all users of SearchConstraintSearchSince to use this approach for consistency.

Resolves: #609