### PR TITLE
Fix CLIHelper().systemctl_status_all

### DIFF
--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -55,12 +55,14 @@ class SystemdService(object):
         #       searching in all but currently do this to have parity with
         #       sosreport.
         fs = FileSearcher()
+        # The following expressions need to take account of control characters
+        # that might exist in the output e.g. line can start with '*' or U+25CF
         seqdef = SequenceSearchDef(
-                    start=SearchDef(r'\* ({}.service) -'.format(self.name)),
+                    start=SearchDef(r'\S+ ({}.service) -'.format(self.name)),
                     body=SearchDef(r"\s+Active: active \(?\S*\)?\s*since "
                                    r"\S{3} (\d{4}-\d{2}-\d{2} "
                                    r"\d{2}:\d{2}:\d{2})"),
-                    end=SearchDef(r'(\*) \S'),
+                    end=SearchDef(r'(\S+) \S+.service'),
                     tag='systemd')
         fs.add(seqdef, path=mktemp_dump(''.join(cli.systemctl_status_all())))
         sections = list(fs.run().find_sequence_sections(seqdef).values())


### PR DESCRIPTION
The output of this command can sometimes contain non-unicode
chars or special encodings e.g. in sosreports so we need to
handle UnicodeDecodeErrors correctly. We now process each line
individually and store an empty line for those that could not
be decoded. We also use subprocess.run as opposed to
subprocess.check_output since some commands like this return
non-zero exit codes by default which does not work with
check_output.

Resolves: #678