### PR TITLE
Align timestamp regex expr across searches

### DIFF
--- a/hotsos/core/ycheck/engine/properties/search.py
+++ b/hotsos/core/ycheck/engine/properties/search.py
@@ -1,3 +1,5 @@
+import re
+
 from searchkit.constraints import TimestampMatcherBase
 
 from datetime import (
@@ -335,6 +337,15 @@ class YPropertySearchBase(YPropertyMappedOverrideBase):
 
         # can be supplied as a single string or list of strings
         patterns = self._resolve_exprs(list(self.content.keys()))
+        if len(patterns) == 0:
+            raise Exception("no search pattern (expr) defined")
+
+        for pattern in patterns:
+            if not re.search(r"[^\\]\(", pattern):
+                log.info("pattern '%s' does not contain a subgroup. this "
+                         "is inefficient and can result in unnecessary "
+                         "memory consumption", pattern)
+
         if len(patterns) == 1:
             return patterns[0]
 

--- a/hotsos/core/ycheck/events.py
+++ b/hotsos/core/ycheck/events.py
@@ -122,7 +122,18 @@ class EventProcessingUtils(object):
                                         'key': r.get(3)})
                     else:
                         _fail_count += 1
+                elif len(r) < 1:
+                    msg = ("result (tag={}) does not have enough groups "
+                           "(min 1) to be categorised - aborting".
+                           format(r.tag))
+                    raise Exception(msg)
                 else:
+                    if len(r) < 2:
+                        # results with just a date will have None for the key
+                        log.debug("result (tag=%s) has just one group which "
+                                  "is assumed to be a date and using key=None",
+                                  r.tag)
+
                     results.append({'date': r.get(1), 'key': r.get(2)})
 
             if _fail_count:

--- a/hotsos/defs/events/README.md
+++ b/hotsos/defs/events/README.md
@@ -1,0 +1,30 @@
+# Writing Events
+
+The files under this directory contain "event" definitions which are basically
+regex patterns associated with an event name. Events are coupled with a callback
+function which is called and passed any search results matched using the pattern
+associated with the event.
+
+Event callbacks will typically use hotsos.core.ycheck.events.EventProcessingUtils
+to categorise events for display in the summary. Search patterns using this
+method must have at least one result group defined and can optionally have more.
+Groups are used as follows; if a single group is used it must match the date
+and the events will be tallied by date e.g.
+
+2023-01-01: 10
+2023-01-02: 23
+2023-01-03: 4
+
+The other way is to have three groups such that group 1 is date, group 2 is time
+and group 3 matches a value this can be used as the root key for a tally e.g.
+
+val1:
+  2023-01-01: 10
+  2023-01-02: 23
+  2023-01-03: 4
+val2:
+  2023-01-01: 3
+  2023-01-02: 4
+  2023-01-03: 10
+
+See the class docstring for more information on how to use it.

--- a/hotsos/defs/events/openstack/http-requests.yaml
+++ b/hotsos/defs/events/openstack/http-requests.yaml
@@ -1,3 +1,4 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 neutron:
   input:
     path: 'var/log/neutron/neutron-server.log'
@@ -5,5 +6,5 @@ neutron:
       # If we do this for all logs the output will overwhelm
       # the summary so restrict to most recent.
       disable-all-logs: True
-  expr: '^([0-9-]+) (\d+:\d+:\d+)\.\d+ .+ neutron.wsgi .+ "(GET|POST|PUT|DELETE)'
+  expr: '([\d-]+) [\d:]+\.\d{3} .+ neutron.wsgi .+ "(GET|POST|PUT|DELETE)'
 

--- a/hotsos/defs/events/openstack/neutron/agents.yaml
+++ b/hotsos/defs/events/openstack/neutron/agents.yaml
@@ -1,3 +1,4 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 neutron-ovs-agent:
   input:
     path: 'var/log/neutron/neutron-openvswitch-agent.log'
@@ -9,10 +10,10 @@ neutron-ovs-agent:
   # identify rpc_loop iterations and get stats and longest running loops.
   rpc-loop:
     start:
-      expr: '^([0-9\-]+) (\S+) .+ Agent rpc_loop - iteration:([0-9]+) started.*'
+      expr: '([\d-]+) ([\d:]+\.\d{3}) .+ Agent rpc_loop - iteration:([0-9]+) started.*'
       hint: 'Agent rpc_loop'
     end:
-      expr: '^([0-9\-]+) (\S+) .+ Agent rpc_loop - iteration:([0-9]+) completed..+'
+      expr: '([\d-]+) ([\d:]+\.\d{3}) .+ Agent rpc_loop - iteration:([0-9]+) completed..+'
       hint: 'Agent rpc_loop'
     # we want to analyse these with core.analytics.LogEventStats so don't treat as sequence.
     passthrough-results: True      
@@ -22,10 +23,10 @@ neutron-l3-agent:
   # identify router updates that took the longest to complete and report the longest updates.
   router-updates:
     start:
-      expr: '^([0-9-]+) (\S+) .+ Starting router update for (\S+), .+ update_id (\S+). .+'
+      expr: '([\d-]+) ([\d:]+\.\d{3}) .+ Starting router update for (\S+), .+ update_id (\S+). .+'
       hint: 'router update'
     end:
-      expr: '^([0-9-]+) (\S+) .+ Finished a router update for (\S+), update_id (\S+). .+'
+      expr: '([\d-]+) ([\d:]+\.\d{3}) .+ Finished a router update for (\S+), update_id (\S+). .+'
       hint: 'router update'
     # we want to analyse these with core.analytics.LogEventStats so don't treat as sequence.
     passthrough-results: True
@@ -34,10 +35,10 @@ neutron-l3-agent:
     # router state_change_monitor + keepalived spawn
     # NOTE: there are no logs that depict a router create so we use the state change monitor spawn as a start point.
     start:
-      expr: '^([0-9-]+) (\S+) .+ Router (\S+) .+ spawn_state_change_monitor'
+      expr: '([\d-]+) ([\d:]+\.\d{3}) .+ Router (\S+) .+ spawn_state_change_monitor'
       hint: 'spawn_state_change'
     end:
-      expr: '^([0-9-]+) (\S+) .+ neutron.agent.linux.utils .+neutron-rootwrap.+''keepalived'',.+''/var/lib/neutron/ha_confs/([0-9a-z-]+)/keepalived.conf''.+ create_process'
+      expr: '([\d-]+) ([\d:]+\.\d{3}) .+ neutron.agent.linux.utils .+neutron-rootwrap.+''keepalived'',.+''/var/lib/neutron/ha_confs/([0-9a-z-]+)/keepalived.conf''.+ create_process'
       hint: 'Keepalived'
     # we want to analyse these with core.analytics.LogEventStats so don't treat as sequence.
     passthrough-results: True

--- a/hotsos/defs/events/openstack/neutron/ml2-routers.yaml
+++ b/hotsos/defs/events/openstack/neutron/ml2-routers.yaml
@@ -1,7 +1,9 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 l3ha:
   vrrp-transitions:
     input:
       command: journalctl
       options:
         args-callback: hotsos.plugin_extensions.openstack.agent.events.NeutronL3HAEventChecks.journalctl_args
