### PR TITLE
Move maas postgres dep to non-core

### DIFF
--- a/hotsos/core/plugins/maas.py
+++ b/hotsos/core/plugins/maas.py
@@ -7,8 +7,8 @@ from hotsos.core.host_helpers import (
 )
 from hotsos.core.plugintools import PluginPartBase
 
-CORE_APT = ['maas', 'postgres']
-APT_DEPS = ['isc-dhcp', 'bind9']
+CORE_APT = ['maas']
+APT_DEPS = ['isc-dhcp', 'bind9', 'postgres']
 CORE_SNAPS = CORE_APT
 
 SERVICE_EXPRS = [s + '[A-Za-z0-9-]*' for s in CORE_APT + APT_DEPS]


### PR DESCRIPTION
This is to ensure we dont run maas plugin on nodes that have postgres but not maas.