### PR TITLE
Allow tar extraction failures

### DIFF
--- a/hotsos/core/root_manager.py
+++ b/hotsos/core/root_manager.py
@@ -72,7 +72,18 @@ class DataRootManager(object):
                 if not os.path.exists(target):
                     sys.stdout.write("INFO: extracting sosreport {} to {}\n".
                                      format(path, target))
-                    tar.extractall(self.tmpdir)
+                    try:
+                        tar.extractall(self.tmpdir)
+                    except Exception:
+                        # some members might fail to extract e.g. permission
+                        # denied but we dont want that to cause the whole run
+                        # to fail so we just log a message and ignore them.
+                        tar.errorlevel = 0
+                        sys.stdout.write("INFO: one or more members failed to "
+                                         "extract - disabling error mode and "
+                                         "continuing extraction (which will "
+                                         "be incomplete as a result)\n")
+                        tar.extractall(self.tmpdir)
                 else:
                     sys.stdout.write("INFO: target {} already exists - "
                                      "skipping unpack\n".format(target))


### PR DESCRIPTION
If one or more tar member fails to extract e.g. due to permissions errors, we continue extraction but
log a message to say it may be incomplete.