-    expr: '^([0-9-]+)T\S+ \S+ Keepalived_vrrp\[\d+\]: (?:VRRP_Instance)?\(VR_(\d+)\) .+ (\S+) STATE'
+    # timestamp at start of line will be in journalctl -oshort-iso format
+    expr: '([\d-]+)T([\d:]+)\S+ \S+ Keepalived_vrrp\[\d+\]: (?:VRRP_Instance)?\(VR_(\d+)\) .+ (\S+) STATE'

--- a/hotsos/defs/events/openstack/nova/external-events.yaml
+++ b/hotsos/defs/events/openstack/nova/external-events.yaml
@@ -1,3 +1,4 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 input:
   path: 'var/log/nova/nova-compute.log'
   options:
@@ -7,6 +8,6 @@ input:
 # Supported events - https://docs.openstack.org/api-ref/compute/?expanded=run-events-detail#create-external-events-os-server-external-events  # noqa E501
 events:
   network-changed:
-    expr: '.+\[instance: (\S+)\].+Received event (network-changed)-(\S+)\s+'
+    expr: '[\d-]+ [\d:]+\.\d{3} .+\[instance: (\S+)\].+Received event (network-changed)-(\S+)\s+'
   network-vif-plugged:
-    expr: '.+\[instance: (\S+)\].+Preparing to wait for external event (network-vif-plugged)-(\S+)\s+'
+    expr: '[\d-]+ [\d:]+\.\d{3} .+\[instance: (\S+)\].+Preparing to wait for external event (network-vif-plugged)-(\S+)\s+'

--- a/hotsos/defs/events/openstack/nova/migrations/live-migration/dst-pre-live-migration.yaml
+++ b/hotsos/defs/events/openstack/nova/migrations/live-migration/dst-pre-live-migration.yaml
@@ -1,3 +1,4 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 passthrough-results: True
-start: '^([0-9\-]+) (\S+) .+ \[instance: (\S+)\] pre_live_migration data is LibvirtLiveMigrateData'
-end: '^([0-9\-]+) (\S+) .+ \[instance: (\S+)\] pre_live_migration result data is LibvirtLiveMigrateData'
+start: '([\d-]+) ([\d:]+)\.\d{3} .+ \[instance: (\S+)\] pre_live_migration data is LibvirtLiveMigrateData'
+end: '([\d-]+) ([\d:]+)\.\d{3} .+ \[instance: (\S+)\] pre_live_migration result data is LibvirtLiveMigrateData'

--- a/hotsos/defs/events/openstack/nova/migrations/live-migration/src-migration.yaml
+++ b/hotsos/defs/events/openstack/nova/migrations/live-migration/src-migration.yaml
@@ -1,4 +1,5 @@
-start: '^([0-9\-]+) (\S+)\.\d+ .+ \[instance: (\S+)\] About to invoke the migrate API _live_migration_operation'
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
+start: '([\d-]+) ([\d:]+)\.\d{3} .+ \[instance: (\S+)\] About to invoke the migrate API _live_migration_operation'
 body:
-  - '^([0-9\-]+) (\S+)\.\d+ .+ \[instance: (\S+)\] Migration running for \d+ secs, memory (\d+)% remaining .+ disk (\d+)% remaining'
-end: '^([0-9\-]+) (\S+)\.\d+ .+ \[instance: (\S+)\] Migration operation has completed'
+  - '([\d-]+) ([\d:]+)\.\d{3} .+ \[instance: (\S+)\] Migration running for \d+ secs, memory (\d+)% remaining .+ disk (\d+)% remaining'
+end: '([\d-]+) ([\d:]+)\.\d{3} .+ \[instance: (\S+)\] Migration operation has completed'

--- a/hotsos/defs/events/openstack/nova/migrations/live-migration/src-post-live-migration.yaml
+++ b/hotsos/defs/events/openstack/nova/migrations/live-migration/src-post-live-migration.yaml
@@ -1,3 +1,4 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 passthrough-results: True
-start: '^([0-9\-]+) (\S+) .+ \[instance: (\S+)\] _post_live_migration() is started'
-end: '^([0-9\-]+) (\S+) .+ \[instance: (\S+)\] VM Stopped (Lifecycle Event)'
+start: '([\d-]+) ([\d:]+)\.\d{3} .+ \[instance: (\S+)\] _post_live_migration() is started'
+end: '([\d-]+) ([\d:]+)\.\d{3} .+ \[instance: (\S+)\] VM Stopped (Lifecycle Event)'

--- a/hotsos/defs/events/openstack/nova/nova-compute.yaml
+++ b/hotsos/defs/events/openstack/nova/nova-compute.yaml
@@ -1,6 +1,7 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 input:
   path: 'var/log/nova/nova-compute.log'
 warnings:
   pci-dev-not-found:
-    expr: '^([0-9\-]+) (\S+) .+ No net device was found for VF \S+: nova.exception.PciDeviceNotFoundById: PCI device (\S+) not found'
+    expr: '([\d-]+) ([\d:]+)\.\d{3} .+ No net device was found for VF \S+: nova.exception.PciDeviceNotFoundById: PCI device (\S+) not found'
     hint: 'WARNING'

--- a/hotsos/defs/events/openstack/octavia.yaml
+++ b/hotsos/defs/events/openstack/octavia.yaml
@@ -1,15 +1,16 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 octavia-health-manager:
   input:
     path: 'var/log/octavia/octavia-health-manager.log'
   amp-missed-heartbeats:
-    expr: '^(\S+) \S+ .+ Amphora (\S+) health message was processed too slowly:.+'
+    expr: '([\d-]+) ([\d:]+)\.\d{3} .+ Amphora (\S+) health message was processed too slowly:.+'
     hint: 'Amphora'
   lb-failover-auto:
-    expr: '^(\S+) \S+ .+ Performing failover for amphora:\s+(.+)'
+    expr: '([\d-]+) ([\d:]+)\.\d{3} .+ Performing failover for amphora:\s+(.+)'
     hint: 'failover'
 octavia-worker:
   lb-failover-manual:
     input:
       path: 'var/log/octavia/octavia-worker.log'
-    expr: '^(\S+) \S+ .+ Performing failover for amphora:\s+(.+)'
+    expr: '([\d-]+) ([\d:]+)\.\d{3} .+ Performing failover for amphora:\s+(.+)'
     hint: 'failover'

--- a/hotsos/defs/events/openvswitch/ovn/errors-and-warnings.yaml
+++ b/hotsos/defs/events/openvswitch/ovn/errors-and-warnings.yaml
@@ -1,20 +1,21 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 ovsdb-server-sb:
   input:
     path: 'var/log/ovn/ovsdb-server-sb.log'
   hint: '(ERR|WARN|EMER)'
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
 ovsdb-server-nb:
   input:
     path: 'var/log/ovn/ovsdb-server-nb.log'
   hint: '(ERR|WARN|EMER)'
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
 ovn-northd:
   input:
     path: 'var/log/ovn/ovn-northd.log'
   hint: '(ERR|WARN|EMER)'
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
 ovn-controller:
   input:
     path: 'var/log/ovn/ovn-controller.log'
   hint: '(ERR|WARN|EMER)'
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'

--- a/hotsos/defs/events/openvswitch/ovn/ovn-central.yaml
+++ b/hotsos/defs/events/openvswitch/ovn/ovn-central.yaml
@@ -1,31 +1,32 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 ovsdb-server-sb:
   input:
     path: 'var/log/ovn/ovsdb-server-sb.log'
   inactivity-probe:
