### PR TITLE
Shorten some summary entries

### DIFF
--- a/examples/hotsos-example-openstack.summary.yaml
+++ b/examples/hotsos-example-openstack.summary.yaml
@@ -109,8 +109,7 @@ openstack:
     - qemu-kvm 1:4.2-3ubuntu6.19
     - radvd 1:2.17-2
   neutron-l3ha:
-    backup:
-      - 984c22fd-64b3-4fa1-8ddd-87090f401ce5
+    backup: 1
   os-server-external-events:
     network-changed:
       succeeded:
@@ -122,7 +121,9 @@ openstack:
           instance: 359150c9-6f40-416e-b381-185bff09e974
   vm-info:
     running:
-      - d1d75e2f-ada4-49bc-a963-528d89dfda25
+      count: 1
+      uuids:
+        - d1d75e2f-ada4-49bc-a963-528d89dfda25
     cpu-models:
       Skylake-Client-IBRS: 1
     vcpu-info:

--- a/hotsos/plugin_extensions/openstack/summary.py
+++ b/hotsos/plugin_extensions/openstack/summary.py
@@ -39,9 +39,9 @@ class OpenstackSummary(OpenstackChecksBase):
         for router in ha_info.ha_routers:
             state = router.ha_state
             if state in routers:
-                routers[state].append(router.uuid)
+                routers[state] += 1
             else:
-                routers[state] = [router.uuid]
+                routers[state] = 1
 
         if routers:
             return routers

--- a/hotsos/plugin_extensions/openstack/vm_info.py
+++ b/hotsos/plugin_extensions/openstack/vm_info.py
@@ -26,7 +26,8 @@ class OpenstackInstanceChecks(OpenstackChecksBase):
 
         instances = self.nova.instances.values()
         if instances:
-            _info['running'] = [i.uuid for i in instances]
+            _info['running'] = {'count': len(instances),
+                                'uuids': [i.uuid for i in instances]}
 
         novalibvirt = NovaLibvirt()
         cpu_models = novalibvirt.cpu_models

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -32,7 +32,7 @@ class OVSEventChecks(OpenvSwitchEventChecksBase):
                              event_names=['bridge-no-such-device',
                                           'netdev-linux-no-such-device'])
     def process_vswitchd_events(self, event):
-        ret = self.categorise_events(event)
+        ret = self.categorise_events(event, max_results_per_date=5)
         if ret:
             return {event.name: ret}, 'ovs-vswitchd'
 

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -612,7 +612,7 @@ class TestOpenstackSummary(TestOpenstackBase):
         self.assertTrue(inst.ovs_cleanup_run_manually)
 
     def test_get_neutronl3ha_info(self):
-        expected = {'backup': ['984c22fd-64b3-4fa1-8ddd-87090f401ce5']}
+        expected = {'backup': 1}
         inst = summary.OpenstackSummary()
         actual = self.part_output_to_actual(inst.output)
         self.assertEqual(actual['neutron-l3ha'], expected)
@@ -622,7 +622,9 @@ class TestOpenstackVmInfo(TestOpenstackBase):
 
     def test_get_vm_checks(self):
         expected = {"vm-info": {
-                        "running": ['d1d75e2f-ada4-49bc-a963-528d89dfda25'],
+                        "running": {
+                            'count': 1,
+                            'uuids': ['d1d75e2f-ada4-49bc-a963-528d89dfda25']},
                         "cpu-models": {'Skylake-Client-IBRS': 1},
                         "vcpu-info": {
                             "available-cores": 2,


### PR DESCRIPTION
Some summary entries can have long lists of subentries which can make them hard to read and with no real value. This adds support to events.EventProcessingUtils.categorise_events to pick top N results for events saved by date.

Also summarises neutron l3ha router counts and nova vm counts.

Resolves: #682