### PR TITLE
Use newer flake8 and pylint versions

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,14 @@
-[MASTER]
+[MAIN]
 jobs=0
+ignore=.git,tests/unit/fake_data_root
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=pylint.extensions.no_self_use
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
 
 [FORMAT]
 max-line-length=79
@@ -48,9 +57,15 @@ disable=
  no-self-use,
  simplifiable-if-statement,
  broad-except,
- trailing-comma-tuple,
  redefined-outer-name,
- expression-not-assigned,
  unnecessary-lambda,
- pointless-string-statement,
  arguments-differ,
+ broad-exception-raised,
+ superfluous-parens,
+ unspecified-encoding,
+ consider-using-f-string,
+ consider-using-join,
+ consider-using-with,
+ consider-using-dict-items,
+ consider-using-generator,
+ unused-private-member,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 bashate
-flake8
-mock
+flake8==6.0.0
+flake8-import-order==0.18.2
 stestr
-pylint==2.8.3
+pylint==2.17.4
 rpdb
 testtools

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -372,8 +372,8 @@ class TestCephMonSummary(CephMonTestsBase):
     def test_ceph_pg_imbalance_unavailable(self):
         inst = ceph_summary.CephSummary()
         actual = self.part_output_to_actual(inst.output)
-        self.assertFalse('osd-pgs-suboptimal' in actual)
-        self.assertFalse('osd-pgs-near-limit' in actual)
+        self.assertNotIn('osd-pgs-suboptimal', actual)
+        self.assertNotIn('osd-pgs-near-limit', actual)
 
     def test_ceph_versions(self):
         result = {'mgr': ['15.2.14'],

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -205,7 +205,7 @@ class TestCLIHelper(utils.BaseTestCase):
     def test_ns_ip_addr(self):
         ns = "qrouter-984c22fd-64b3-4fa1-8ddd-87090f401ce5"
         out = host_helpers.cli.CLIHelper().ns_ip_addr(namespace=ns)
-        self.assertEqual(type(out), list)
+        self.assertIsInstance(out, list)
         self.assertEqual(len(out), 18)
 
     def test_udevadm_info_dev(self):
@@ -311,7 +311,7 @@ class TestSystemdHelper(utils.BaseTestCase):
         svc = host_helpers.systemd.ServiceFactory().rsyslog
         self.assertEqual(svc.start_time_secs, 1644446297.0)
 
-        self.assertEqual(host_helpers.systemd.ServiceFactory().noexist, None)
+        self.assertIsNone(host_helpers.systemd.ServiceFactory().noexist)
 
     def test_systemd_helper(self):
         expected = {'ps': ['nova-api-metadata (5)', 'nova-compute (1)'],
@@ -349,7 +349,7 @@ class TestPebbleHelper(utils.BaseTestCase):
         svc = getattr(host_helpers.pebble.ServiceFactory(), 'nova-conductor')
         self.assertEqual(svc.state, 'backoff')
 
-        self.assertEqual(host_helpers.pebble.ServiceFactory().noexist, None)
+        self.assertIsNone(host_helpers.pebble.ServiceFactory().noexist)
 
     @utils.create_data_root({'sos_commands/pebble/pebble_services':
                              PEBBLE_SERVICES,
@@ -482,7 +482,7 @@ class TestConfigHelper(utils.BaseTestCase):
         self.assertTrue(cfg.exists)
         self.assertEqual(cfg.get('a-key'), '1023')
         self.assertEqual(cfg.get('a-key', section='a-section'), '1023')
-        self.assertEqual(cfg.get('a-key', section='missing-section'), None)
+        self.assertIsNone(cfg.get('a-key', section='missing-section'))
         self.assertEqual(cfg.get('a-key', expand_to_list=True), [1023])
 
         expanded = cfg.get('b-key', expand_to_list=True)

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -37,6 +37,7 @@ net.ipv4.udp_mem = 379728	506307	762456
 net.ipv4.tcp_mem = 189864	253153	379728
 """
 
+# pylint: disable=C0301
 PROC_NETLINK = r"""sk               Eth Pid        Groups   Rmem     Wmem     Dump  Locks    Drops    Inode
 0000000000000000 0   23984      00000113 0        0        0     2        0        129906  
 0000000000000000 0   142171     00000113 0        0        0     2        0        411370  
@@ -48,8 +49,9 @@ PROC_NETLINK = r"""sk               Eth Pid        Groups   Rmem     Wmem     Du
 0000000000000000 0   10542      00000113 0        0        0     2        0        114127  
 0000000000000000 0   2199       000405d1 0        0        0     2        1        34703   
 0000000000000000 0   3426       00000440 0        0        0     2        0        89397 
-""" # noqa
+"""  # noqa
 
+# pylint: disable=C0301
 LSOF_MNLC = r"""                                                                                                                                                                                                                                    COMMAND     PID   USER   FD      TYPE             DEVICE     SIZE/OFF       NODE NAME
 systemd       1        0  cwd       DIR                9,1         4096          2 /
 systemd       1        0  rtd       DIR                9,1         4096          2 /
@@ -101,7 +103,7 @@ libvirtd  44443        0  mem       REG                9,1       408472      335
 nova-comp 49287      114  mem       REG                9,1        68512      33561 /usr/lib/x86_64-linux-gnu/libavahi-client.so.3.2.9
 nova-comp 49287      114   21u     IPv4            2914832          0t0        TCP 192.168.2.24:46064->192.168.2.45:5673 (ESTABLISHED)
 sosreport 67605        0    5r     FIFO               0,12          0t0  289262208 pipe
-""" # noqa
+"""  # noqa
 
 
 class TestKernelBase(utils.BaseTestCase):

--- a/tests/unit/test_kubernetes.py
+++ b/tests/unit/test_kubernetes.py
@@ -83,7 +83,7 @@ class TestKubernetesSummary(KubernetesTestsBase):
             SNAP_LIST_ALL_NO_K8S.splitlines()
         inst = summary.KubernetesSummary()
         self.assertFalse(inst.plugin_runnable)
-        self.assertTrue('snaps' not in inst.output)
+        self.assertNotIn('snaps', inst.output)
 
     def test_network_info(self):
         expected = {'flannel.1': {'addr': '10.1.84.0',

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -685,7 +685,7 @@ class TestOpenstackServiceNetworkChecks(TestOpenstackBase):
         mock_helper.return_value.ip_link.return_value = []
         inst = service_network_checks.OpenstackNetworkChecks()
         actual = self.part_output_to_actual(inst.output)
-        self.assertFalse('namespaces' in actual)
+        self.assertNotIn('namespaces', actual)
 
     def test_get_network_checker(self):
         expected = {

--- a/tests/unit/test_sosreport.py
+++ b/tests/unit/test_sosreport.py
@@ -34,7 +34,7 @@ class TestSOSReportSummary(TestSOSReportBase):
     def test_check_plugin_timouts_none(self):
         inst = summary.SOSReportSummary()
         actual = self.part_output_to_actual(inst.output)
-        self.assertFalse('plugin-timeouts' in actual)
+        self.assertNotIn('plugin-timeouts', actual)
 
     @utils.create_data_root({'sos_logs/ui.log':
                              (" Plugin networking timed out\n"

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -216,8 +216,7 @@ class TestUbuntuPro(SystemTestsBase):
         mh.return_value = mock.MagicMock()
         mh.return_value.pro_status.return_value = UBUNTU_PRO_ATTACHED
         result = SystemBase().ubuntu_pro_status
-        self.assertNotEqual(result, None)
-        self.assertNotEqual(result, False)
+        self.assertIsNotNone(result)
 
         expected_result = {
             "status": "attached",
@@ -262,7 +261,7 @@ class TestUbuntuPro(SystemTestsBase):
         mh.return_value = mock.MagicMock()
         mh.return_value.pro_status.return_value = UA_ATTACHED
         result = SystemBase().ubuntu_pro_status
-        self.assertNotEqual(result, None)
+        self.assertIsNotNone(result)
 
         expected_result = {
             "status": "attached",

--- a/tests/unit/test_ycheck.py
+++ b/tests/unit/test_ycheck.py
@@ -800,7 +800,7 @@ class TestYamlChecks(utils.BaseTestCase):
 
     def test_yproperty_attr_cache(self):
         p = TestProperty()
-        self.assertEqual(getattr(p.cache, '__yproperty_attr__myattr'), None)
+        self.assertIsNone(getattr(p.cache, '__yproperty_attr__myattr'))
         self.assertEqual(p.myattr, '123')
         self.assertEqual(getattr(p.cache, '__yproperty_attr__myattr'), '123')
         self.assertEqual(p.myattr, '123')
@@ -1050,11 +1050,11 @@ class TestYamlChecks(utils.BaseTestCase):
 
         _result = {1: '2022-01-06', 2: 'foo'}
         ts = YPropertySearch.get_datetime_from_result(result)
-        self.assertEqual(ts, None)
+        self.assertIsNone(ts)
 
         _result = {1: 'foo'}
         ts = YPropertySearch.get_datetime_from_result(result)
-        self.assertEqual(ts, None)
+        self.assertIsNone(ts)
 
     @mock.patch('hotsos.core.ycheck.engine.properties.search.CLIHelper')
     @utils.create_data_root({'foo.log': '2022-01-06 00:00:00.000 an event\n'})

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,8 +1,8 @@
 import os
 import importlib
-import mock
 import re
 import sys
+from unittest import mock
 import yaml
 
 import shutil
@@ -91,7 +91,7 @@ class TemplatedTest(object):
         """
 
         if not expected:
-            test_inst.assertTrue('bugs-detected' not in actual)
+            test_inst.assertNotIn('bugs-detected', actual)
             return
         elif 'bugs-detected' not in actual:
             raise Exception("test expects one or more bugs to have "
@@ -113,7 +113,7 @@ class TemplatedTest(object):
         """
 
         if not expected:
-            test_inst.assertTrue('potential-issues' not in actual)
+            test_inst.assertNotIn('potential-issues', actual)
             return
         elif 'potential-issues' not in actual:
             raise Exception("test expects one or more issues to have "

--- a/tox.ini
+++ b/tox.ini
@@ -2,32 +2,72 @@
 skipsdist = True
 envlist = py3,pep8,pylint,bashate,functional
 sitepackages = False
+minversion = 3.18.0
 
 [testenv]
+basepython = {env:TOX_PYTHON:python3}
 unit_tests = {toxinidir}/tests/unit/
-pyfiles =
-    {toxinidir}/setup.py
-    {toxinidir}/hotsos/
-    {[testenv]unit_tests}
 passenv = TESTS_LOG_LEVEL_DEBUG
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
          TERM=linux
          HOTSOS_ROOT={toxinidir}/hotsos
          TESTS_DIR={[testenv]unit_tests}
+         PYFILES={toxinidir}/setup.py {toxinidir}/hotsos/ {[testenv]unit_tests}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-basepython = python3
 commands = stestr run --serial --test-path {[testenv]unit_tests} {posargs}
 
 [testenv:pep8]
-commands = flake8 -v --exclude=fake_data_root {posargs:{[testenv]pyfiles}}
+allowlist_externals = flake8
+commands =
+  flake8 -v --exclude=fake_data_root {posargs:{env:PYFILES}}
+
+[flake8]
+# E121 continuation line under-indented for hanging indent
+# E122 continuation line missing indentation or outdented
+# E123 closing bracket does not match indentation of opening bracket's line
+# E126 continuation line over-indented for hanging indent
+# E127 continuation line over-indented for visual indent
+# E128 continuation line under-indented for visual indent
+# E226 missing whitespace around arithmetic operator
+# E241 multiple spaces after ','
+# E265 block comment should start with '# '
+# E275 missing whitespace after keyword
+# E401 multiple imports on one line
+# H101 Use TODO(NAME)
+# H102 Apache 2.0 license header not found
+# H104 File contains nothing but comments
+# H202 assertRaises Exception too broad
+# H301 one import per line
+# H306 imports not in alphabetical order
+# H401 docstring should not start with a space
+# H403 multi line docstrings should end on a new line
+# H404 multi line docstring should start without a leading new line
+# H405 multi line docstring summary not separated with an empty line
+# I100 Import statements are in the wrong order
+# I201 Missing newline between import groups
+# I202 Additional newline in a group of imports
+# W503 line break before binary operator
+# W504 line break after binary operator
+ignore = E121,E122,E123,E126,E127,E128,E226,E241,E265,E261,E275,E401,H101,H102,H202,H301,H306,H401,H403,H404,H405,I100,I201,I202,W503,W504
+# H106: Don't put vim configuration in source files
+# H203: Use assertIs(Not)None to check for None
+# H204: Use assert(Not)Equal to check for equality
+# H205: Use assert(Greater|Less)(Equal) for comparison
+# H904: Delay string interpolations at logging calls
+enable-extensions = H106,H203,H204,H205,H904
+show-source = true
+exclude = ./.*,build,dist,tests/unit/fake_data_root
+import-order-style = pep8
 
 [testenv:pylint]
-commands = pylint -v --rcfile={toxinidir}/pylintrc {posargs:{[testenv]pyfiles}}
+allowlist_externals = pylint
+commands = pylint -v --rcfile={toxinidir}/pylintrc {posargs:{env:PYFILES}}
 
 [testenv:bashate]
+allowlist_externals = bashate
 commands = bashate --verbose {toxinidir}/build.sh {toxinidir}/tools/test/functest.sh
 
 [testenv:functional]


### PR DESCRIPTION
Bump the version of flake8, flake8-import-order and pylint, which will trigger stricter pep8 and pylint checking. Tweaked tox.ini accordingly to make sure it runs correctly outside the github gate by using setenv to set the files and directories to run against.

Had to add a lot of 'ignore' directives to tox.ini and pylintrc for new issues that were found.

Fixed a number of number of initial warnings:

 - use of incorrect and deprecated assert* checks
 - use of mock instead of unittest.mock
 - line too long

Follow-on changes can address some of these warnings.