### PR TITLE
Fix some timestamp regex matching

### DIFF
--- a/hotsos/defs/events/openstack/apparmor.yaml
+++ b/hotsos/defs/events/openstack/apparmor.yaml
@@ -1,9 +1,17 @@
 input:
   path: 'var/log/kern.log'
 denials:
+  # NOTE: the kern.log timestamp pattern is of the form
+  #       "Jun  8 10:48:13 compute4 kernel:"
+  #       or
+  #       "Jun 08 10:48:13 compute4 kernel:"
+  #
+  # The time regex is a little different here as we need the month (\w{3,5}),
+  # day (\d{1,2}), time ([\d:]+) and key (\S+neutron\S+) separated for
+  # grouping. See AgentApparmorChecks class for more details.
   nova:
-    expr: '(\S+)\s+(\d+)\s+([\d+:]+)\s+.+apparmor="DENIED".+\s+profile="(\S+nova\S+)"\s+.+'
+    expr: '(\w{3,5})\s+(\d{1,2})\s+([\d:]+)\s+.+apparmor="DENIED".+\s+profile="(\S+nova\S+)"\s+.+'
     hint: apparmor
   neutron:
-    expr: '(\S+)\s+(\d+)\s+([\d+:]+)\s+.+apparmor="DENIED".+\s+profile="(\S+neutron\S+)"\s+.+'
+    expr: '(\w{3,5})\s+(\d{1,2})\s+([\d:]+)\s+.+apparmor="DENIED".+\s+profile="(\S+neutron\S+)"\s+.+'
     hint: apparmor

--- a/hotsos/defs/events/openvswitch/ovs/datapath-checks.yaml
+++ b/hotsos/defs/events/openvswitch/ovs/datapath-checks.yaml
@@ -9,5 +9,12 @@ port-stats:
 deferred-action-limit-reached:
   input:
     path: 'var/log/kern.log'
-  expr: '(\S+\s+\d+\s+)\S+ .+ (\S+): deferred action limit reached, drop recirc action'
+  # NOTE: the kern.log timestamp pattern is of the form
+  #       "Jun  8 10:48:13 compute4 kernel:"
+  #       or
+  #       "Jun 08 10:48:13 compute4 kernel:"
+  # The time regex is a little different here as we need the month (\w{3,5}),
+  # day (\d{1,2}), time ([\d:]+), and key ((\S+) separated for grouping. See
+  # deferred_action_limit_reached() method for more details.
+  expr: '(\w{3,5})\s+(\d{1,2})\s+([\d:]+)\s+.+openvswitch:\s+(\S+):.+deferred action limit reached, drop recirc action'
   hint: openvswitch

--- a/hotsos/defs/scenarios/kernel/disk_failure.yaml
+++ b/hotsos/defs/scenarios/kernel/disk_failure.yaml
@@ -2,7 +2,11 @@ checks:
   disk_failure:
     input:
       path: 'var/log/kern.log'
-    expr: '.+ critical medium error, dev (\S+), .+'
+    # NOTE: the kern.log timestamp pattern is of the form
+    #       "Jun  8 10:48:13 compute4 kernel:"
+    #       or
+    #       "Jun 08 10:48:13 compute4 kernel:"
+    expr: '(\w{3,5}\s+\d{1,2}\s+[\d:]+)\S+ .+ critical medium error, dev (\S+), .+'
 conclusions:
   failing_disk:
     decision: disk_failure
@@ -12,4 +16,4 @@ conclusions:
         critical medium error detected in kern.log for device {dev}.
         This implies that this disk has a hardware issue!
       format-dict:
-        dev: '@checks.disk_failure.search.results_group_1:comma_join'
+        dev: '@checks.disk_failure.search.results_group_2:comma_join'

--- a/hotsos/defs/scenarios/kernel/network/misc.yaml
+++ b/hotsos/defs/scenarios/kernel/network/misc.yaml
@@ -2,7 +2,11 @@ checks:
   has_nf_conntrack_full:
     input:
       path: 'var/log/kern.log'
