### PR TITLE
Add bash completion for snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,7 @@ layout:
 apps:
   hotsos:
     command: bin/hotsos
+    completer: usr/share/hotsos/bash-completion/hotsos-complete.bash
     plugs:
       - home
       - network
@@ -48,3 +49,6 @@ parts:
       pip install setuptools-git-versioning
       craftctl set version="$(setuptools-git-versioning)"
       craftctl default
+      _HOTSOS_COMPLETE=bash_source scripts/hotsos > hotsos-complete.bash
+      install --mode 0755 -D hotsos-complete.bash \
+        ${CRAFT_PART_INSTALL}/usr/share/hotsos/bash-completion/hotsos-complete.bash


### PR DESCRIPTION
This change adds bash completions for the snap version of hotsos.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
