### PR TITLE
Fix pep8 indentation and operator warnings

### DIFF
--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -62,7 +62,7 @@ def get_repo_info():
                 return fd.read().strip()
 
     try:
-        out = subprocess.check_output(['git', '-C',  get_hotsos_root(),
+        out = subprocess.check_output(['git', '-C', get_hotsos_root(),
                                        'rev-parse', '--short', 'HEAD'],
                                       stderr=subprocess.DEVNULL)
         if not out:

--- a/hotsos/client.py
+++ b/hotsos/client.py
@@ -100,8 +100,7 @@ PLUGIN_CATALOG = {'hotsos': {
                   'mysql': {
                      'summary': {
                          'objects': [MySQLSummary],
-                         'part_yaml_offset': 0},
-                      },
+                         'part_yaml_offset': 0}},
                   'openstack': {
                      'summary': {
                          'objects': [ost_summary.OpenstackSummary],

--- a/hotsos/core/plugins/kernel/net.py
+++ b/hotsos/core/plugins/kernel/net.py
@@ -327,8 +327,7 @@ class SockStat(ProcNetBase):
                 self._data[key]["statistics_mem_usage_pct"] = round(
                     (self._data[key]["mem"] /
                         self._data[key]["sysctl_mem_max"] if
-                        self._data[key]["sysctl_mem_max"] else 0)
-                    * 100.0, 2)
+                        self._data[key]["sysctl_mem_max"] else 0) * 100.0, 2)
 
     def _process_file(self, fname):
         if not os.path.exists(fname):
@@ -347,7 +346,8 @@ class SockStat(ProcNetBase):
                     self._data[label] = {}
                 try:
                     stats = stats.strip().split(' ')
-                    stats = dict(stats[i:i+2] for i in range(0, len(stats), 2))
+                    stats = dict(stats[i:i + 2]
+                                 for i in range(0, len(stats), 2))
                     # Convert string values to `int``
                     stats = {k: int(v) for k, v in stats.items()}
                     self._data[label] = stats

--- a/hotsos/core/plugins/openstack/openstack.py
+++ b/hotsos/core/plugins/openstack/openstack.py
@@ -222,7 +222,7 @@ OST_REL_INFO = {
         'ussuri': '3.0.0',
         'train': '2.0.0',
         'stein': '1.0.0'}
-    }
+}
 
 OST_EXCEPTIONS = {'barbican': BARBICAN_EXCEPTIONS + CASTELLAN_EXCEPTIONS,
                   'cinder': CINDER_EXCEPTIONS + CASTELLAN_EXCEPTIONS,

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -70,7 +70,7 @@ CEPH_REL_INFO = {
         'luminous': '12.0',
         'kraken': '11.0',
         'jewel': '10.0'},
-    }
+}
 
 CEPH_POOL_TYPE = {1: 'replicated', 3: 'erasure-coded'}
 
@@ -340,7 +340,7 @@ class CephCrushMap(object):
                 if isinstance(outer_d, dict):
                     if outer_d['metadata']['frontend_type#0'] == 'civetweb':
                         return True
-        except(ValueError, KeyError):
+        except (ValueError, KeyError):
             pass
         return False
 
@@ -588,10 +588,10 @@ class CephCluster(object):
                 pg_id = pg['pgid']
                 pg_pool_id = pg_id.partition('.')[0]
                 _large_omap_pgs[pg['pgid']] = {
-                        'pool': self.pool_id_to_name(pg_pool_id),
-                        'last_scrub_stamp': pg['last_scrub_stamp'],
-                        'last_deep_scrub_stamp': pg['last_deep_scrub_stamp']
-                        }
+                    'pool': self.pool_id_to_name(pg_pool_id),
+                    'last_scrub_stamp': pg['last_scrub_stamp'],
+                    'last_deep_scrub_stamp': pg['last_deep_scrub_stamp']
+                }
 
         return _large_omap_pgs
 

--- a/hotsos/plugin_extensions/openstack/agent/exceptions.py
+++ b/hotsos/plugin_extensions/openstack/agent/exceptions.py
@@ -125,7 +125,7 @@ class AgentExceptionChecks(OpenstackChecksBase):
             'neutron': [r'OVS is dead',
                         r'MessagingTimeout',
                         ]
-            }
+        }
 
         # The following are expected to be ERROR. This is typically used to
         # catch events that are not logged as an exception with the usual
