### PR TITLE
Fix spinner message printing multiple times

### DIFF
--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -309,7 +309,10 @@ def main():
                     spinner_msg = ''
                 else:
                     show_spinner = not debug
-                    spinner_msg = 'INFO: analysing {} '.format(drm.name)
+                    if show_spinner:
+                        sys.stdout.write(
+                            'INFO: analysing {}\n'.format(drm.name))
+                    spinner_msg = 'INFO: analysing '
 
                 with progress_spinner(show_spinner, spinner_msg):
                     plugins = []

--- a/tools/test/functest.sh
+++ b/tools/test/functest.sh
@@ -47,12 +47,12 @@ test_plugin ()
         args+=( --short )
         label=".short"
     fi
-    # NOTE: we remove repo-info and date from hotsos and system plugin
+    # NOTE: we remove repo-info, date and INFO from hotsos and system plugin
     #       output since they are liable to change.
     ./scripts/hotsos --${plugin} ${args[@]} $data_root 2>/dev/null| \
-        egrep -v "^  repo-info:|date:" > $dtmp/$plugin$label
+        egrep -v "^  repo-info:|date:|INFO:" > $dtmp/$plugin$label
     litmus=examples/hotsos-example-${plugin}${label}.summary.yaml
-    egrep -v "^  repo-info:|date:" $litmus > $dtmp/$plugin.litmus
+    egrep -v "^  repo-info:|date:|INFO:" $litmus > $dtmp/$plugin.litmus
     if diff $dtmp/$plugin.litmus $dtmp/$plugin$label &> $dtmp/fail; then
         echo -e " [${F_GRN}PASS${RES}]"
     else


### PR DESCRIPTION
When analysing a tarfile, attempting to print the
"INFO: analysing $file" line in the spinner code
can overflow the window if it's narrow, resulting
in hundreds of lines of extra output.

Change to print what is being analysed on its own
line to keep the "analysing" spinner message short and prevent the extra output.

Resolves: #729