### PR TITLE
Tolerate systemctl status non-unicode chars

### DIFF
--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -83,7 +83,7 @@ class SystemdService(object):
         # NOTE: should consider getting service status directly rather than
         #       searching in all but currently do this to have parity with
         #       sosreport.
-        fs = FileSearcher()
+        fs = FileSearcher(decode_errors='backslashreplace')
         # The following expressions need to take account of control characters
         # that might exist in the output e.g. line can start with '*' or U+25CF
         # Active: active (running) since Wed 2022-02-09 22:38:17 UTC; 17h ago

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     'progress',
     'propertree >= 1.0.3',
     'pyyaml',
-    'searchkit >= 0.3.2',
+    'searchkit >= 0.3.3',
     'simplejson',
     'python-dateutil',
     'pytz',

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2
 progress
 propertree >= 1.0.3
 pyyaml
-searchkit >= 0.3.2
+searchkit >= 0.3.3
 simplejson
 sphinx>=4.3.2
 python-dateutil


### PR DESCRIPTION
We now use decode('utf-8', errors="backslashreplace") in FileSearcher when searching sosreport systemctl status output that can contain non-unicode chars.

Resolves: #718