-    expr: '([0-9-]+)T[0-9:\.]+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
+    expr: '([\d-]+)T[\d:]+\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
   unreasonably-long-poll-interval:
-    expr: '([0-9-]+)T[0-9:\.]+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
+    expr: '([\d-]+)T[\d:]+\.\d+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
   leadership-transfers:
     expr:
-      - '([0-9-]+)T[0-9:\.]+Z.+\|raft\|INFO\|received leadership transfer from '
-      - '([0-9-]+)T[0-9:\.]+Z.+\|raft\|INFO\|Transferring leadership to write a snapshot.'
+      - '([\d-]+)T[\d:]+\.\d+Z.+\|raft\|INFO\|received leadership transfer from '
+      - '([\d-]+)T[\d:]+\.\d+Z.+\|raft\|INFO\|Transferring leadership to write a snapshot.'
   compactions:
-    expr: '([0-9-]+)T[0-9:\.]+Z.+\|ovsdb\|INFO\|OVN_Southbound: Database compaction'
+    expr: '([\d-]+)T[\d:]+\.\d+Z.+\|ovsdb\|INFO\|OVN_Southbound: Database compaction'
 ovsdb-server-nb:
   input:
     path: 'var/log/ovn/ovsdb-server-nb.log'
   inactivity-probe:
-    expr: '([0-9-]+)T[0-9:\.]+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
+    expr: '([\d-]+)T[\d:]+\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
   unreasonably-long-poll-interval:
-    expr: '([0-9-]+)T[0-9:\.]+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
+    expr: '([\d-]+)T[\d:]+\.\d+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
   leadership-transfers:
     expr:
-      - '([0-9-]+)T[0-9:\.]+Z.+\|raft\|INFO\|received leadership transfer from '
-      - '([0-9-]+)T[0-9:\.]+Z.+\|raft\|INFO\|Transferring leadership to write a snapshot.'
+      - '([\d-]+)T[\d:]+\.\d+Z.+\|raft\|INFO\|received leadership transfer from '
+      - '([\d-]+)T[\d:]+\.\d+Z.+\|raft\|INFO\|Transferring leadership to write a snapshot.'
   compactions:
-    expr: '([0-9-]+)T[0-9:\.]+Z.+\|ovsdb\|INFO\|OVN_Northbound: Database compaction'
+    expr: '([\d-]+)T[\d:]+\.\d+Z.+\|ovsdb\|INFO\|OVN_Northbound: Database compaction'
 northd:
   input:
     path: 'var/log/ovn/ovn-northd.log'
   inactivity-probe:
-    expr: '([0-9-]+)T[0-9:\.]+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
+    expr: '([\d-]+)T[\d:]+\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'

--- a/hotsos/defs/events/openvswitch/ovn/ovn-controller.yaml
+++ b/hotsos/defs/events/openvswitch/ovn/ovn-controller.yaml
@@ -1,11 +1,13 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 input:
   path: 'var/log/ovn/ovn-controller.log'
 unreasonably-long-poll-interval:
-  expr: '^([0-9-]+)T[0-9:\.]+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
   hint: 'Unreasonably'
 bridge-not-found-for-port:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|\S+\|ERR\|bridge not found for localnet port ''(\S+)'' with network name ''\S+'''
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|\S+\|ERR\|bridge not found for localnet port ''(\S+)'' with network name ''\S+'''
   hint: 'bridge not found'
 involuntary-context-switches:
-  expr: '([0-9-]+)T(\d+):\d+:\d+\.\S+Z.+\|timeval\|WARN\|context switches: \d+ voluntary, (\d+) involuntary'
+  # we capture date and hour as subgroups
+  expr: '([\d-]+)T(\d+):[\d:]+\.\d+Z.+\|timeval\|WARN\|context switches: \d+ voluntary, (\d+) involuntary'
   hint: timeval

--- a/hotsos/defs/events/openvswitch/ovs/bfd.yaml
+++ b/hotsos/defs/events/openvswitch/ovs/bfd.yaml
@@ -1,4 +1,5 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 input:
   path: 'var/log/openvswitch/ovs-vswitchd.log'
 bfd-state-changes:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|bfd(?:\S+)?\|\S+\|(\S+): BFD state change: (\S+)'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|bfd(?:\S+)?\|\S+\|(\S+): BFD state change: (\S+)'

--- a/hotsos/defs/events/openvswitch/ovs/errors-and-warnings.yaml
+++ b/hotsos/defs/events/openvswitch/ovs/errors-and-warnings.yaml
@@ -1,10 +1,11 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 ovs-vswitchd:
   input:
     path: 'var/log/openvswitch/ovs-vswitchd.log'
   hint: '(ERR|WARN|EMER)'
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
 ovsdb-server:
   input:
     path: 'var/log/openvswitch/ovsdb-server.log'
   hint: '(ERR|WARN|EMER)'
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)\|.+'

--- a/hotsos/defs/events/openvswitch/ovs/ovs-vswitchd.yaml
+++ b/hotsos/defs/events/openvswitch/ovs/ovs-vswitchd.yaml
@@ -1,22 +1,24 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 input:
   path: 'var/log/openvswitch/ovs-vswitchd.log'
 netdev-linux-no-such-device:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|(\S+): .+ \S+: No such device'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(\S+): .+ \S+: No such device'
 bridge-no-such-device:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|could not open network device (\S+) \(No such device\)'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|could not open network device (\S+) \(No such device\)'
 unreasonably-long-poll-interval:
