### PR TITLE
Adding MAAS proxy error check

### DIFF
--- a/hotsos/defs/scenarios/maas/maas_proxy_issue.yaml
+++ b/hotsos/defs/scenarios/maas/maas_proxy_issue.yaml
@@ -1,0 +1,18 @@
+checks:
+  has_proxy_issue:
+    input:
+      - 'var/snap/maas/common/log/proxy/access.log'
+      - 'var/log/maas/proxy/access.log'
+    expr: '.+ TAG_NONE/503 \d+ CONNECT (\S+)'
+conclusions:
+  possible_issues:
+    decision: has_proxy_issue
+    raises:
+      type: MAASWarning
+      message: >-
+        maas-proxy is reporting failure to forward requests (e.g. to
+        {destinations}). You can try increasing forward_max_tries to 50 or
+        setting client_persistent_connections off,
+        server_persistent_connections off to alleviate the problem.
+      format-dict:
+        destinations: '@checks.has_proxy_issue.search.results_group_1:unique_comma_join'

--- a/hotsos/defs/tests/scenarios/maas/maas_proxy_issue.yaml
+++ b/hotsos/defs/tests/scenarios/maas/maas_proxy_issue.yaml
@@ -1,0 +1,13 @@
+data-root:
+  files:
+    var/snap/maas/common/log/proxy/access.log: |
+      1666854189.800 68 xx.xx.xx.xx. TAG_NONE/503 0 CONNECT api.snapcraft.io:443 - HIER_NONE/- -
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-issues:
+  MAASWarning: >-
+    maas-proxy is reporting failure to forward requests (e.g. to
+    api.snapcraft.io:443). You can try increasing forward_max_tries to 50 or
+    setting client_persistent_connections off, server_persistent_connections off
+    to alleviate the problem.

--- a/hotsos/defs/tests/scenarios/maas/placeholder-not-a-test.yaml
+++ b/hotsos/defs/tests/scenarios/maas/placeholder-not-a-test.yaml
@@ -1,6 +1,0 @@
-# THIS IS A PLACEHOLDER FILE AND SHOULD BE DELETED ONCE A TEST IS ADDED TO THIS DIRECTORY
-data-root:
-  files:
-  copy-from-original:
-raised-bugs:
-raised-issues:


### PR DESCRIPTION
TAG_NONE/503 error is happening when
maas-proxy has high load

resolves: #482