### PR TITLE
Check libvirtd memory usage

### DIFF
--- a/hotsos/defs/scenarios/openstack/nova/service_mem_usage.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/service_mem_usage.yaml
@@ -1,0 +1,17 @@
+vars:
+  limit: 536870912  # 5G
+  libvirtd_usage: '@hotsos.core.host_helpers.systemd.ServiceFactory.memory_current:libvirtd'
+checks:
+  libvirtd_mem_use_above_limit:
+    systemd: libvirtd
+    varops: [[$libvirtd_usage], [gt, $limit]]
+conclusions:
+  northd_overuse:
+    decision: libvirtd_mem_use_above_limit
+    raises:
+      type: OpenstackWarning
+      message: >-
+        The libvirtd service is consuming more than 5G memory (current={usage}). This is
+        not normal and could indicate a memory leak. Please check.
+      format-dict:
+        usage: $libvirtd_usage

--- a/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage.yaml
@@ -1,0 +1,13 @@
+data-root:
+  files:
+    sys/fs/cgroup/system.slice/libvirtd.service/memory.current: '536870913'
+    sos_commands/systemd/systemctl_list-unit-files: |
+      libvirtd.service                        enabled         enabled
+    sos_commands/systemd/systemctl_list-units: |
+      libvirtd.service                                                            loaded active running   Virtualization daemon
+    sos_commands/dpkg/dpkg_-l: |
+      ii  libvirt-daemon                  8.0.0-1ubuntu7.4~cloud0           amd64        Virtualization daemon
+raised-issues:
+  OpenstackWarning: >-
+    The libvirtd service is consuming more than 5G memory (current=536870913). This is
+    not normal and could indicate a memory leak. Please check.

--- a/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage_ok.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage_ok.yaml
@@ -1,0 +1,11 @@
+target-name: service_mem_usage.yaml
+data-root:
+  files:
+    sys/fs/cgroup/system.slice/libvirtd.service/memory.current: '536870912'
+    sos_commands/systemd/systemctl_list-unit-files: |
+      libvirtd.service                        enabled         enabled
+    sos_commands/systemd/systemctl_list-units: |
+      libvirtd.service                                                            loaded active running   Virtualization daemon
+    sos_commands/dpkg/dpkg_-l: |
+      ii  libvirt-daemon                  8.0.0-1ubuntu7.4~cloud0           amd64        Virtualization daemon
+raised-issues:


### PR DESCRIPTION
Added a check that raises an OpenstackWarning if libvirtd memory usage is > 5G.

Resolves: #643