@@ -133,7 +133,7 @@ class AgentExceptionChecks(OpenstackChecksBase):
         self._agent_errors = {
             'neutron': [r'RuntimeError'],
             'keystone': [r'\([a-zA-Z\.]+\)']
-            }
+        }
 
     def _add_agent_searches(self, project, agent_name, logs_path,
                             expr_template):

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -98,8 +98,8 @@ class OVSEventChecks(OpenvSwitchEventChecksBase):
 
                     log_stats = False
                     if packets:
-                        dropped_pcent = int((100/packets) * dropped)
-                        errors_pcent = int((100/packets) * errors)
+                        dropped_pcent = int((100 / packets) * dropped)
+                        errors_pcent = int((100 / packets) * errors)
                         if dropped_pcent > 1 or errors_pcent > 1:
                             log_stats = True
                     elif errors or dropped:

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -133,13 +133,14 @@ CEPH_OSD_CRUSH_DUMP = """
     }
 """
 
-PG_DUMP_JSON_DECODED = {'pg_map': {
-                          'pg_stats': [
-                            {'stat_sum': {'num_large_omap_objects': 1},
-                             'last_scrub_stamp': '2021-09-16T21:26:00.00',
-                             'last_deep_scrub_stamp': '2021-09-16T21:26:00.00',
-                             'pgid': '2.f',
-                             'state': 'active+clean+laggy'}]}}
+PG_DUMP_JSON_DECODED = {
+    'pg_map':
+        {'pg_stats': [
+         {'stat_sum': {'num_large_omap_objects': 1},
+          'last_scrub_stamp': '2021-09-16T21:26:00.00',
+          'last_deep_scrub_stamp': '2021-09-16T21:26:00.00',
+          'pgid': '2.f',
+          'state': 'active+clean+laggy'}]}}
 
 
 CEPH_MON_DATA_ROOT = os.path.join(utils.TESTS_DIR,
@@ -287,14 +288,12 @@ class TestCephMonSummary(CephMonTestsBase):
         svc_info = {'systemd': {'enabled': [
                                     'ceph-crash',
                                     'ceph-mgr',
-                                    'ceph-mon',
-                                    ],
+                                    'ceph-mon'],
                                 'disabled': [
                                     'ceph-mds',
                                     'ceph-osd',
                                     'ceph-radosgw',
-                                    'ceph-volume'
-                                    ],
+                                    'ceph-volume'],
                                 'generated': ['radosgw'],
                                 'masked': ['ceph-create-keys']},
                     'ps': ['ceph-crash (1)', 'ceph-mgr (1)', 'ceph-mon (1)']}

--- a/tests/unit/storage/test_ceph_osd.py
+++ b/tests/unit/storage/test_ceph_osd.py
@@ -102,7 +102,7 @@ class TestCephOSDSummary(StorageCephOSDTestsBase):
     def test_local_osd_ids(self):
         inst = ceph_summary.CephSummary()
         actual = self.part_output_to_actual(inst.output)
-        self.assertEqual(list(actual['local-osds'].keys()),  [0])
+        self.assertEqual(list(actual['local-osds'].keys()), [0])
 
     def test_local_osd_info(self):
         fsid = "48858aa1-71a3-4f0e-95f3-a07d1d9a6749"
@@ -117,14 +117,12 @@ class TestCephOSDSummary(StorageCephOSDTestsBase):
     def test_service_info(self):
         svc_info = {'systemd': {'enabled': [
                                     'ceph-crash',
-                                    'ceph-osd',
-                                    ],
+                                    'ceph-osd'],
                                 'disabled': [
                                     'ceph-mds',
                                     'ceph-mgr',
                                     'ceph-mon',
-                                    'ceph-radosgw',
-                                    ],
+                                    'ceph-radosgw'],
                                 'generated': ['radosgw']},
                     'ps': ['ceph-crash (1)', 'ceph-osd (1)']}
         release_info = {'name': 'octopus', 'days-to-eol': 3000}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,6 @@
 from hotsos.core.config import (
     ConfigOpt,
     ConfigOptGroupBase,
-    HotSOSConfig
     HotSOSConfig,
     RegisteredOpts,
 )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,7 @@ from hotsos.core.config import (
     ConfigOpt,
     ConfigOptGroupBase,
     HotSOSConfig
-    )
+)
 
 from . import utils
 

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -309,7 +309,7 @@ class TestKernelNetworkInfo(TestKernelBase):
             ("ceilomete", 4129, 116, "mem", "REG", "9,1", "43200", 48271,
              "/usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0"),
             ("kworker/1", 10645, 0, "rtd", "DIR", "9,1", "4096", 2, "/"),
