### PR TITLE
Remove `--classic ` in snap test

### DIFF
--- a/.github/workflows/snapfunctionaltest.yaml
+++ b/.github/workflows/snapfunctionaltest.yaml
@@ -15,7 +15,7 @@ jobs:
         id: snapcraft
       - name: Install snap
         run: |
-          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
+          sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
       - name: Run snap (functional test)
         run: hotsos > output.yaml && exit 1 || echo 'pass'
       - name: Run snap (JSON output)


### PR DESCRIPTION
The snap is strictly confined now and we can install it without the
`--classic ` switch in the functional test.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
