### PR TITLE
Check ovn-northd memory usage

### DIFF
--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -53,6 +53,27 @@ class SystemdService(object):
 
         return t.timestamp()
 
+    @property
+    def memory_current(self):
+        """ Returns service current memory usage in bytes. """
+        path = os.path.join(HotSOSConfig.data_root,
+                            'sys/fs/cgroup/memory/system.slice',
+                            "{}.service".format(self.name),
+                            'memory.usage_in_bytes')
+        if not os.path.exists(path):
+            # path changed between Ubuntu Focal and Jammy releases.
+            path = os.path.join(HotSOSConfig.data_root,
+                                'sys/fs/cgroup/system.slice',
+                                "{}.service".format(self.name),
+                                'memory.current')
+
+        if not os.path.exists(path):
+            log.warning("service memory info not found at %s", path)
+            return 0
+
+        with open(path) as fd:
+            return int(fd.read())
+
     def __repr__(self):
         return ("name={}, state={}, start_time={}, has_instances={}".
                 format(self.name, self.state, self.start_time,

--- a/hotsos/defs/scenarios/openvswitch/ovn/service_mem_usage.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/service_mem_usage.yaml
@@ -1,0 +1,17 @@
+vars:
+  limit: 536870912  # 5G
+  northd_usage: '@hotsos.core.host_helpers.systemd.ServiceFactory.memory_current:ovn-northd'
+checks:
+  northd_mem_use_above_limit:
+    systemd: ovn-northd
+    varops: [[$northd_usage], [gt, $limit]]
+conclusions:
+  northd_overuse:
+    decision: northd_mem_use_above_limit
+    raises:
+      type: OpenvSwitchWarning
+      message: >-
+        The ovn-northd service is consuming more than 5G memory (current={usage}). This is
+        not normal and could indicate a memory leak. Please check.
+      format-dict:
+        usage: $northd_usage

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/service_mem_usage.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/service_mem_usage.yaml
@@ -1,0 +1,22 @@
+data-root:
+  files:
+    sys/fs/cgroup/system.slice/ovn-northd.service/memory.current: '536870913'
+    sos_commands/systemd/systemctl_list-unit-files: |
+      ovn-central.service                        enabled         enabled
+      ovn-nb-ovsdb.service                       enabled         enabled
+      ovn-northd.service                         static          enabled
+      ovn-ovsdb-server-nb.service                enabled         enabled
+      ovn-ovsdb-server-sb.service                enabled         enabled
+      ovn-sb-ovsdb.service                       enabled         enabled
+    sos_commands/systemd/systemctl_list-units: |
+      ovn-central.service                                                         loaded active exited    Open Virtual Network central components
+      ovn-northd.service                                                          loaded active running   Open Virtual Network central control daemon
+      ovn-ovsdb-server-nb.service                                                 loaded active running   Open vSwitch database server for OVN Northbound database
+      ovn-ovsdb-server-sb.service                                                 loaded active running   Open vSwitch database server for OVN Southbound database
+    sos_commands/dpkg/dpkg_-l: |
+      ii  ovn-central                     20.03.2-0ubuntu0.20.04.4          amd64        OVN central components
+      ii  ovn-common                      20.03.2-0ubuntu0.20.04.4          amd64        OVN common components
+raised-issues:
+  OpenvSwitchWarning: >-
+    The ovn-northd service is consuming more than 5G memory (current=536870913). This is
+    not normal and could indicate a memory leak. Please check.

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/service_mem_usage_ok.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/service_mem_usage_ok.yaml
@@ -1,0 +1,20 @@
+target-name: service_mem_usage.yaml
+data-root:
+  files:
+    sys/fs/cgroup/system.slice/ovn-northd.service/memory.current: '536870912'
+    sos_commands/systemd/systemctl_list-unit-files: |
+      ovn-central.service                        enabled         enabled
+      ovn-nb-ovsdb.service                       enabled         enabled
+      ovn-northd.service                         static          enabled
+      ovn-ovsdb-server-nb.service                enabled         enabled
+      ovn-ovsdb-server-sb.service                enabled         enabled
+      ovn-sb-ovsdb.service                       enabled         enabled
+    sos_commands/systemd/systemctl_list-units: |
+      ovn-central.service                                                         loaded active exited    Open Virtual Network central components
+      ovn-northd.service                                                          loaded active running   Open Virtual Network central control daemon
+      ovn-ovsdb-server-nb.service                                                 loaded active running   Open vSwitch database server for OVN Northbound database
+      ovn-ovsdb-server-sb.service                                                 loaded active running   Open vSwitch database server for OVN Southbound database
+    sos_commands/dpkg/dpkg_-l: |
+      ii  ovn-central                     20.03.2-0ubuntu0.20.04.4          amd64        OVN central components
+      ii  ovn-common                      20.03.2-0ubuntu0.20.04.4          amd64        OVN common components
+raised-issues:

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -320,6 +320,26 @@ class TestSystemdHelper(utils.BaseTestCase):
         s = host_helpers.systemd.SystemdHelper([r'nova\S+'])
         self.assertEqual(s.summary, expected)
 
+    @utils.create_data_root(
+        {},
+        copy_from_original=['sos_commands/systemd/systemctl_list-units',
+                            'sos_commands/systemd/systemctl_list-unit-files',
+                            'sys/fs/cgroup/memory/system.slice'])
+    def test_systemd_service_focal(self):
+        s = host_helpers.systemd.SystemdHelper([r'nova\S+'])
+        svc = s.services['nova-compute']
+        self.assertEqual(svc.memory_current, 1517850624)
+
+    @utils.create_data_root(
+        {'sys/fs/cgroup/system.slice/nova-compute.service/memory.current':
+         '1234'},
+        copy_from_original=['sos_commands/systemd/systemctl_list-units',
+                            'sos_commands/systemd/systemctl_list-unit-files'])
+    def test_systemd_service_jammy(self):
+        s = host_helpers.systemd.SystemdHelper([r'nova\S+'])
+        svc = s.services['nova-compute']
+        self.assertEqual(svc.memory_current, 1234)
+
 
 class TestPebbleHelper(utils.BaseTestCase):
 


### PR DESCRIPTION
Add a mem_current property to the SystemdService class to return current memory usage of a given interface. Adds a check to ensure if ovn-northd usage is > 10G raise a OpenvSwitchWarning.

Resolves: #634