### PR TITLE
Remove `stestr` dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
 bashate
 flake8==6.0.0
 flake8-import-order==0.18.2
-stestr
 pylint==2.17.4
 rpdb
 testtools

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv = VIRTUAL_ENV={envdir}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-commands = stestr run --serial --test-path {[testenv]unit_tests} {posargs}
+commands = python -m unittest --verbose {posargs}
 
 [testenv:pep8]
 allowlist_externals = flake8


### PR DESCRIPTION
We are not using `stestr` in parallel and can simplify the test
requirements by using `unittest` instead.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
