### PR TITLE
Add check for LP#2012284

### DIFF
--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp2012284.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp2012284.yaml
@@ -1,0 +1,18 @@
+checks:
+  has_2012284:
+    input:
+      path: 'var/log/nova/nova-compute.log'
+    expr: ".+Failure prepping block device: gi.repository.GLib.GError: g-io-error-quark: Error opening directory '/usr/share/osinfo': Permission denied"
+    hint: 'osinfo'
+conclusions:
+  lp2012284:
+    decision: has_2012284
+    raises:
+      type: LaunchpadBug
+      bug-id: 2012284
+      message: >-
+        known nova compute issue caused when package gir1.2-libosinfo-1.0 is installed
+        and apparmor is set to enforced. To fix the issue, the offending package needs to
+        be removed, or apparmor set to complain, or the rules would need to be added to the
+        apparmor profile (but this is not supported and can be overridden). Please refer
+        to the Launchpad #2012284 bug page more information.

--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp2012284.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp2012284.yaml
@@ -1,18 +1,31 @@
+vars:
+  nc_aa_mode: '@hotsos.core.host_helpers.apparmor.AAProfileFactory.mode:/usr/bin/nova-compute'
 checks:
   has_2012284:
     input:
       path: 'var/log/nova/nova-compute.log'
     expr: '([\d-]+) ([\d:]+).\d{3} .+Failure prepping block device: gi.repository.GLib.GError: g-io-error-quark: Error opening directory ./usr/share/osinfo.: Permission denied'
     hint: 'osinfo'
+  nc_in_enforce_mode:
+    varops: [[$nc_aa_mode], [eq, enforce]]
+  has_package:
+    or:
+      - apt: gir1.2-libosinfo-1.0
+      - apt: gir1.2-libosinfo-1.0:amd64
 conclusions:
   lp2012284:
-    decision: has_2012284
+    decision:
+        - has_package
+        - has_2012284
+        - nc_in_enforce_mode
     raises:
       type: LaunchpadBug
       bug-id: 2012284
       message: >-
-        Known nova compute issue caused when package gir1.2-libosinfo-1.0 is installed
+        Known nova compute issue caused when package {package} is installed
         and apparmor is set to enforce. To fix the issue, the offending package needs to
         be removed, or apparmor set to complain, or the rules would need to be added to the
         apparmor profile (but this is not supported and can be overridden). Please refer
         to the Launchpad #2012284 bug page more information.
+      format-dict:
+        package: '@checks.has_package.requires.package'

--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp2012284.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp2012284.yaml
@@ -2,7 +2,7 @@ checks:
   has_2012284:
     input:
       path: 'var/log/nova/nova-compute.log'
-    expr: ".+Failure prepping block device: gi.repository.GLib.GError: g-io-error-quark: Error opening directory '/usr/share/osinfo': Permission denied"
+    expr: '([\d-]+) ([\d:]+).\d{3} .+Failure prepping block device: gi.repository.GLib.GError: g-io-error-quark: Error opening directory ./usr/share/osinfo.: Permission denied'
     hint: 'osinfo'
 conclusions:
   lp2012284:
@@ -11,8 +11,8 @@ conclusions:
       type: LaunchpadBug
       bug-id: 2012284
       message: >-
-        known nova compute issue caused when package gir1.2-libosinfo-1.0 is installed
-        and apparmor is set to enforced. To fix the issue, the offending package needs to
+        Known nova compute issue caused when package gir1.2-libosinfo-1.0 is installed
+        and apparmor is set to enforce. To fix the issue, the offending package needs to
         be removed, or apparmor set to complain, or the rules would need to be added to the
         apparmor profile (but this is not supported and can be overridden). Please refer
         to the Launchpad #2012284 bug page more information.

--- a/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp2012284.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp2012284.yaml
@@ -1,0 +1,13 @@
+data-root:
+  files:
+    var/log/nova/nova-compute.log: |
+      2023-02-14 11:54:31.094 3490324 ERROR nova.compute.manager [req-d8c21949-4edb-4ae8-859e-bdc407402446 919173c1ba5b04004ac4c467c678e6e842b90f5206a224168ba0d3d83c398dfb fd686745c7724189bb02e5f62020a1b2 - 7078ee187a1c42c2a798707b9ca4cd68 7078ee187a1c42c2a798707b9ca4cd68] [instance: ae35c62d-3f91-4e76-8274-9a7893b9627d] Failure prepping block device: gi.repository.GLib.GError: g-io-error-quark: Error opening directory '/usr/share/osinfo': Permission denied (14)
+  copy-from-original:
+    - sos_commands/date/date
+raised-bugs:
+  https://bugs.launchpad.net/bugs/2012284: >-
+    known nova compute issue caused when package gir1.2-libosinfo-1.0 is installed
+    and apparmor is set to enforced. To fix the issue, the offending package needs to
+    be removed, or apparmor set to complain, or the rules would need to be added to the
+    apparmor profile (but this is not supported and can be overridden). Please refer
+    to the Launchpad #2012284 bug page more information.

--- a/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp2012284.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp2012284.yaml
@@ -6,8 +6,8 @@ data-root:
     - sos_commands/date/date
 raised-bugs:
   https://bugs.launchpad.net/bugs/2012284: >-
-    known nova compute issue caused when package gir1.2-libosinfo-1.0 is installed
-    and apparmor is set to enforced. To fix the issue, the offending package needs to
+    Known nova compute issue caused when package gir1.2-libosinfo-1.0 is installed
+    and apparmor is set to enforce. To fix the issue, the offending package needs to
     be removed, or apparmor set to complain, or the rules would need to be added to the
     apparmor profile (but this is not supported and can be overridden). Please refer
     to the Launchpad #2012284 bug page more information.

--- a/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp2012284.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp2012284.yaml
@@ -1,12 +1,17 @@
 data-root:
   files:
+    sos_commands/apparmor/apparmor_status: |
+      32 profiles are in enforce mode.
+         /usr/bin/nova-compute
+    sos_commands/dpkg/dpkg_-l: |
+      ii  gir1.2-libosinfo-1.0:amd64           1.7.1-1                                              amd64        GObject introspection data for libosinfo
     var/log/nova/nova-compute.log: |
       2023-02-14 11:54:31.094 3490324 ERROR nova.compute.manager [req-d8c21949-4edb-4ae8-859e-bdc407402446 919173c1ba5b04004ac4c467c678e6e842b90f5206a224168ba0d3d83c398dfb fd686745c7724189bb02e5f62020a1b2 - 7078ee187a1c42c2a798707b9ca4cd68 7078ee187a1c42c2a798707b9ca4cd68] [instance: ae35c62d-3f91-4e76-8274-9a7893b9627d] Failure prepping block device: gi.repository.GLib.GError: g-io-error-quark: Error opening directory '/usr/share/osinfo': Permission denied (14)
   copy-from-original:
     - sos_commands/date/date
 raised-bugs:
   https://bugs.launchpad.net/bugs/2012284: >-
-    Known nova compute issue caused when package gir1.2-libosinfo-1.0 is installed
+    Known nova compute issue caused when package gir1.2-libosinfo-1.0:amd64 is installed
     and apparmor is set to enforce. To fix the issue, the offending package needs to
     be removed, or apparmor set to complain, or the rules would need to be added to the
     apparmor profile (but this is not supported and can be overridden). Please refer


### PR DESCRIPTION
Error creating Nova VM with AppArmor set
to "enforce": osinfo permission denied

Closes: #723 