### PR TITLE
github-actions&tox: add non-utc timezone test run

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,6 +28,8 @@ jobs:
         pip install -r gh-test-requirements.txt
     - name: Test with tox
       run: tox -e py3
+    - name: Test with tox (non-utc timezone)
+      run: tox -e py3-non-utc-tz
     - name: Run pylint
       run: tox -e pylint
       if: matrix.python-version == '3.10'

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ setenv = VIRTUAL_ENV={envdir}
          HOTSOS_ROOT={toxinidir}/hotsos
          TESTS_DIR={[testenv]unit_tests}
          PYFILES={toxinidir}/setup.py {toxinidir}/hotsos/ {[testenv]unit_tests}
+         non-utc-tz: TZ=EST+5
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
the tests were only being run in the UTC timezone which hides most of the timezone problems the code potentially has. this patch extends the existing `py3` tox environment to pass a non-UTC timezone to the test environment.

Fixes: #691