### PR TITLE
Add types to config opt defs

### DIFF
--- a/hotsos/core/config.py
+++ b/hotsos/core/config.py
@@ -9,16 +9,17 @@ class ConfigException(Exception):
 
 class ConfigOpt(object):
 
-    def __init__(self, name, description, default_value):
+    def __init__(self, name, description, default_value, type):
         self.name = name
         self.description = description
         self.default_value = default_value
+        self.type = type
 
 
 class ConfigOptGroupBase(UserDict):
 
     def __init__(self):
-        self.opts = []
+        self.opts = {}
 
     @property
     @abc.abstractmethod
@@ -28,13 +29,13 @@ class ConfigOptGroupBase(UserDict):
     @property
     def data(self):
         d = {}
-        for opt in self.opts:
-            d.update({opt.name: opt.default_value})
+        for name, opt in self.opts.items():
+            d[name] = opt.default_value
 
         return d
 
     def add(self, opt):
-        self.opts.append(opt)
+        self.opts[opt.name] = opt
 
 
 class HotSOSConfigOpts(ConfigOptGroupBase):
@@ -45,69 +46,69 @@ class HotSOSConfigOpts(ConfigOptGroupBase):
                            description=('This is the filesystem root used for '
                                         'all files and is typically / or a '
                                         'path to a sosreport'),
-                           default_value=None))
+                           default_value=None, type=str))
         self.add(ConfigOpt(name='force_mode',
                            description=('Plugin execution is usually gated '
                                         'on a set of conditions. Setting this '
                                         'to True bypasses these conditions '
                                         'and forces all plugins to run'),
-                           default_value=False))
+                           default_value=False, type=bool))
         self.add(ConfigOpt(name='global_tmp_dir',
                            description=('A temporary directory created at the '
                                         'start of execution and visible to '
                                         'all plugins.'),
-                           default_value=None))
+                           default_value=None, type=str))
         self.add(ConfigOpt(name='plugin_tmp_dir',
                            description=('A temporary directory created for '
                                         'each plugin.'),
-                           default_value=None))
+                           default_value=None, type=str))
         self.add(ConfigOpt(name='use_all_logs',
                            description=('Automatically convert log paths to '
                                         'glob e.g. <path> becomes <path>*'),
-                           default_value=False))
+                           default_value=False, type=bool))
         self.add(ConfigOpt(name='machine_readable',
                            description=('If set to True, the summary output'
                                         'will contain extra information '
                                         'that might be useful if the output '
                                         'is being read by an application.'),
-                           default_value=False))
+                           default_value=False, type=bool))
         self.add(ConfigOpt(name='part_name',
                            description=('Plugins have many parts each with '
                                         'its own name and this will be set to '
                                         'the current part being executed.'),
-                           default_value=None))
+                           default_value=None, type=str))
         self.add(ConfigOpt(name='repo_info',
                            description=('Source repository sha1 from which '
                                         'the current build was created'),
-                           default_value=None))
+                           default_value=None, type=str))
         self.add(ConfigOpt(name='hotsos_version',
                            description='Version of hotsos being run.',
-                           default_value=None))
+                           default_value=None, type=str))
         self.add(ConfigOpt(name='debug_mode',
                            description='Set to True to enable debug logging',
-                           default_value=False))
+                           default_value=False, type=bool))
         self.add(ConfigOpt(name='plugin_yaml_defs',
                            description='Path to yaml-defined checks.',
-                           default_value=None))
+                           default_value=None, type=str))
         self.add(ConfigOpt(name='templates_path',
                            description='Path to jinja templates.',
-                           default_value='templates'))
+                           default_value='templates', type=str))
         self.add(ConfigOpt(name='plugin_name',
                            description='Name of current plugin being executed',
-                           default_value=None))
+                           default_value=None, type=str))
         self.add(ConfigOpt(name='event_tally_granularity',
                            description=("By default event tallies are listed "
                                         "by date in the summary. This option "
                                         "can be set to one of 'date' or "
                                         "'time' to get the corresponding "
                                         "granularity of results."),
-                           default_value='date'))
+                           default_value='date', type=str))
         self.add(ConfigOpt(name='command_timeout',
                            description=("Maximum time in seconds before "
                                         "command execution will timeout. Used "
                                         "by host_helpers.cli when executing "
                                         "binary commands"),
-                           default_value=300))
+                           default_value=300, type=int))
 
     @property
     def name(self):
