### PR TITLE
Make UptimeHelper clearer

### DIFF
--- a/hotsos/core/ycheck/engine/properties/search.py
+++ b/hotsos/core/ycheck/engine/properties/search.py
@@ -150,7 +150,7 @@ class YPropertySearchConstraints(YPropertyOverrideBase):
         if not any([has_result_hours, has_boot_hours]):
             return
 
-        uptime_etime_hours = UptimeHelper().hours
+        uptime_etime_hours = UptimeHelper().in_hours
         hours = self.search_result_age_hours
         min_hours_since_last_boot = self.min_hours_since_last_boot
         if not hours:

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
@@ -13,7 +13,7 @@ data-root:
     - sos_commands/systemd/systemctl_list-unit-files
 mock:
   patch:
-    hotsos.core.ycheck.engine.properties.search.UptimeHelper.hours:
+    hotsos.core.ycheck.engine.properties.search.UptimeHelper.in_hours:
       kwargs:
         new: 49
     hotsos.core.plugins.storage.ceph.CephChecksBase.has_interface_errors:

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/osd_slow_heartbeats.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/osd_slow_heartbeats.yaml
@@ -17,7 +17,7 @@ data-root:
     - sos_commands/systemd/systemctl_list-unit-files
 mock:
   patch:
-    hotsos.core.ycheck.engine.properties.search.UptimeHelper.hours:
+    hotsos.core.ycheck.engine.properties.search.UptimeHelper.in_hours:
       kwargs:
         new: 49
     hotsos.core.plugins.storage.ceph.CephChecksBase.has_interface_errors:

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -492,24 +492,30 @@ class TestUptimeHelper(utils.BaseTestCase):
                          "3.58, 3.27, 2.58")
 
     def test_uptime(self):
-        self.assertEqual(host_helpers.UptimeHelper().seconds, 63660)
-        self.assertEqual(host_helpers.UptimeHelper().hours, 17)
+        uptime = host_helpers.UptimeHelper()
+        self.assertEqual(uptime.in_seconds, 63660)
+        self.assertEqual(uptime.in_hours, 17)
+        self.assertEqual(repr(uptime), '0d:17h:41m')
 
     @utils.create_data_root({'uptime':
                              (' 14:51:10 up 1 day,  6:27,  1 user,  '
                               'load average: 0.55, 0.73, 0.70')})
     def test_uptime_alt_format(self):
-        self.assertEqual(host_helpers.UptimeHelper().seconds, 109620)
-        self.assertEqual(host_helpers.UptimeHelper().hours, 30)
+        uptime = host_helpers.UptimeHelper()
+        self.assertEqual(uptime.in_seconds, 109620)
+        self.assertEqual(uptime.in_hours, 30)
+        self.assertEqual(repr(uptime), '1d:6h:27m')
 
     @utils.create_data_root({'uptime':
                              (' 19:12:40 up  1:55,  2 users,  '
                               'load average: 3.92, 4.05, 3.90')})
     def test_uptime_alt_format2(self):
-        self.assertEqual(host_helpers.UptimeHelper().seconds, 6900)
-        self.assertEqual(host_helpers.UptimeHelper().hours, 1)
-        self.assertEqual(host_helpers.UptimeHelper().loadavg,
+        uptime = host_helpers.UptimeHelper()
+        self.assertEqual(uptime.in_seconds, 6900)
+        self.assertEqual(uptime.in_hours, 1)
+        self.assertEqual(uptime.loadavg,
                          '3.92, 4.05, 3.90')
+        self.assertEqual(repr(uptime), '0d:1h:55m')
 
 
 class TestSysctlHelper(utils.BaseTestCase):


### PR DESCRIPTION
Makes it clearer that the timing properties are reflections of total time by prefixin them with in_* e.g. in_minutes. Also implements a __repr__ to return a string of format <int>d:<int>h:<int>m:<int>s to represent total uptime.