### PR TITLE
Ensure start time non-zero when checking certs

### DIFF
--- a/hotsos/core/ycheck/engine/properties/requires/common.py
+++ b/hotsos/core/ycheck/engine/properties/requires/common.py
@@ -75,8 +75,7 @@ class PackageCheckItemsBase(CheckItemsBase):
 
     @cached_property
     def not_installed(self):
-        _all = self.packages_to_check
-        return set(self.installed).symmetric_difference(_all)
+        return set(self.packages_to_check).difference(self.installed)
 
 
 class OpsUtils(object):
@@ -231,8 +230,7 @@ class ServiceCheckItemsBase(CheckItemsBase):
 
     @cached_property
     def not_installed(self):
-        _installed = self.installed.keys()
-        return set(_installed).symmetric_difference(self._svcs_all)
+        return set(self._svcs_all).difference(self.installed)
 
     @cached_property
     def installed(self):

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_central_certs_logs.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_central_certs_logs.yaml
@@ -7,15 +7,21 @@ vars:
   cert_expired_expr: '([\d-]+)T([\d:]+)\.\d+Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:ssl3_read_bytes:sslv3 alert certificate expired'
   cert_invalid_expr: '([\d-]+)T([\d:]+)\.\d+Z\|\S+\|stream_ssl\|WARN\|SSL_accept: error:\S+:SSL routines:tls_process_client_certificate:certificate verify failed'
 checks:
-  services_not_restarted_after_cert_update:
-    - systemd: [ovn-northd, ovn-ovsdb-server-nb, ovn-ovsdb-server-sb]
-    - or:
-        - varops: [[$host_cert_mtime], [gt, $northd_start_time]]
-        - varops: [[$host_cert_mtime], [gt, $ovsdb_nb_start_time]]
-        - varops: [[$host_cert_mtime], [gt, $ovsdb_sb_start_time]]
-        - varops: [[$ovn_central_cert_mtime], [gt, $northd_start_time]]
-        - varops: [[$ovn_central_cert_mtime], [gt, $ovsdb_nb_start_time]]
-        - varops: [[$ovn_central_cert_mtime], [gt, $ovsdb_sb_start_time]]
+  northd_not_restarted_after_cert_update:
+    - systemd: ovn-northd
+    - varops: [[$northd_start_time], [gt, 0]]
+    - varops: [[$host_cert_mtime], [gt, $northd_start_time]]
+    - varops: [[$ovn_central_cert_mtime], [gt, $northd_start_time]]
+  nbdb_not_restarted_after_cert_update:
+    - systemd: ovn-ovsdb-server-nb
+    - varops: [[$ovsdb_nb_start_time], [gt, 0]]
+    - varops: [[$host_cert_mtime], [gt, $ovsdb_nb_start_time]]
+    - varops: [[$ovn_central_cert_mtime], [gt, $ovsdb_nb_start_time]]
+  sbdb_not_restarted_after_cert_update:
+    - systemd: ovn-ovsdb-server-sb
+    - varops: [[$ovsdb_sb_start_time], [gt, 0]]
+    - varops: [[$host_cert_mtime], [gt, $ovsdb_sb_start_time]]
+    - varops: [[$ovn_central_cert_mtime], [gt, $ovsdb_sb_start_time]]
   northd_certs_invalid_logs:
     input: var/log/ovn/ovn-northd.log
     expr: $cert_invalid_expr
@@ -42,7 +48,11 @@ checks:
       search-result-age-hours: 24
 conclusions:
   services_not_restarted_after_cert_update:
-    decision: services_not_restarted_after_cert_update
+    decision:
+      or:
+        - northd_not_restarted_after_cert_update
+        - nbdb_not_restarted_after_cert_update
+        - sbdb_not_restarted_after_cert_update
     raises:
       type: OVNWarning
       message: >-

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_chassis_certs_logs.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_chassis_certs_logs.yaml
@@ -7,6 +7,7 @@ vars:
 checks:
   services_not_restarted_after_cert_update:
     - systemd: ovn-controller
+    - varops: [[$ovn_controller_start_time], [gt, 0]]
     - varops: [[$host_cert_mtime], [gt, $ovn_controller_start_time]]
     - varops: [[$ovn_chassis_cert_mtime], [gt, $ovn_controller_start_time]]
   certs_expired_logs:

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -312,6 +312,18 @@ class TestSystemdHelper(utils.BaseTestCase):
 
         self.assertIsNone(host_helpers.systemd.ServiceFactory().noexist)
 
+    @utils.create_data_root(
+        {},
+        copy_from_original=['sos_commands/systemd/systemctl_list-units',
+                            'sos_commands/systemd/systemctl_list-unit-files',
+                            'sys/fs/cgroup/memory/system.slice',
+                            'sos_commands/systemd/systemctl_status_--all'])
+    def test_service_factory_no_journal(self):
+        svc = host_helpers.systemd.ServiceFactory().rsyslog
+        self.assertEqual(svc.start_time_secs, 1644446297.0)
+
+        self.assertIsNone(host_helpers.systemd.ServiceFactory().noexist)
+
     def test_systemd_helper(self):
         expected = {'ps': ['nova-api-metadata (5)', 'nova-compute (1)'],
                     'systemd': {'enabled':


### PR DESCRIPTION
When we check that certs are modified before last service start we must ensure that the start time is non-zero for cases where it is not available.

Adds support for getting service start time from status if not found in journal.

Resolves: #673