-    expr: '.+ nf_conntrack: table full, dropping packet'
+    # NOTE: the kern.log timestamp pattern is of the form
+    #       "Jun  8 10:48:13 compute4 kernel:"
+    #       or
+    #       "Jun 08 10:48:13 compute4 kernel:"
+    expr: '(\w{3,5}\s+\d{1,2}\s+[\d:]+)\S+.+ nf_conntrack: table full, dropping packet'
   has_over_mtu_dropped_packets:
     property: hotsos.core.plugins.kernel.kernlog.KernLogEvents.over_mtu_dropped_packets
 conclusions:

--- a/hotsos/defs/scenarios/kernel/qla2xxx.yaml
+++ b/hotsos/defs/scenarios/kernel/qla2xxx.yaml
@@ -2,7 +2,11 @@ checks:
   qla2xxx_skipping_scsi_scan_host:
     input:
       path: 'var/log/kern.log'
-    expr: '.+ qla2xxx (\S+): skipping scsi_scan_host\(\) for non-initiator port'
+    # NOTE: the kern.log timestamp pattern is of the form
+    #       "Jun  8 10:48:13 compute4 kernel:"
+    #       or
+    #       "Jun 08 10:48:13 compute4 kernel:"
+    expr: '(\w{3,5}\s+\d{1,2}\s+[\d:]+) \S+ .+ qla2xxx (\S+): skipping scsi_scan_host\(\) for non-initiator port'
 conclusions:
   qla2xxx_skipped_scsi_scan_host:
     decision: qla2xxx_skipping_scsi_scan_host
@@ -13,4 +17,4 @@ conclusions:
         Some SCSI disks/paths might not be present. (Module option
         'qla2xxx.qlini_mode')
       format-dict:
-        port: '@checks.qla2xxx_skipping_scsi_scan_host.search.results_group_1:first'
+        port: '@checks.qla2xxx_skipping_scsi_scan_host.search.results_group_2:first'

--- a/hotsos/defs/scenarios/lxd/bugs/lp1807628.yaml
+++ b/hotsos/defs/scenarios/lxd/bugs/lp1807628.yaml
@@ -2,7 +2,11 @@ checks:
   lxcfs_segfault:
     input:
       path: 'var/log/kern.log'
-    expr: '.+ segfault at 0 .+ error 4 in liblxcfs.so.+'
+    # NOTE: the kern.log timestamp pattern is of the form
+    #       "Jun  8 10:48:13 compute4 kernel:"
+    #       or
+    #       "Jun 08 10:48:13 compute4 kernel:"
+    expr: '(\w{3,5}\s+\d{1,2}\s+[\d:]+)\S+ .+ (\S+): segfault at 0 .+ error 4 in liblxcfs.so.+'
   has_1807628:
     apt:
       lxcfs:

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1896506.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1896506.yaml
@@ -2,7 +2,10 @@ checks:
   has_1896506:
     input:
       path: 'var/log/syslog'
-    expr: '.+Unknown configuration entry ''no_track'' for ip address - ignoring.*'
+    # NOTE: the syslog timestamp pattern is of the form
+    #       "Apr  6 06:36:09 kermath Keepalived_vrrp[23396]:"
+    #       which is similar to kern.log
+    expr: '(\w{3,5}\s+\d{1,2}\s+[\d:]+)\s+.+Unknown configuration entry ''no_track'' for ip address - ignoring.*'
     hint: 'no_track'
 conclusions:
   lp1896506:

--- a/hotsos/defs/scenarios/openstack/neutron/bugs/lp1996594.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/bugs/lp1996594.yaml
@@ -8,7 +8,7 @@ checks:
     input:
       path: 'var/log/neutron/neutron-ovn-metadata-agent.log'
     search:
-      expr: '([0-9-]+)\s([0-9:]+)\.\d{3}.+OVSDB Error: no error details.+'
+      expr: '([\d-]+ [\d:]+.\d{3}) .+OVSDB Error: no error details.+'
       constraints:
         min-results: 1
         min-hours-since-last-boot: 0

--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp1904580.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp1904580.yaml
@@ -2,6 +2,8 @@ checks:
   has_1904580:
     input:
       path: 'var/log/nova/nova-compute.log'