-  expr: '^([0-9-]+)T[0-9:\.]+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
 rx-packet-on-unassociated-datapath-port:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|received packet on unassociated datapath port (\d+)'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|received packet on unassociated datapath port (\d+)'
 receive-tunnel-port-not-found:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|receive tunnel port not found \((\w+),'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|receive tunnel port not found \((\w+),'
 dpif-netlink-lost-packet-on-handler:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|system@ovs-system: lost packet on port channel.+'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|system@ovs-system: lost packet on port channel.+'
 inactivity-probe:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
 involuntary-context-switches:
-  expr: '([0-9-]+)T(\d+):\d+:\d+\.\S+Z.+\|timeval\|WARN\|context switches: 0 voluntary, (\d+) involuntary'
+  # we capture date and hour as subgroups
+  expr: '([\d-]+)T(\d+):[\d:]+\.\d+Z.+\|timeval\|WARN\|context switches: 0 voluntary, (\d+) involuntary'
   hint: timeval
 assertion-failures:
-  expr: '([0-9-]+)T[0-9:\.]+Z.+\|util.+\|EMER\|\S+: assertion '
+  expr: '([\d-]+)T[\d:]+\.\d+Z.+\|util.+\|EMER\|\S+: assertion '
   hint: assertion

--- a/hotsos/defs/events/storage/ceph/mon/monlogs.yaml
+++ b/hotsos/defs/events/storage/ceph/mon/monlogs.yaml
@@ -1,15 +1,16 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 input:
   path: ['var/log/ceph/ceph.log', 'var/log/ceph/ceph-mon*.log']
 osd-reported-failed:
-  expr: '^([0-9-]+)\S* \S+ .+ (osd.[0-9]+) reported failed by osd.[0-9]+'
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ (osd.[0-9]+) reported failed by osd.[0-9]+'
   hint: 'reported failed'
 mon-elections-called:
-  expr: '^([0-9-]+)\S* \S+ .+ (mon.\S+) calling monitor election'
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ (mon.\S+) calling monitor election'
   hint: 'calling monitor election'
 long-heartbeat-pings:
-  expr: '^([0-9-]+)\S* \S+ .+ Long heartbeat ping times on \S+ interface seen'
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ Long heartbeat ping times on \S+ interface seen'
   hint: 'Long heartbeat ping'
 heartbeat-no-reply:
-  expr: '^([0-9-]+)\S* \S+ \S+ \S+ osd.[0-9]+ .+ heartbeat_check: no reply from [0-9.:]+ (osd.[0-9]+)'
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ osd.[0-9]+ .+ heartbeat_check: no reply from [0-9.:]+ (osd.[0-9]+)'
   hint: 'heartbeat_check'
 

--- a/hotsos/defs/events/storage/ceph/osd/osdlogs.yaml
+++ b/hotsos/defs/events/storage/ceph/osd/osdlogs.yaml
@@ -1,14 +1,11 @@
+# NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 input:
   path: 'var/log/ceph/ceph-osd*.log'
 slow-requests:
-  expr: '^([0-9-]+)\S* \S+ .+ ([0-9]+) slow requests are blocked .+ \(REQUEST_SLOW\)'
-  hint: 'REQUEST_SLOW'
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ ([0-9]+) slow requests are blocked .+ \(REQUEST_SLOW\)'
 crc-err-bluestore:
-  expr: '^([0-9-]+)\S* .+ _verify_csum bad .+'
-  hint: '_verify_csum'
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ _verify_csum bad .+'
 crc-err-rocksdb:
-  expr: '^([0-9-]+)\S* .+ rocksdb: .+block checksum mismatch'
-  hint: 'checksum mismatch'
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ rocksdb: .+block checksum mismatch'
 superblock-read-error:
-  expr: '.+ unable to read osd superblock'
-  hint: 'osd superblock'
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ unable to read osd superblock'

--- a/hotsos/defs/scenarios/juju/bugs/lp1812361.yaml
+++ b/hotsos/defs/scenarios/juju/bugs/lp1812361.yaml
@@ -1,7 +1,7 @@
 checks:
   has_lp1812361:
     input: 'var/log/juju/unit-glance-simplestreams-sync*.log'
-    expr: '\S+ \S+ INFO unit.glance-simplestreams-sync/\d+\.juju-log \S+ (identity-service:\d+): Missing required data: internal_host internal_port'
+    expr: '[\d-]+ [\d:]+ INFO unit.glance-simplestreams-sync/\d+\.juju-log \S+ (identity-service:\d+): Missing required data: internal_host internal_port'
 conclusions:
   lp1812361:
     decision: has_lp1812361

--- a/hotsos/defs/scenarios/juju/bugs/lp1858519.yaml
+++ b/hotsos/defs/scenarios/juju/bugs/lp1858519.yaml
@@ -1,7 +1,7 @@
 checks:
   has_lp1858519:
     input: 'var/log/juju/unit-ceph-osd*.log'
-    expr: '\S+ \S+ INFO unit.(ceph-osd/\d+).juju-log server.go:\d+ Cannot zap a device used by lvm'
+    expr: '[\d-]+ [\d:]+ INFO unit.(ceph-osd/\d+).juju-log server.go:\d+ Cannot zap a device used by lvm'
 conclusions:
   lp1858519:
     decision: has_lp1858519

--- a/hotsos/defs/scenarios/juju/bugs/lp1895040.yaml
+++ b/hotsos/defs/scenarios/juju/bugs/lp1895040.yaml
@@ -2,7 +2,7 @@ checks:
   has_unknown_relation_errors:
     input:
       path: 'var/log/juju/unit-*.log'
-    expr: '(\S+) (\S+) ERROR juju.worker.uniter agent.go:\d+ resolver loop error: unknown relation: (\d+)'
+    expr: '([\d-]+) ([\d:]+) ERROR juju.worker.uniter agent.go:\d+ resolver loop error: unknown relation: (\d+)'
     constraints:
       # within 7 days
       search-result-age-hours: 168

--- a/hotsos/defs/scenarios/juju/bugs/lp1910958.yaml
+++ b/hotsos/defs/scenarios/juju/bugs/lp1910958.yaml
@@ -2,7 +2,7 @@ checks:
   has_lp1910958:
     input:
       path: 'var/log/juju/unit-*.log'
-    expr: '\S+ \S+ ERROR juju.worker.dependency engine.go:\d+ "uniter" manifold worker .+ error: failed to initialize uniter for "(\S+)": cannot create relation state tracker: cannot remove persisted state, relation (\d+) has members'
+    expr: '[\d-]+ [\d:]+ ERROR juju.worker.dependency engine.go:\d+ "uniter" manifold worker .+ error: failed to initialize uniter for "(\S+)": cannot create relation state tracker: cannot remove persisted state, relation (\d+) has members'
     hint: 'manifold worker returned unexpected error'
 conclusions:
   lp1910958:

--- a/hotsos/defs/scenarios/juju/bugs/lp1948906.yaml
+++ b/hotsos/defs/scenarios/juju/bugs/lp1948906.yaml
@@ -2,7 +2,7 @@ checks:
   has_lp1948906:
     input:
       path: 'var/log/juju/unit-*.log'
-    expr: '\S+ \S+ ERROR juju.worker.dependency engine.go:\d+ "uniter" manifold worker .+ error: executing operation "run post-series-upgrade hook" for (\S+): upgrade series status "complete running"'
+    expr: '[\d-]+ [\d:]+ ERROR juju.worker.dependency engine.go:\d+ "uniter" manifold worker .+ error: executing operation "run post-series-upgrade hook" for (\S+): upgrade series status "complete running"'
 conclusions:
   lp1948906:
     decision: has_lp1948906

--- a/hotsos/defs/scenarios/juju/bugs/lp1983140.yaml
+++ b/hotsos/defs/scenarios/juju/bugs/lp1983140.yaml
@@ -2,7 +2,7 @@ checks:
   has_lp1983140:
     input:
       path: 'var/log/juju/machine-*.log'
-    expr: '.* quiescing, timed out waiting for agents to report'
+    expr: '([\d-]+) [\d:]+ .+ quiescing, timed out waiting for agents to report'
 conclusions:
   lp1983140:
     decision: has_lp1983140

--- a/hotsos/defs/scenarios/juju/bugs/lp1983506.yaml
+++ b/hotsos/defs/scenarios/juju/bugs/lp1983506.yaml
@@ -2,7 +2,7 @@ checks:
   has_lp1983506:
     input:
       path: 'var/log/juju/machine-*.log'
-    expr: '.* failed to migrate binaries: charm local:(\S+) unexpectedly assigned local:'
+    expr: '[\d-]+ [\d:]+ .+ failed to migrate binaries: charm local:(\S+) unexpectedly assigned local:'
 conclusions:
   lp1983506:
     decision: has_lp1983506

--- a/hotsos/defs/scenarios/juju/bugs/lp1996230.yaml
+++ b/hotsos/defs/scenarios/juju/bugs/lp1996230.yaml
@@ -2,7 +2,7 @@ checks:
   has_lp1996230:
     input:
       path: 'var/log/juju/machine-*.log'
-    expr: '\S+ \S+ ERROR juju.worker.dependency engine.go:\d+ "\S+" manifold worker .+ error: could not retrieve action (\S+): action no longer available'
+    expr: '[\d-]+ [\d:]+ ERROR juju.worker.dependency engine.go:\d+ "\S+" manifold worker .+ error: could not retrieve action (\S+): action no longer available'
 conclusions:
   lp1996230:
     decision: has_lp1996230

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1883089.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1883089.yaml
@@ -2,7 +2,7 @@ checks:
   has_1883089:
     input:
       path: 'var/log/neutron/neutron-l3-agent.log'
-    expr: '.+AttributeError: ''NoneType'' object has no attribute ''get'''
+    expr: '([\d-]+) [\d:]+\.\d{3} .+AttributeError: ''NoneType'' object has no attribute ''get'''
     hint: 'AttributeError'
 conclusions:
   lp1883089:

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1907686.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1907686.yaml
@@ -4,7 +4,7 @@ checks:
   has_1907686:
     input:
       path: 'var/log/neutron/neutron-openvswitch-agent.log'
-    expr: '.+OVS database connection to OVN_\S+bound failed with error: ''Timeout''.+'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+OVS database connection to OVN_\S+bound failed with error: ''Timeout''.+'
 conclusions:
   lp1907686:
     decision:

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1928031.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1928031.yaml
@@ -2,8 +2,7 @@ checks:
   has_1928031:
     input:
       path: 'var/log/neutron/neutron-ovn-metadata-agent.log'
-    expr: '.+AttributeError: ''MetadataProxyHandler'' object has no attribute ''sb_idl'''
-    hint: 'AttributeError'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+AttributeError: ''MetadataProxyHandler'' object has no attribute ''sb_idl'''
 conclusions:
   lp1928031:
     decision: has_1928031

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1929832.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1929832.yaml
@@ -2,8 +2,7 @@ checks:
   has_1929832:
     input:
       path: 'var/log/neutron/neutron-l3-agent.log'
-    expr: '.+Error while deleting router \S+: \S+ProcessExecutionError: .+ /usr/bin/neutron-rootwrap: Unauthorized command: kill -15 \d+ \(no filter matched\)'
-    hint: 'ProcessExecutionError'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+Error while deleting router \S+: \S+ProcessExecutionError: .+ /usr/bin/neutron-rootwrap: Unauthorized command: kill -15 \d+ \(no filter matched\)'
 conclusions:
   lp1929832:
     decision: has_1929832

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1960319.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1960319.yaml
@@ -1,7 +1,7 @@
 checks:
   has_1960319_log:
     input: var/log/neutron/neutron-server.log
-    expr: '(\S+\s+[\d:]+).\S+ .+ ovsdbapp.event FileNotFoundError: \[Errno 2\] No such file or directory: ''ovsdb-client'''
+    expr: '([\d-]+) ([\d:]+)\.\d{3} .+ ovsdbapp.event FileNotFoundError: \[Errno 2\] No such file or directory: ''ovsdb-client'''
     constraints:
       search-result-age-hours: 168  # 7 days
   has_1960319_package:

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1965297.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1965297.yaml
@@ -2,7 +2,7 @@ checks:
   has_1965297:
     input:
       path: 'var/log/neutron/neutron-l3-agent.log'
-    expr: '.+Gateway interface for router \S+ was not set up; router will not work properly'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+Gateway interface for router \S+ was not set up; router will not work properly'
 conclusions:
   lp1965297:
     decision: has_1965297

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1979089.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1979089.yaml
@@ -3,7 +3,7 @@ checks:
     input:
       path: 'var/log/neutron/neutron-l3-agent.log'
     search:
-      expr: '(\S+\s+[\d:]+).\S+ .+ Cannot open network namespace "qrouter-\S+": No such file or directory'
+      expr: '([\d-]+) ([\d:]+)\.\d{3} .+ Cannot open network namespace "qrouter-\S+": No such file or directory'
       hint: 'ERROR neutron.agent.linux.utils'
       constraints:
         # if we hit this bug there will be a large number in a small space of time

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1993628.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1993628.yaml
@@ -2,7 +2,7 @@ checks:
   logs:
     input: var/log/neutron/neutron-server.log
     search:
-      expr: '(\S+\s+[\d:]+).\S+ .+ neutron_lib.exceptions.dns.DuplicateRecordSet: Name \S+ is duplicated in the external DNS service'
+      expr: '([\d-]+) ([\d:]+)\.\d{3} .+ neutron_lib.exceptions.dns.DuplicateRecordSet: Name \S+ is duplicated in the external DNS service'
       constraints:
         search-result-age-hours: 168  # max 7 days
 conclusions:

--- a/hotsos/defs/scenarios/openstack/neutron/ovn_stale_db.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/ovn_stale_db.yaml
@@ -15,13 +15,13 @@ checks:
       - var/log/neutron/neutron-server.log
       - var/log/neutron/neutron-ovn-metadata-agent.log
     # note: neutron-server and neutron-ovn-metadata-agent use different ports to speak to the southbound db (16642/6642)
-    expr: '(\S+\s+[\d:]+).\S+ .+ ovsdbapp.backend.ovs_idl.vlog \[-\] ssl:\S+:1?6642: clustered database server has stale data; trying another server'
+    expr: '([\d-]+) ([\d:]+)\.\d{3} .+ ovsdbapp.backend.ovs_idl.vlog \[-\] ssl:\S+:1?6642: clustered database server has stale data; trying another server'
     constraints:
       min-results: 10
       search-result-age-hours: 6
   has_1829109_ovn_controller_log:
     input: var/log/ovn/ovn-controller.log
-    expr: '([0-9-]+)T([0-9:\.]+)Z.+\|ovsdb_idl\|WARN\|tcp:\S+:6642: clustered database server has stale data; trying another server'
+    expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|ovsdb_idl\|WARN\|tcp:\S+:6642: clustered database server has stale data; trying another server'
     constraints:
       min-results: 10
       search-result-age-hours: 6

--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp1860743.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp1860743.yaml
@@ -2,7 +2,7 @@ checks:
   has_1860743:
     input:
       path: 'var/log/nova/nova-compute.log'
-    expr: '.+Live Migration failure: operation failed: Failed to connect to remote libvirt URI .+Cannot recv data: Host key verification failed\.: Connection reset by peer: libvirtError: operation failed: Failed to connect to remote libvirt URI.+Cannot recv data: Host key verification failed\.: Connection reset by peer'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+Live Migration failure: operation failed: Failed to connect to remote libvirt URI .+Cannot recv data: Host key verification failed\.: Connection reset by peer: libvirtError: operation failed: Failed to connect to remote libvirt URI.+Cannot recv data: Host key verification failed\.: Connection reset by peer'
     hint: 'libvirtError'
 conclusions:
   lp1860743:

--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp1888395.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp1888395.yaml
@@ -2,7 +2,7 @@ checks:
   has_1888395_pt1:
     input:
       path: 'var/log/nova/nova-compute.log'
-    expr: '.+NotImplementedError: Cannot load ''vifs'' in the base class'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+NotImplementedError: Cannot load ''vifs'' in the base class'
     hint: 'NotImplementedError'
   has_1888395_pt2:
     apt:

--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp1944619.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp1944619.yaml
@@ -2,7 +2,7 @@ checks:
   has_1944619:
     input:
       path: 'var/log/nova/nova-compute.log'
-    expr: '.+attaching network adapter failed.: libvirt.libvirtError: Requested operation is not valid: PCI device'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+attaching network adapter failed.: libvirt.libvirtError: Requested operation is not valid: PCI device'
     hint: 'libvirtError'
 conclusions:
   lp1944619:

--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp1967956.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp1967956.yaml
@@ -3,7 +3,7 @@ checks:
     input:
       path: 'var/log/nova/nova-compute.log'
     search:
-      expr: '^([\d-]+\s+[\d:]+)\S+ .+ libvirt.libvirtError: Cannot access storage file ''\S+'' \(as uid:\d+, gid:\d+\): Permission denied'
+      expr: '([\d-]+) ([\d:]+)\.\d{3} .+ libvirt.libvirtError: Cannot access storage file ''\S+'' \(as uid:\d+, gid:\d+\): Permission denied'
       hint: ERROR
       constraints:
         search-result-age-hours: 168  # 7 days

--- a/hotsos/defs/scenarios/openstack/octavia/bugs/sb1896125.yaml
+++ b/hotsos/defs/scenarios/openstack/octavia/bugs/sb1896125.yaml
@@ -11,7 +11,7 @@ checks:
   has_2008099_logs:
     input:
       path: 'var/log/octavia/octavia-worker.log'
-    expr: '.+octavia.amphorae.drivers.haproxy.exceptions .+ Removing incomplete section ''peers'
+    expr: '([\d-]+) [\d:]+\.\d{3} \d+ ERROR octavia.amphorae.drivers.haproxy.exceptions .+ Removing incomplete section ''peers'
     hint: octavia.amphorae.drivers.haproxy.exceptions
 conclusions:
   2008099:

--- a/hotsos/defs/scenarios/openstack/octavia/excessive_failovers.yaml
+++ b/hotsos/defs/scenarios/openstack/octavia/excessive_failovers.yaml
@@ -2,7 +2,7 @@ checks:
   auto_failovers_day_limit:
     input:
       path: 'var/log/octavia/octavia-health-manager.log'
-    expr: '([\d-]+) ([\d:]+)\.\d+ \d+ INFO \S+ \S+ Performing failover for amphora: (.+)'
+    expr: '([\d-]+) ([\d:]+)\.\d{3} \d+ INFO \S+ \S+ Performing failover for amphora: (.+)'
     constraints:
       search-result-age-hours: 48
       search-period-hours: 24
@@ -10,7 +10,7 @@ checks:
   auto_failovers_hour_limit:
     input:
       path: 'var/log/octavia/octavia-health-manager.log'
-    expr: '([\d-]+) ([\d:]+)\.\d+ \d+ INFO \S+ \S+ Performing failover for amphora: (.+)'
+    expr: '([\d-]+) ([\d:]+)\.\d{3} \d+ INFO \S+ \S+ Performing failover for amphora: (.+)'
     constraints:
       search-result-age-hours: 48
       search-period-hours: 1

--- a/hotsos/defs/scenarios/openvswitch/bugs/lp1978806.yaml
+++ b/hotsos/defs/scenarios/openvswitch/bugs/lp1978806.yaml
@@ -4,18 +4,19 @@ input:
     kwargs:
       datapath: 'system@ovs-system'
 checks:
+  # NOTE: we don't extract any info from the following searches so they define the smallest group possible so as to minimise saved data.
   ovs_using_geneve:
     input:
       command: ovs_appctl_ofproto_list_tunnels
-    search: '.+ \(geneve:'
+    search: '.+ \((g)eneve:'
   ovs_using_vxlan:
     input:
       command: ovs_appctl_ofproto_list_tunnels
-    search: '.+ \(vxlan:'
+    search: '.+ \((v)xlan:'
   geneve_is_tracked:
-    search: '^udp,.+,sport=6081,'
+    search: '^(u)dp,.+,sport=6081,'
   vxlan_is_tracked:
-    search: '^udp,.+,sport=4789,'
+    search: '^(u)dp,.+,sport=4789,'
 conclusions:
   ovs_ct_tunnels:
     decision:

--- a/hotsos/defs/scenarios/openvswitch/dpif_lost_packets.yaml
+++ b/hotsos/defs/scenarios/openvswitch/dpif_lost_packets.yaml
@@ -22,7 +22,7 @@ checks:
     varops: [[$num_lost_packets], [gt, 5]]  # allow a very small number
   dpif_netlink_lost_packet_on_handler:
     search:
-      expr: '([0-9-]+)T([0-9:\.]+)Z.+\|system@ovs-system: lost packet on port channel.+'
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|system@ovs-system: lost packet on port channel.+'
       constraints:
         min-results: 10  # allow a very small number
         search-period-hours: 24

--- a/hotsos/defs/scenarios/openvswitch/dpif_resubmit_actions.yaml
+++ b/hotsos/defs/scenarios/openvswitch/dpif_resubmit_actions.yaml
@@ -4,7 +4,7 @@ input:
 checks:
   dpif_resubmit_limit_reached:
     search:
-      expr: '([0-9-]+)T([0-9:\.]+)Z.+\|WARN\|over (\d+) resubmit actions on bridge (\S+) while processing'
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|WARN\|over (\d+) resubmit actions on bridge (\S+) while processing'
       constraints:
         min-results: 5
         search-period-hours: 24

--- a/hotsos/defs/scenarios/openvswitch/ovn/bfd_flapping.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/bfd_flapping.yaml
@@ -3,7 +3,7 @@ checks:
     input:
       path: var/log/openvswitch/ovs-vswitchd.log
     search:
-      expr: '([0-9-]+)T([0-9:\.]+)Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
       constraints:
         # trigger if we at least this many in 1 hour period and look at last 24 hours only.
         min-results: 10
@@ -13,7 +13,7 @@ checks:
     input:
       path: var/log/openvswitch/ovs-vswitchd.log
     search:
-      expr: '([0-9-]+)T([0-9:\.]+)Z.+\|bfd\(\S+\)\|INFO\|[a-z0-9-]+: BFD state change'
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|bfd\(\S+\)\|INFO\|[a-z0-9-]+: BFD state change'
       constraints:
         # trigger if we at least this many in 1 hour period and look at last 24 hours only.
         min-results: 10
@@ -23,7 +23,7 @@ checks:
     input:
       path: var/log/ovn/ovn-controller.log
     search:
-      expr: '([0-9-]+)T([0-9:\.]+)Z.+\|binding\|INFO\|(Claiming|Releasing) lport cr-lrp-\S+ for this chassis.'
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|binding\|INFO\|(Claiming|Releasing) lport cr-lrp-\S+ for this chassis.'
       constraints:
         # trigger if we see at least this many in last 24 hours.
         min-results: 20

--- a/hotsos/defs/scenarios/openvswitch/ovn/bugs/lp1865127.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/bugs/lp1865127.yaml
@@ -1,9 +1,11 @@
 checks:
-  has_1865127:
-    input:
-      path: 'var/log/ovn/ovn-controller.log'
-    expr: '.+ERR\|bridge not found for localnet port \S+ with network name'
-  1865127_broken_package:
+  1865127_logs:
+    input: 'var/log/ovn/ovn-controller.log'
+    search:
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+ERR\|bridge not found for localnet port \S+ with network name'
+      constraints:
+        search-result-age-hours: 24
+  1865127_apt_broken_package:
     apt:
       ovn-common:
         - min: 0
@@ -11,8 +13,8 @@ checks:
 conclusions:
   lp1865127:
     decision:
-      - has_1865127
-      - 1865127_broken_package
+      - 1865127_logs
+      - 1865127_apt_broken_package
     raises:
       type: LaunchpadBug
       bug-id: 1865127

--- a/hotsos/defs/scenarios/openvswitch/ovn/bugs/lp1917475.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/bugs/lp1917475.yaml
@@ -1,8 +1,10 @@
 checks:
   has_1917475:
-    input:
-      path: 'var/log/ovn/ovn-controller.log'
-    expr: '.+transaction error: {"details":"RBAC rules for client \\"\S+\\" role \\"\S+\\" prohibit .+ table\s+\\"\S+\\".","error":"permission error"'
+    input: 'var/log/ovn/ovn-controller.log'
+    search:
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+transaction error: {"details":"RBAC rules for client \\"\S+\\" role \\"\S+\\" prohibit .+ table\s+\\"\S+\\".","error":"permission error"'
+      constraints:
+        search-result-age-hours: 24
 conclusions:
   lp1917475:
     decision: has_1917475

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_central_certs_logs.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_central_certs_logs.yaml
@@ -4,8 +4,8 @@ vars:
   northd_start_time: '@hotsos.core.host_helpers.systemd.ServiceFactory.start_time_secs:ovn-northd'
   ovsdb_nb_start_time: '@hotsos.core.host_helpers.systemd.ServiceFactory.start_time_secs:ovn-ovsdb-server-nb'
   ovsdb_sb_start_time: '@hotsos.core.host_helpers.systemd.ServiceFactory.start_time_secs:ovn-ovsdb-server-sb'
-  cert_expired_expr: '([0-9-]+)T([0-9:\.]+)Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired'
-  cert_invalid_expr: '([0-9-]+)T([0-9:\.]+)Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:tls_process_client_certificate:certificate verify failed'
+  cert_expired_expr: '([\d-]+)T([\d:]+)\.\d+Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired'
+  cert_invalid_expr: '([\d-]+)T([\d:]+)\.\d+Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:tls_process_client_certificate:certificate verify failed'
 checks:
   services_not_restarted_after_cert_update:
     - systemd: [ovn-northd, ovn-ovsdb-server-nb, ovn-ovsdb-server-sb]

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_chassis_certs_logs.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_chassis_certs_logs.yaml
@@ -2,8 +2,8 @@ vars:
   host_cert_mtime: '@hotsos.core.host_helpers.filestat.FileFactory.mtime:etc/ovn/cert_host'
   ovn_chassis_cert_mtime: '@hotsos.core.host_helpers.filestat.FileFactory.mtime:etc/ovn/ovn-chassis.crt'
   ovn_controller_start_time: '@hotsos.core.host_helpers.systemd.ServiceFactory.start_time_secs:ovn-controller'
-  cert_expired_expr: '([0-9-]+)T([0-9:\.]+)Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired'
-  cert_invalid_expr: '([0-9-]+)T([0-9:\.]+)Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:tls_process_client_certificate:certificate verify failed'
+  cert_expired_expr: '([\d-]+)T([\d:]+)\.\d+Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired'
+  cert_invalid_expr: '([\d-]+)T([\d:]+)\.\d+Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:tls_process_client_certificate:certificate verify failed'
 checks:
   services_not_restarted_after_cert_update:
     - systemd: ovn-controller

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_db_upgrade.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_db_upgrade.yaml
@@ -8,7 +8,7 @@ checks:
           max: 20.03.2-0ubuntu0.20.04.3
   has_northd_version_mismatch:
     input: var/log/ovn/ovn-controller.log
-    expr: '([0-9-]+)T([0-9:\.]+)Z\|\S+\|main\|WARN\|controller version - (\S+) mismatch with northd version - (\S+)'
+    expr: '([\d-]+)T([\d:]+)\.\d+Z\|\S+\|main\|WARN\|controller version - (\S+) mismatch with northd version - (\S+)'
     constraints:
       search-result-age-hours: 336  # 14 days
 conclusions:

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_elections.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_elections.yaml
@@ -3,7 +3,7 @@ checks:
     input:
       path: var/log/ovn/ovsdb-server-sb.log
     search:
-      expr: '([0-9-]+)T([0-9:\.]+)Z.+\|raft\|INFO\|term ([0-9]+):\s(([0-9]+) ms timeout expired, )?starting election$'
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|raft\|INFO\|term ([0-9]+):\s(([0-9]+) ms timeout expired, )?starting election$'
       constraints:
         min-results: 5
         search-period-hours: 1
@@ -12,7 +12,7 @@ checks:
     input:
       path: var/log/ovn/ovsdb-server-nb.log
     search:
-      expr: '([0-9-]+)T([0-9:\.]+)Z.+\|raft\|INFO\|term ([0-9]+):\s(([0-9]+) ms timeout expired, )?starting election$'
+      expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|raft\|INFO\|term ([0-9]+):\s(([0-9]+) ms timeout expired, )?starting election$'
       constraints:
         min-results: 5
         search-period-hours: 1

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovsdb_reconnect_errors.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovsdb_reconnect_errors.yaml
@@ -3,7 +3,7 @@ checks:
     input:
       - var/log/neutron/neutron-server.log
       - var/log/neutron/neutron-ovn-metadata-agent.log
-    expr: '.+ ovsdbapp.backend.ovs_idl.connection ValueError: non-zero flags not allowed in calls to send\(\) on <class ''eventlet.green.ssl.GreenSSLSocket''>'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+ ovsdbapp.backend.ovs_idl.connection ValueError: non-zero flags not allowed in calls to send\(\) on <class ''eventlet.green.ssl.GreenSSLSocket''>'
     hint: ERROR
   has_pyovs_with_reconnection_bug:
     apt:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
@@ -3,7 +3,7 @@ checks:
     input:
       path: var/log/ceph/ceph*.log
     search:
-      expr: '^([0-9-]+)\S* (\S+) .+ mon.\S+ calling monitor election'
+      expr: '^([\d-]+)[T ]([\d:]+)\S+ (\S+) .+ mon.\S+ calling monitor election'
       constraints:
         # i.e. must occur 5 times within same 24 hour period
         min-results: 5

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_flapping.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_flapping.yaml
@@ -4,7 +4,7 @@ checks:
   osd_flapping:
     input:
       path: var/log/ceph/ceph*.log
-    expr: '^([\d-]+)[T ]([\d:]+\.\d)\S+ .+ wrongly marked me down at .+'
+    expr: '([\d-])+[T ][\d:]+\S+ .+ wrongly marked me down at .+'
   ceph_interfaces_have_errors:
     property: hotsos.core.plugins.storage.ceph.CephChecksBase.has_interface_errors
 conclusions:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_slow_heartbeats.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_slow_heartbeats.yaml
@@ -3,7 +3,7 @@ checks:
     input:
       path: var/log/ceph/ceph*.log
     search:
-      expr: '^([\d-]+)T([\d:]+\.\d)\S+ .+ Slow OSD heartbeats on .+'
+      expr: '^([\d-]+)[T ]([\d:]+)\S+ .+ Slow OSD heartbeats on .+'
       constraints:
         # i.e. must occur 10 times within an hour
         min-results: 10

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_slow_ops.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_slow_ops.yaml
@@ -5,7 +5,7 @@ checks:
     input:
       path: var/log/ceph/ceph*.log
     search:
-      expr: '^([\d-]+)[T ]([\d:]+\.\d)\S+ .+ slow ops, oldest one blocked .+'
+      expr: '^([\d-]+)[T ]([\d:]+)\S+ .+ slow ops, oldest one blocked .+'
       constraints:
         # i.e. must occur 5 times within same 24 hour period
         min-results: 5

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/bugs/lp1996010.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/bugs/lp1996010.yaml
@@ -5,7 +5,7 @@ checks:
   has_1996010_osd_log:
     # NOTE: this needs quite a high debug level to appear - debug_bluestore=30/30
     input: var/log/ceph/ceph-osd.*.log
-    expr: '^([\d-]+)[T ]([\d:]+\.\d)\S+ .+ bluestore\.MempoolThread\(\S+\) _resize_shards max_shard_onodes: 0 '
+    expr: '([\d-]+)[T ][\d:]+\S+ .+ bluestore\.MempoolThread\(\S+\) _resize_shards max_shard_onodes: 0 '
   has_1996010_mempools:
     # this is a hack to check if a value less than 10 exists in the list
     or:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/osd_latency.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/osd_latency.yaml
@@ -3,7 +3,7 @@ checks:
     input:
       path: var/log/ceph/ceph*.log
     search:
-      expr: '^([\d-]+)[T ]([\d:]+\.\d)\S+ .+ slow operation observed .+'
+      expr: '^([\d-]+)[T ]([\d:]+)\S+ .+ slow operation observed .+'
       constraints:
         # Expect several in a row; anything that's temporary wouldn't result in
         # slow ops and likely to be a result of momentary extreme load.

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/pg_overdose.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/pg_overdose.yaml
@@ -7,7 +7,7 @@ checks:
     input:
       path: [var/log/ceph/ceph-osd*.log, var/log/ceph/ceph.log]
     search:
-      expr: '.+ (osd.+) .+ maybe_wait_for_max_pg withhold creation of pg .+: (.+) >= (.+)'
+      expr: '[\d-]+[T ][\d:]+\S+ .+ (osd.+) .+ maybe_wait_for_max_pg withhold creation of pg .+: (.+) >= (.+)'
 conclusions:
   pending_creating_pgs:
     decision:

--- a/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp1904580.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp1904580.yaml
@@ -1,7 +1,7 @@
 data-root:
   files:
     var/log/nova/nova-compute.log: |
-      2022-02-03 19:02:58.275 29845 INFO nova.compute.manager [req-1ca6c5ea-839d-454a-a7ac-f1f7df882f95 ca1265ef24834623b3ff360f95bbec9b caadf4ef9ccb4eae8a2f6ca0cb142827 - 28c08ee9c0114334a269a1f56b1d6724 28c08ee9c0114334a269a1f56b1d6724] [instance: ba04a48c-1dff-4015-a4f1-625946a40611] Setting instance back to active after: Instance rollback performed due to: Resize error: not able to execute ssh command: Unexpected error while running command.
+      2022-02-04 19:02:58.275 29845 INFO nova.compute.manager [req-1ca6c5ea-839d-454a-a7ac-f1f7df882f95 ca1265ef24834623b3ff360f95bbec9b caadf4ef9ccb4eae8a2f6ca0cb142827 - 28c08ee9c0114334a269a1f56b1d6724 28c08ee9c0114334a269a1f56b1d6724] [instance: ba04a48c-1dff-4015-a4f1-625946a40611] Setting instance back to active after: Instance rollback performed due to: Resize error: not able to execute ssh command: Unexpected error while running command.
       Command: ssh -o BatchMode=yes 10.5.1.153 mkdir -p /var/lib/nova/instances/ba04a48c-1dff-4015-a4f1-625946a40611
       Exit code: 255
       Stdout: ''

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/bugs/lp1865127.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/bugs/lp1865127.yaml
@@ -14,4 +14,3 @@ raised-bugs:
     messages containing "No bridge for localnet port ..." when
     that is in fact not an error. Upgrading to a version >=
     20.12.0 will fix the issue.
-

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/bugs/lp1917475.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/bugs/lp1917475.yaml
@@ -1,7 +1,7 @@
 data-root:
   files:
     var/log/ovn/ovn-controller.log: |
-      2022-09-22T01:13:33.307Z|00266|ovsdb_idl|WARN|transaction error: {"details":"RBAC rules for client \"compute5\" role \"ovn-controller\" prohibit row insertion into table \"IGMP_Group\".","error":"permission error"}
+      2022-02-10T01:13:33.307Z|00266|ovsdb_idl|WARN|transaction error: {"details":"RBAC rules for client \"compute5\" role \"ovn-controller\" prohibit row insertion into table \"IGMP_Group\".","error":"permission error"}
   copy-from-original:
     - uptime
     - sos_commands/date/date

--- a/hotsos/plugin_extensions/openstack/agent/events.py
+++ b/hotsos/plugin_extensions/openstack/agent/events.py
@@ -95,8 +95,7 @@ class APIEvents(OpenstackEventChecksBase):
                              event_names=['neutron'])
     def http_requests(self, event):
         results = [{'date': r.get(1),
-                    'time': r.get(2),
-                    'key': r.get(3)} for r in event.results]
+                    'key': r.get(2)} for r in event.results]
         ret = self.categorise_events(event, results=results)
         if ret:
             return ret
