### PR TITLE
Add check for LP #1948466

### DIFF
--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1948466.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1948466.yaml
@@ -1,0 +1,15 @@
+checks:
+  has_1948466:
+    input:
+      path: 'var/log/neutron/neutron-server.log'
+    expr: '([\d-]+) [\d:]+\.\d{3} .+ ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance .+ Maintenance task: Failed to fix deleted resource .+ \(type: subnets\): KeyError: ''uuid'''
+    hint: 'ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance'
+conclusions:
+  lp1948466:
+    decision: has_1948466
+    raises:
+      type: LaunchpadBug
+      bug-id: 1948466
+      message: >-
+        Known neutron-server bug identified that impacts deletion of neutron
+        subnets from the OVN database via the maintenance task.

--- a/hotsos/defs/tests/scenarios/openstack/neutron/bugs/lp1948466.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/neutron/bugs/lp1948466.yaml
@@ -1,0 +1,11 @@
+data-root:
+  files:
+    var/log/neutron/neutron-server.log: |
+      2023-08-16 00:22:14.209 87890 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [req-cef1fdf1-c249-4d8c-ad0d-23d3a81f60ec - - - - -] Maintenance task: Failed to fix deleted resource fe5482d2-351d-4b9d-9da1-3d6738f64755 (type: subnets): KeyError: 'uuid'
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-bugs:
+  https://bugs.launchpad.net/bugs/1948466: >-
+    Known neutron-server bug identified that impacts deletion of neutron
+    subnets from the OVN database via the maintenance task.


### PR DESCRIPTION
OVN maintenance task can throw a KeyError trying to delete a subnet, leading to neutron-server slowness.

Closes-bug: #710