-            ("ovs-vswit", 13936,  0, "mem-R", "REG", "0,43", "2097152",
+            ("ovs-vswit", 13936, 0, "mem-R", "REG", "0,43", "2097152",
              129906, "/mnt/huge_ovs_2M/rtemap_286"),
             ("ovs-vswit", 13936, 0, "mem-R", "REG", "0,43", "2097152", 44403,
              "/mnt/huge_ovs_2M/rtemap_33226"),

--- a/tests/unit/test_kubernetes.py
+++ b/tests/unit/test_kubernetes.py
@@ -47,8 +47,7 @@ class TestKubernetesSummary(KubernetesTestsBase):
                             'snap.kube-apiserver.daemon',
                             'snap.kube-controller-manager.daemon',
                             'snap.kube-proxy.daemon',
-                            'snap.kube-scheduler.daemon']
-                        },
+                            'snap.kube-scheduler.daemon']},
                     'ps': [
                         'calico-node (3)',
                         'containerd (1)',

--- a/tests/unit/test_maas.py
+++ b/tests/unit/test_maas.py
@@ -84,8 +84,7 @@ class TestMAASSummary(MAASTestsBase):
                                             'maas-regiond',
                                             'maas-syslog'],
                                         'disabled': [
-                                            'postgresql',
-                                            ]}}}
+                                            'postgresql']}}}
             inst = summary.MAASSummary()
             self.assertEqual(self.part_output_to_actual(inst.output), expected)
 

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -579,7 +579,7 @@ class TestOpenstackSummary(TestOpenstackBase):
             'python3-oslo.vmware 3.3.1-0ubuntu1',
             'qemu-kvm 1:4.2-3ubuntu6.19',
             'radvd 1:2.17-2'
-            ]
+        ]
         inst = summary.OpenstackSummary()
         actual = self.part_output_to_actual(inst.output)
         self.assertEqual(actual["dpkg"], expected)
@@ -629,9 +629,7 @@ class TestOpenstackVmInfo(TestOpenstackBase):
                             "system-cores": 2,
                             "smt": False,
                             "used": 1,
-                            "overcommit-factor": 0.5,
-                            }
-                        }
+                            "overcommit-factor": 0.5}}
                     }
         inst = vm_info.OpenstackInstanceChecks()
         actual = self.part_output_to_actual(inst.output)
@@ -900,17 +898,14 @@ class TestOpenstackAgentEvents(TestOpenstackBase):
     def test_run_octavia_checks(self):
         expected = {'amp-missed-heartbeats': {
                      '2021-06-01': {
-                      '3604bf2a-ee51-4135-97e2-ec08ed9321db': 1,
-                      }},
+                         '3604bf2a-ee51-4135-97e2-ec08ed9321db': 1, }},
                     'lb-failovers': {
-                     'auto': {
-                      '2021-03-09': {
-                          '7a3b90ed-020e-48f0-ad6f-b28443fa2277': 1,
-                          '98aefcff-60e5-4087-8ca6-5087ae970440': 1,
-                          '9cd90142-5501-4362-93ef-1ad219baf45a': 1,
-                          'e9cb98af-9c21-4cf6-9661-709179ce5733': 1,
-                        }
-                      }
+                        'auto': {
+                            '2021-03-09': {
+                                '7a3b90ed-020e-48f0-ad6f-b28443fa2277': 1,
+                                '98aefcff-60e5-4087-8ca6-5087ae970440': 1,
+                                '9cd90142-5501-4362-93ef-1ad219baf45a': 1,
+                                'e9cb98af-9c21-4cf6-9661-709179ce5733': 1, }}
                      }
                     }
         for section_key in ["octavia-worker", "octavia-health-manager"]:
@@ -989,8 +984,8 @@ class TestOpenstackAgentEvents(TestOpenstackBase):
     def test_run_neutron_l3ha_checks(self):
         expected = {'keepalived': {
                      'transitions': {
-                      '984c22fd-64b3-4fa1-8ddd-87090f401ce5': {
-                          '2022-02-10': 1}}}}
+                         '984c22fd-64b3-4fa1-8ddd-87090f401ce5': {
+                             '2022-02-10': 1}}}}
         sobj = FileSearcher()
         inst = agent.events.NeutronL3HAEventChecks(searchobj=sobj)
         inst.run_checks()
