### PR TITLE
Second attempt at temp file and directory cleanup

### DIFF
--- a/hotsos/client.py
+++ b/hotsos/client.py
@@ -372,6 +372,8 @@ class HotSOSClient(object):
         log.debug("tearing down global env")
         if os.path.exists(HotSOSConfig.global_tmp_dir):
             shutil.rmtree(HotSOSConfig.global_tmp_dir)
+        # Ensure tmp dir doesn't get accidentally recreated
+        HotSOSConfig.plugin_tmp_dir = None
 
     def setup_plugin_env(self, plugin):
         """ State saved here is specific to a plugin. """

--- a/hotsos/core/host_helpers/common.py
+++ b/hotsos/core/host_helpers/common.py
@@ -1,4 +1,5 @@
 import abc
+import os
 import re
 
 from searchkit.utils import MPCache
@@ -6,12 +7,28 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core.log import log
 
 
+class NullCache(object):
+    """ A cache that does nothing but maintains the MPCache abi. """
+
+    def get(self, *args, **kwargs):
+        log.debug("null cache get() op args=%s kwargs=%s", args, kwargs)
+
+    def set(self, *args, **kwargs):
+        log.debug("null cache set() op args=%s kwargs=%s", args, kwargs)
+
+
 class HostHelpersBase(abc.ABC):
 
     def __init__(self, *args, **kwargs):
-        self.cache = MPCache(self.cache_name,
-                             'host_helpers_{}'.format(self.cache_type),
-                             self.cache_root)
+        if not self.cache_root or not os.path.exists(self.cache_root):
+            log.debug("cache root invalid or does not exist so disabling %s "
+                      "cache", self.__class__.__name__)
+            self.cache = NullCache()
+        else:
+            self.cache = MPCache(self.cache_name,
+                                 'host_helpers_{}'.format(self.cache_type),
+                                 self.cache_root)
+
         super().__init__(*args, **kwargs)
 
     @property

--- a/hotsos/core/host_helpers/network.py
+++ b/hotsos/core/host_helpers/network.py
@@ -58,7 +58,7 @@ class NetworkPort(HostHelpersBase):
         return "port-{}".format(self.name)
 
     def cache_load(self):
-        contents = self.cache.get('stats')
+        contents = self.cache.get('stats')  # pylint: disable=E1111
         if not contents:
             log.debug("network port %s not found in cache", self.name)
             return
@@ -165,9 +165,9 @@ class HostNetworkingHelper(HostHelpersBase):
         log.debug("loading network helper info from cache (namespaces=%s)",
                   namespaces)
         if namespaces:
-            contents = self.cache.get('ns-interfaces')
+            contents = self.cache.get('ns-interfaces')  # pylint: disable=E1111
         else:
-            contents = self.cache.get('interfaces')
+            contents = self.cache.get('interfaces')  # pylint: disable=E1111
 
         if contents:
             return contents

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -106,7 +106,7 @@ class TestHostNetworkingHelper(utils.BaseTestCase):
     def test_get_interfaces_cached(self):
         helper = host_helpers.HostNetworkingHelper()
         helper.host_interfaces_all
-        ifaces = helper.cache.get('interfaces')
+        ifaces = helper.cache.get('interfaces')  # pylint: disable=E1111
         expected = ['lo',
                     'ens3',
                     'ens4',
@@ -132,7 +132,7 @@ class TestHostNetworkingHelper(utils.BaseTestCase):
                     'vxlan_sys_4789',
                     'tap0e778df8-ca']
         self.assertEqual([i['name'] for i in ifaces], expected)
-        ns_ifaces = helper.cache.get('ns-interfaces')
+        ns_ifaces = helper.cache.get('ns-interfaces')  # pylint: disable=E1111
         expected = [('lo',
                      'fip-32981f34-497a-4fae-914a-8576055c8d0d'),
                     ('fpr-984c22fd-6@if2',

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -11,7 +11,7 @@ import yaml
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.issues import IssuesManager
 # disable for stestr otherwise output is much too verbose
-from hotsos.core.log import setup_logging, log, logging
+from hotsos.core.log import log, logging, LoggingManager
 from hotsos.core.ycheck.scenarios import YScenarioChecker
 
 # Must be set prior to other imports
@@ -437,11 +437,12 @@ class BaseTestCase(unittest.TestCase):
             HotSOSConfig.plugin_tmp_dir = self.plugin_tmp_dir
 
         if os.environ.get('TESTS_LOG_LEVEL_DEBUG', 'no') == 'yes':
-            setup_logging(level=logging.DEBUG)
+            LoggingManager().start(level=logging.DEBUG)
         else:
-            setup_logging(level=logging.INFO)
+            LoggingManager().start(level=logging.INFO)
 
     def tearDown(self):
+        LoggingManager().stop()
         HotSOSConfig.reset()
         HotSOSConfig.set(**self.hotsos_config)
         shutil.rmtree(self.global_tmp_dir)

--- a/tools/test/functest.sh
+++ b/tools/test/functest.sh
@@ -47,7 +47,6 @@ test_plugin ()
         args+=( --short )
         label=".short"
     fi
-    export PYTHONPATH=.
     # NOTE: we remove repo-info and date from hotsos and system plugin
     #       output since they are liable to change.
     ./scripts/hotsos --${plugin} ${args[@]} $data_root 2>/dev/null| \
@@ -63,11 +62,17 @@ test_plugin ()
     fi
 }
 
+# this is needed for github workflows to work
+export PYTHONPATH=.
 
 default=${PLUGIN_ROOTS[openstack]}
 for plugin in ${PLUGINS[@]}; do
     test_plugin $plugin
     test_plugin $plugin short
 done
+
+# do a test run with --save to be sure we havent broken anything
+./scripts/hotsos --kernel --save --output-path $dtmp
+
 rm -rf $dtmp
 $result


### PR DESCRIPTION
Ensure HotSOSConfig.plugin_tmp_dir is unset after running plugins and delete temp log file once we are done with it.

If there was an exception running any of the plugins, a message is now printed along with the name of the temporary log file as it may have useful information. Otherwise the temp file is removed.

Also ensures that if plugin_tmp_dir is None the
host_helpers cache uses a new NullCache so that calls still work but are not cached. This allows e.g. the CLIhelper to be used after the plugin env teardown()

Resolves: #730