### PR TITLE
Reorganize bash completion for deb support

### DIFF
--- a/scripts/hotsos-complete
+++ b/scripts/hotsos-complete
@@ -1,0 +1,29 @@
+_hotsos_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _HOTSOS_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_hotsos_completion_setup() {
+    complete -o nosort -F _hotsos_completion hotsos
+}
+
+_hotsos_completion_setup;
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ layout:
 apps:
   hotsos:
     command: bin/hotsos
-    completer: usr/share/hotsos/bash-completion/hotsos-complete.bash
+    completer: usr/share/hotsos/bash-completion/completions/hotsos-complete
     plugs:
       - home
       - network
@@ -49,6 +49,9 @@ parts:
       pip install setuptools-git-versioning
       craftctl set version="$(setuptools-git-versioning)"
       craftctl default
-      _HOTSOS_COMPLETE=bash_source scripts/hotsos > hotsos-complete.bash
-      install --mode 0755 -D hotsos-complete.bash \
-        ${CRAFT_PART_INSTALL}/usr/share/hotsos/bash-completion/hotsos-complete.bash
+    override-stage: |
+      set -e -u -x
+      install -D \
+        ${CRAFT_PART_BUILD}/scripts/hotsos-complete \
+        ${CRAFT_PART_INSTALL}/usr/share/hotsos/bash-completion/completions/hotsos-complete
+      craftctl default


### PR DESCRIPTION
Necessary prerequesite for adding bash completion for debian package
support. This change adds the completion script as an artifact to the
repository and makes the necessary changes in the snap definition to use
that artifcat.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