@@ -1003,8 +998,8 @@ class TestOpenstackAgentEvents(TestOpenstackBase):
         HotSOSConfig.use_all_logs = False
         expected = {'keepalived': {
                      'transitions': {
-                      '984c22fd-64b3-4fa1-8ddd-87090f401ce5': {
-                       '2022-02-10': 1}}}}
+                         '984c22fd-64b3-4fa1-8ddd-87090f401ce5': {
+                             '2022-02-10': 1}}}}
         sobj = FileSearcher()
         inst = agent.events.NeutronL3HAEventChecks(searchobj=sobj)
         inst.run_checks()
@@ -1040,15 +1035,13 @@ class TestOpenstackAgentExceptions(TestOpenstackBase):
                         'nova': {
                             'nova-compute': {
                                 'oslo_messaging.exceptions.MessagingTimeout': {
-                                    '2022-02-09': 2}
-                                }}},
+                                    '2022-02-09': 2}}}},
                     'warning': {
                         'nova': {
                             'nova-compute': {
                                 'oslo_messaging.exceptions.MessagingTimeout': {
                                     '2022-02-04': 1,
-                                    '2022-02-09': 1}
-                                }}}}
+                                    '2022-02-09': 1}}}}}
         inst = agent.exceptions.AgentExceptionChecks()
         files = {}
         logs = {}
@@ -1079,41 +1072,36 @@ class TestOpenstackAgentExceptions(TestOpenstackBase):
             'neutron-openvswitch-agent': {
                 'oslo_messaging.exceptions.MessagingTimeout': {
                     '2022-02-04': 75,
-                    '2022-02-09': 3
-                    }},
+                    '2022-02-09': 3}},
             'neutron-dhcp-agent': {
                 'oslo_messaging.exceptions.MessagingTimeout': {
                     '2022-02-04': 124,
-                    '2022-02-09': 17
-                    }},
+                    '2022-02-09': 17}},
             'neutron-l3-agent': {
                 'oslo_messaging.exceptions.MessagingTimeout': {
                     '2022-02-04': 73,
-                    '2022-02-09': 3
-                    }},
+                    '2022-02-09': 3}},
             'neutron-metadata-agent': {
                 'OSError': {'2022-02-09': 1},
                 'oslo_messaging.exceptions.MessagingTimeout': {
                     '2022-02-04': 48,
                     '2022-02-09': 14}},
-            }
+        }
         nova_error_exceptions = {
             'nova-compute': {
                 'oslo_messaging.exceptions.MessagingTimeout': {
                     '2022-02-04': 64,
-                    '2022-02-09': 2,
-                    },
+                    '2022-02-09': 2},
                 'nova.exception.ResourceProviderRetrievalFailed': {
-                    '2022-02-04': 6
-                    },
+                    '2022-02-04': 6},
                 'nova.exception.ResourceProviderAllocationRetrievalFailed': {
-                    '2022-02-04': 2
-                    }},
+                    '2022-02-04': 2}},
             'nova-api-metadata': {
                 'OSError': {'2022-02-09': 4},
                 'oslo_messaging.exceptions.MessagingTimeout': {
                     '2022-02-04': 110,
-                    '2022-02-09': 56}}}
+                    '2022-02-09': 56}}
+        }
         neutron_warn_exceptions = {
             'neutron-dhcp-agent': {
                 'oslo_messaging.exceptions.MessagingTimeout': {
@@ -1127,14 +1115,13 @@ class TestOpenstackAgentExceptions(TestOpenstackBase):
                 'oslo_messaging.exceptions.MessagingTimeout': {
                     '2022-02-04': 13,
                     '2022-02-09': 6}}
-            }
+        }
         nova_warn_exceptions = {
             'nova-compute': {
                 'oslo_messaging.exceptions.MessagingTimeout': {
                     '2022-02-04': 59,
-                    '2022-02-09': 1,
-                    },
-            }}
+                    '2022-02-09': 1}}
+        }
         expected = {'error': {
                         'neutron': neutron_error_exceptions,
                         'nova': nova_error_exceptions},

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -112,12 +112,9 @@ class TestOpenvswitchServiceInfo(TestOpenvswitchBase):
     def test_get_resource_checks(self):
         expected = {'systemd': {
                         'enabled': [
-                            'openvswitch-switch'
-                            ],
+                            'openvswitch-switch'],
                         'static': [
-                            'ovs-vswitchd', 'ovsdb-server'
-                            ]
-                        },
+                            'ovs-vswitchd', 'ovsdb-server']},
                     'ps': [
                         'ovs-vswitchd (1)',
                         'ovsdb-server (1)']}
@@ -255,8 +252,7 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                         'qr-aa623763-fd': {
                             'RX': {
                                 'dropped': 1394875,
-                                'packets': 309
-                                }}}}
+                                'packets': 309}}}}
         inst = event_checks.OVSEventChecks()
         self.assertEqual(self.part_output_to_actual(inst.output), expected)
 

