### PR TITLE
Run functest.sh under bash

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,8 @@ allowlist_externals = bashate
 commands = bashate --verbose {toxinidir}/build.sh {toxinidir}/tools/test/functest.sh
 
 [testenv:functional]
-commands = {toxinidir}/tools/test/functest.sh
+allowlist_externals = bash
+commands = bash {toxinidir}/tools/test/functest.sh
 
 [testenv:docs]
 commands = sphinx-build -j auto -d {toxinidir}/doc/build/doctrees -b html {toxinidir}/doc/source doc/build/html


### PR DESCRIPTION
Trying to run 'tox -e functional' locally yields:

functional: failed with /home/bhaley/hotsos/tools/test/functest.sh is not allowed, use allowlist_externals to allow it
  functional: FAIL code 1 (10.80 seconds)
  evaluation failed :( (10.86 seconds)

With the newer version of tox we are using, we need to add it to allowlist_externals.