### PR TITLE
Detect ovs-vswitchd assertion failures

### DIFF
--- a/hotsos/defs/events/openvswitch/ovs/ovs-vswitchd.yaml
+++ b/hotsos/defs/events/openvswitch/ovs/ovs-vswitchd.yaml
@@ -17,3 +17,6 @@ inactivity-probe:
 involuntary-context-switches:
   expr: '([0-9-]+)T(\d+):\d+:\d+\.\S+Z.+\|timeval\|WARN\|context switches: 0 voluntary, (\d+) involuntary'
   hint: timeval
+assertion-failures:
+  expr: '([0-9-]+)T[0-9:\.]+Z.+\|util.+\|EMER\|\S+: assertion '
+  hint: assertion

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -42,6 +42,7 @@ class OVSEventChecks(OpenvSwitchEventChecksBase):
                                     'receive-tunnel-port-not-found',
                                     'rx-packet-on-unassociated-datapath-port',
                                     'dpif-netlink-lost-packet-on-handler',
+                                    'assertion-failures',
                                     'unreasonably-long-poll-interval'])
     def process_log_events(self, event):
         key_by_date = True


### PR DESCRIPTION
An assertion failure is basically a crash, start logging the number seen on ovs-vswitchd.log. Had to update tests to match EMER messages in output as that is the level an assertion failure is logged at.