--- a/tests/unit/test_plugintools.py
+++ b/tests/unit/test_plugintools.py
@@ -244,7 +244,7 @@ class TestPluginTools(utils.BaseTestCase):
                 },
             'item-2':
                 ['a', 'b', 'c'],
-            }
+        }
         expected = '''# hotsos summary
 
 ## item-1
@@ -283,7 +283,7 @@ plain value
                 },
             'item-2':
                 ['a', 'b', 'c'],
-            }
+        }
         expected = htmlout.header + HTML1 + htmlout.footer
         filtered = OutputManager(summary).get(format='html')
         self.assertEqual(filtered, expected)
@@ -303,7 +303,7 @@ plain value
                 },
             'item-2':
                 ['a', 'b', 'c'],
-            }
+        }
         expected = htmlout.header + HTML2 + htmlout.footer
         filtered = OutputManager(summary).get(format='html')
         self.assertEqual(filtered, expected)
@@ -323,7 +323,7 @@ plain value
                 },
             'item-2':
                 ['a', 'b', 'c'],
-            }
+        }
         expected = htmlout.header + HTML3 + htmlout.footer
         filtered = OutputManager(summary).get(format='html')
         self.assertEqual(filtered, expected)

--- a/tests/unit/test_rabbitmq.py
+++ b/tests/unit/test_rabbitmq.py
@@ -55,8 +55,7 @@ class TestRabbitmqSummary(TestRabbitmqBase):
                 "openstack",
                 "telegraf-telegraf-12",
                 "telegraf-telegraf-13",
-                "telegraf-telegraf-14",
-                ],
+                "telegraf-telegraf-14"],
             'vhost-queue-distributions': {
                 'openstack': {
                     'rabbit@juju-52088b-0-lxd-11': '1137 (86.14%)',
@@ -106,8 +105,7 @@ class TestRabbitmqSummary(TestRabbitmqBase):
                 'openstack'],
             'vhost-queue-distributions': {
                 'openstack': {
-                    'rabbit@juju-04f1e3-1-lxd-5': '194 (100.00%)'
-                    }},
+                    'rabbit@juju-04f1e3-1-lxd-5': '194 (100.00%)'}},
             'connections-per-host': {
                 'rabbit@juju-04f1e3-1-lxd-5': 159},
             'client-connections': {

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -32,7 +32,7 @@ class TestVaultSummary(VaultTestsBase):
                         'enabled': [
                             'vault',
                             'vault-mysql-router']
-                        }}
+                    }}
         inst = summary.VaultSummary()
         self.assertEqual(self.part_output_to_actual(inst.output)['services'],
                          expected)

--- a/tox.ini
+++ b/tox.ini
@@ -25,29 +25,12 @@ commands =
   flake8 -v --exclude=fake_data_root {posargs:{env:PYFILES}}
 
 [flake8]
-# E121 continuation line under-indented for hanging indent
-# E122 continuation line missing indentation or outdented
-# E123 closing bracket does not match indentation of opening bracket's line
 # E126 continuation line over-indented for hanging indent
-# E127 continuation line over-indented for visual indent
 # E128 continuation line under-indented for visual indent
-# E226 missing whitespace around arithmetic operator
-# E241 multiple spaces after ','
-# E265 block comment should start with '# '
-# E275 missing whitespace after keyword
 # E401 multiple imports on one line
-# H101 Use TODO(NAME)
-# H102 Apache 2.0 license header not found
-# H104 File contains nothing but comments
-# H202 assertRaises Exception too broad
 # H301 one import per line
-# H401 docstring should not start with a space
-# H403 multi line docstrings should end on a new line
-# H404 multi line docstring should start without a leading new line
-# H405 multi line docstring summary not separated with an empty line
-# W503 line break before binary operator
 # W504 line break after binary operator
-ignore = E121,E122,E123,E126,E127,E128,E226,E241,E265,E261,E275,E401,H101,H102,H202,H301,H401,H403,H404,H405,W503,W504
+ignore = E126,E128,E401,H301,W504
 # H106: Don't put vim configuration in source files
 # H203: Use assertIs(Not)None to check for None
 # H204: Use assert(Not)Equal to check for equality


### PR DESCRIPTION
This fixes E121, E122, E123, E127, E226, E241,
E275 and W503 warnings and starts enforcing them.

Also removed a number of ignore directives for
warnings that were no longer being triggered.