@@ -121,13 +122,13 @@ class SearchtoolsConfigOpts(ConfigOptGroupBase):
         self.add(ConfigOpt(name='max_parallel_tasks',
                            description=('Maximum parallelism for searching '
                                         'files concurrently'),
-                           default_value=8))
+                           default_value=8, type=int))
         self.add(ConfigOpt(name='max_logrotate_depth',
                            description=('When log paths are expanded using '
                                         'use_all_logs and they are logrotated '
                                         'log files, this is used to limit the '
                                         'logrotate history in days.'),
-                           default_value=7))
+                           default_value=7, type=int))
         self.add(ConfigOpt(name='allow_constraints_for_unverifiable_logs',
                            description=('Search constraints use a binary '
                                         'search that sometimes needs to '
@@ -149,7 +150,7 @@ class SearchtoolsConfigOpts(ConfigOptGroupBase):
                                         'to enable search constraints for '
                                         'files that contain unverifiable '
                                         'lines.'),
-                           default_value=False))
+                           default_value=False, type=bool))
 
     @property
     def name(self):
@@ -159,9 +160,30 @@ class SearchtoolsConfigOpts(ConfigOptGroupBase):
 class RegisteredOpts(UserDict):
 
     def __init__(self, *optgroups):
+        self.optsgroups = []
         self.data = {}
-        for ogroup in optgroups:
-            self.data.update(ogroup())
+        for optgroup in optgroups:
+            optgroup = optgroup()
+            self.optsgroups.append(optgroup)
+            a = [name.lower() for name in self.data.keys()]
+            b = [name.lower() for name in optgroup.keys()]
+            if set(a).intersection(b):
+                raise Exception("optgroup '{}' contains one or more names "
+                                "that have already been registered".
+                                format(optgroup.name))
+
+            self.data.update(optgroup)
+
+    def __setitem__(self, key, item):
+        for group in self.optsgroups:
+            if key in group.opts:
+                item = group.opts[key].type(item)
+                break
+        else:
+            raise Exception("config option '{}' not found in any optgrpup".
+                            format(key))
+
+        self.data[key] = item
 
 
 class ConfigMeta(abc.ABCMeta):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,8 @@
 from hotsos.core.config import (
     ConfigOpt,
     ConfigOptGroupBase,
-    HotSOSConfig
+    HotSOSConfig,
+    RegisteredOpts,
     )
 
 from . import utils
@@ -11,9 +12,9 @@ class TestOptGroup(ConfigOptGroupBase):
 
     def __init__(self):
         super().__init__()
-        self.add(ConfigOpt('opt1', 'its opt one', None))
-        self.add(ConfigOpt('opt2', 'its opt two', True))
-        self.add(ConfigOpt('opt3', 'its opt three', False))
+        self.add(ConfigOpt('opt1', 'its opt one', None, str))
+        self.add(ConfigOpt('opt2', 'its opt two', True, bool))
+        self.add(ConfigOpt('opt3', 'its opt three', False, bool))
 
     @property
     def name(self):
@@ -27,6 +28,36 @@ class TestHotSOSConfig(utils.BaseTestCase):
         self.assertEqual(len(tog), 3)
         self.assertEqual(tog.name, 'testopts')
         self.assertEqual(tog, {'opt1': None, 'opt2': True, 'opt3': False})
+
+    def test_optgroup_conflict_dup(self):
+
+        class AltOptGroup(ConfigOptGroupBase):
+
+            def __init__(self):
+                super().__init__()
+                self.add(ConfigOpt('opt1', 'its opt one', None, str))
+
+            @property
+            def name(self):
+                return 'altopts'
+
+        with self.assertRaises(Exception):
+            RegisteredOpts(TestOptGroup, AltOptGroup)
+
+    def test_optgroup_conflict_case(self):
+
+        class AltOptGroup(ConfigOptGroupBase):
+
+            def __init__(self):
+                super().__init__()
+                self.add(ConfigOpt('Opt1', 'its opt one', None, str))
+
+            @property
+            def name(self):
+                return 'altopts'
+
+        with self.assertRaises(Exception):
+            RegisteredOpts(TestOptGroup, AltOptGroup)
 
     def test_restore_defaults(self):
         path = 'tests/unit/fake_data_root/openstack'


### PR DESCRIPTION
When config options are registered they must now provide a type and the value they are set to will be cast to this type.