### PR TITLE
Fix service mem usage checks

### DIFF
--- a/hotsos/defs/scenarios/openstack/nova/service_mem_usage.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/service_mem_usage.yaml
@@ -1,6 +1,6 @@
 vars:
-  limit: 536870912  # 5G
-  libvirtd_usage: '@hotsos.core.host_helpers.systemd.ServiceFactory.memory_current:libvirtd'
+  limit: 5242880  # 5G in kb
+  libvirtd_usage: '@hotsos.core.host_helpers.systemd.ServiceFactory.memory_current_kb:libvirtd'
 checks:
   libvirtd_mem_use_above_limit:
     systemd: libvirtd
@@ -17,7 +17,7 @@ conclusions:
     raises:
       type: OpenstackWarning
       message: >-
-        The libvirtd service is consuming more than 5G memory (current={usage}). This is
+        The libvirtd service is consuming more than 5G memory (current_kb={usage}). This is
         not normal and could indicate a memory leak. Please check.
       format-dict:
         usage: $libvirtd_usage
@@ -30,7 +30,7 @@ conclusions:
       type: LaunchpadBug
       bug-id: 2024114
       message: >-
-        The libvirtd service on this host is consuming more than 5G memory (current={usage}). This is
+        The libvirtd service on this host is consuming more than 5G memory (current_kb={usage}). This is
         not normal and could indicate a memory leak. The installed version ({installed})
         is also known to be impacted by a memory leak bug. Recommendation is to upgrade.
       format-dict:

--- a/hotsos/defs/scenarios/openvswitch/ovn/service_mem_usage.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/service_mem_usage.yaml
@@ -1,6 +1,6 @@
 vars:
-  limit: 536870912  # 5G
-  northd_usage: '@hotsos.core.host_helpers.systemd.ServiceFactory.memory_current:ovn-northd'
+  limit: 5242880  # 5G in kb
+  northd_usage: '@hotsos.core.host_helpers.systemd.ServiceFactory.memory_current_kb:ovn-northd'
 checks:
   northd_mem_use_above_limit:
     systemd: ovn-northd
@@ -11,7 +11,7 @@ conclusions:
     raises:
       type: OpenvSwitchWarning
       message: >-
-        The ovn-northd service is consuming more than 5G memory (current={usage}). This is
+        The ovn-northd service is consuming more than 5G memory (current_kb={usage}). This is
         not normal and could indicate a memory leak. Please check.
       format-dict:
         usage: $northd_usage

--- a/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage.yaml
@@ -1,6 +1,6 @@
 data-root:
   files:
-    sys/fs/cgroup/system.slice/libvirtd.service/memory.current: '536870913'
+    sys/fs/cgroup/system.slice/libvirtd.service/memory.current: '5368710144'
     sos_commands/systemd/systemctl_list-unit-files: |
       libvirtd.service                        enabled         enabled
     sos_commands/systemd/systemctl_list-units: |
@@ -9,5 +9,5 @@ data-root:
       ii  libvirt-daemon                  8.0.0-1ubuntu7.6~cloud0           amd64        Virtualization daemon
 raised-issues:
   OpenstackWarning: >-
-    The libvirtd service is consuming more than 5G memory (current=536870913). This is
+    The libvirtd service is consuming more than 5G memory (current_kb=5242881). This is
     not normal and could indicate a memory leak. Please check.

--- a/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage_lp2024114.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage_lp2024114.yaml
@@ -1,7 +1,7 @@
 target-name: service_mem_usage.yaml
 data-root:
   files:
-    sys/fs/cgroup/system.slice/libvirtd.service/memory.current: '536870913'
+    sys/fs/cgroup/system.slice/libvirtd.service/memory.current: '5368710144'
     sos_commands/systemd/systemctl_list-unit-files: |
       libvirtd.service                        enabled         enabled
     sos_commands/systemd/systemctl_list-units: |
@@ -10,6 +10,6 @@ data-root:
       ii  libvirt-daemon                  8.0.0-1ubuntu7.4~cloud0           amd64        Virtualization daemon
 raised-bugs:
   https://bugs.launchpad.net/bugs/2024114: >-
-    The libvirtd service on this host is consuming more than 5G memory (current=536870913). This is
+    The libvirtd service on this host is consuming more than 5G memory (current_kb=5242881). This is
     not normal and could indicate a memory leak. The installed version (8.0.0-1ubuntu7.4~cloud0)
     is also known to be impacted by a memory leak bug. Recommendation is to upgrade.

--- a/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage_ok.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/service_mem_usage_ok.yaml
@@ -1,7 +1,7 @@
 target-name: service_mem_usage.yaml
 data-root:
   files:
-    sys/fs/cgroup/system.slice/libvirtd.service/memory.current: '536870912'
+    sys/fs/cgroup/system.slice/libvirtd.service/memory.current: '5368709120'
     sos_commands/systemd/systemctl_list-unit-files: |
       libvirtd.service                        enabled         enabled
     sos_commands/systemd/systemctl_list-units: |

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/service_mem_usage.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/service_mem_usage.yaml
@@ -1,6 +1,6 @@
 data-root:
   files:
-    sys/fs/cgroup/system.slice/ovn-northd.service/memory.current: '536870913'
+    sys/fs/cgroup/system.slice/ovn-northd.service/memory.current: '5368710144'
     sos_commands/systemd/systemctl_list-unit-files: |
       ovn-central.service                        enabled         enabled
       ovn-nb-ovsdb.service                       enabled         enabled
@@ -18,5 +18,5 @@ data-root:
       ii  ovn-common                      20.03.2-0ubuntu0.20.04.4          amd64        OVN common components
 raised-issues:
   OpenvSwitchWarning: >-
-    The ovn-northd service is consuming more than 5G memory (current=536870913). This is
+    The ovn-northd service is consuming more than 5G memory (current_kb=5242881). This is
     not normal and could indicate a memory leak. Please check.

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/service_mem_usage_ok.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/service_mem_usage_ok.yaml
@@ -1,7 +1,7 @@
 target-name: service_mem_usage.yaml
 data-root:
   files:
-    sys/fs/cgroup/system.slice/ovn-northd.service/memory.current: '536870912'
+    sys/fs/cgroup/system.slice/ovn-northd.service/memory.current: '5368709120'
     sos_commands/systemd/systemctl_list-unit-files: |
       ovn-central.service                        enabled         enabled
       ovn-nb-ovsdb.service                       enabled         enabled

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -339,17 +339,17 @@ class TestSystemdHelper(utils.BaseTestCase):
     def test_systemd_service_focal(self):
         s = host_helpers.systemd.SystemdHelper([r'nova\S+'])
         svc = s.services['nova-compute']
-        self.assertEqual(svc.memory_current, 1517850624)
+        self.assertEqual(svc.memory_current_kb, int(1517744128 / 1024))
 
     @utils.create_data_root(
         {'sys/fs/cgroup/system.slice/nova-compute.service/memory.current':
-         '1234'},
+         '7168'},
         copy_from_original=['sos_commands/systemd/systemctl_list-units',
                             'sos_commands/systemd/systemctl_list-unit-files'])
     def test_systemd_service_jammy(self):
         s = host_helpers.systemd.SystemdHelper([r'nova\S+'])
         svc = s.services['nova-compute']
-        self.assertEqual(svc.memory_current, 1234)
+        self.assertEqual(svc.memory_current_kb, 7)
 
 
 class TestPebbleHelper(utils.BaseTestCase):


### PR DESCRIPTION
The systemd helper now checks memory.stat instead of memory.usage_in_bytes since the latter is just an
approximation.

Resolves: #675