@@ -168,12 +167,12 @@ class OctaviaAgentEventChecks(OpenstackEventChecksBase):
     def lb_failovers(self, event):
         results = []
         for e in event.results:
-            payload = yaml.safe_load(e.get(2))
+            payload = yaml.safe_load(e.get(3))
             lb_id = payload.get('load_balancer_id')
             if lb_id is None:
                 continue
 
-            results.append({'date': e.get(1), 'key': lb_id})
+            results.append({'date': e.get(1), 'time': e.get(2), 'key': lb_id})
 
         ret = self.categorise_events(event, results=results, key_by_date=False)
         if ret:
@@ -282,12 +281,13 @@ class NeutronL3HAEventChecks(OpenstackEventChecksBase):
     def vrrp_transitions(self, event):
         results = []
         for r in event.results:
-            router = self.ha_info.find_router_with_vr_id(r.get(2))
+            router = self.ha_info.find_router_with_vr_id(r.get(3))
             if not router:
-                log.debug("could not find router with vr_id %s", r.get(2))
+                log.debug("could not find router with vr_id %s", r.get(3))
                 continue
 
-            results.append({'date': r.get(1), 'key': router.uuid})
+            results.append({'date': r.get(1), 'time': r.get(2),
+                            'key': router.uuid})
 
         transitions = self.categorise_events(event, results=results,
                                              key_by_date=False)


### PR DESCRIPTION
This patch aligns the format used to match start of line timestamps across events and scenarios for all plugins. It also ensures that (a) every search has at least one subgroup to avoid saving the entire matched string and (b) ensures that we only use a subgroup for time if it is actually needed since using it will increase memory usage due to hh:mm:ss values not being deduplicated.