+    # NOTE: this does not need a timestamp pattern match as the error
+    #       is from an ssh command's stderr
     expr: '.+Permissions (\d{4}) for (\S+) are too open'
     hint: 'Permissions'
 conclusions:

--- a/hotsos/defs/scenarios/openstack/octavia/excessive_failovers.yaml
+++ b/hotsos/defs/scenarios/openstack/octavia/excessive_failovers.yaml
@@ -18,7 +18,11 @@ checks:
   over_mtu_drops_ohm0_kernlog:
     input:
       path: 'var/log/kern.log'
-    expr: '(\w{3,5}\s+\d{1,2}\s+[\d:]+) \S+ \S+ \S+ o-hm0: dropped over-mtu packet: \d+ > (\d+)'
+    # NOTE: the kern.log timestamp pattern is of the form
+    #       "Jun  8 10:48:13 compute4 kernel:"
+    #       or
+    #       "Jun 08 10:48:13 compute4 kernel:"
+    expr: '(\w{3,5}\s+\d{1,2}\s+[\d:]+) \S+ .+ (\S+) o-hm0: dropped over-mtu packet: \d+ > (\d+)'
     constraints:
       search-result-age-hours: 48
   over_mtu_drops_ohm0_dmesg:

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -56,9 +56,12 @@ class OVSEventChecks(OpenvSwitchEventChecksBase):
 
     @EVENTCALLBACKS.callback(event_group='ovs')
     def deferred_action_limit_reached(self, event):
-        ret = self.categorise_events(event, key_by_date=False)
-        output_key = "{}-{}".format(event.section, event.name)
-        return ret, output_key
+        results = [{'date': "{} {}".format(r.get(1), r.get(2)),
+                    'time': r.get(3),
+                    'key': r.get(4)} for r in event.results]
+        ret = self.categorise_events(event, results=results, key_by_date=False)
+        if ret:
+            return {event.name: ret}, event.section
 
     @EVENTCALLBACKS.callback(event_group='ovs')
     def port_stats(self, event):

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -73,6 +73,16 @@ SBDB_COMPACTION = """
 2022-07-14T23:57:57.528Z|631184|ovsdb|INFO|OVN_Southbound: Database compaction took 2151ms
 """  # noqa
 
+DA_MSGS = """
+Mar  3 22:57:11 compute4 kernel: [1381807.338196] openvswitch: ovs-system: deferred action limit reached, drop recirc action
+Mar  3 22:57:11 compute4 kernel: [1381807.714508] openvswitch: ovs-system: deferred action limit reached, drop recirc action
+Mar  3 22:57:11 compute4 kernel: [1381807.843795] openvswitch: ovs-system: deferred action limit reached, drop recirc action
+Mar  3 22:57:22 compute4 kernel: [1381818.448855] openvswitch: ovs-system: deferred action limit reached, drop recirc action
+Mar  3 22:57:23 compute4 kernel: [1381819.715713] openvswitch: ovs-system: deferred action limit reached, drop recirc action
+Mar  3 22:57:24 compute4 kernel: [1381820.269384] openvswitch: ovs-system: deferred action limit reached, drop recirc action
+Mar  3 22:57:24 compute4 kernel: [1381820.499397] openvswitch: ovs-system: deferred action limit reached, drop recirc action
+"""  # noqa
+
 
 class TestOpenvswitchBase(utils.BaseTestCase):
 
@@ -400,6 +410,19 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                     'ovsdb-server-sb': {'compactions': {
                                             '2022-07-14': 3}}}
         inst = event_checks.OVNEventChecks()
+        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+
+    @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
+                new=utils.is_def_filter('ovs/datapath-checks.yaml',
+                                        'events/openvswitch'))
+    @utils.create_data_root({'var/log/kern.log': DA_MSGS})
+    def test_ovs_defferred_action_limit_reached(self):
+        expected = {
+            'datapath-checks': {
+                'deferred-action-limit-reached': {
+                    'ovs-system':
+                        {'Mar 3': 7}}}}
+        inst = event_checks.OVSEventChecks()
         self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
 


### PR DESCRIPTION
There were three scenarios that didn't have any timestamp matching for kern.log or syslog entries, added them.

Also changed a neutron match to be like all the others.

Added a note where a match was not required.