### PR TITLE
Check neutron router port mtus

### DIFF
--- a/examples/hotsos-example-openstack.summary.yaml
+++ b/examples/hotsos-example-openstack.summary.yaml
@@ -175,6 +175,11 @@ openstack:
       fip: 1
       qrouter: 1
       snat: 1
+    router-port-mtus:
+      qr:
+        - 1450
+      sg:
+        - 1450
   features:
     neutron:
       main:

--- a/hotsos/core/host_helpers/network.py
+++ b/hotsos/core/host_helpers/network.py
@@ -163,10 +163,18 @@ class HostNetworkingHelper(HostHelpersBase):
         # this is a global cache i.e. shared by all plugins
         return 'network-helper'
 
-    def cache_load(self, namespaces=False):
-        log.debug("loading network helper info from cache (namespaces=%s)",
-                  namespaces)
-        if namespaces:
+    def cache_load(self, all_namespaces=False, namespace=None):
+        """
+        @param all_namespaces: Set to True to if we are retrieving network info
+                               for all namespaces.
+        @param namespace: Name of specific namespace we are retrieving from.
+                          Takes precedence over all_namespaces.
+        """
+        log.debug("loading network helper info from cache (all_namespaces=%s, "
+                  "namespace=%s)", all_namespaces, namespace)
+        if namespace is not None:
+            contents = self.cache.get('ns-{}-interfaces'.format(namespace))  # noqa, pylint: disable=E1111
+        elif all_namespaces:
             contents = self.cache.get('ns-interfaces')  # pylint: disable=E1111
         else:
             contents = self.cache.get('interfaces')  # pylint: disable=E1111
@@ -175,109 +183,142 @@ class HostNetworkingHelper(HostHelpersBase):
             return contents
 
         log.debug("network helper info not available in cache "
-                  "(namespaces=%s)", namespaces)
+                  "(all_namespaces=%s, namespace=%s)", all_namespaces,
+                  namespace)
 
-    def cache_save(self, data, namespaces=False):
-        log.debug("saving network helper info to cache (namespaces=%s)",
-                  namespaces)
-        if namespaces:
+    def cache_save(self, data, all_namespaces=False, namespace=None):
+        log.debug("saving network helper info to cache (all_namespaces=%s, "
+                  "namespaces=%s)", all_namespaces, namespace)
+        if namespace is not None:
+            self.cache.set('ns-{}-interfaces'.format(namespace), data)
+        elif all_namespaces:
             self.cache.set('ns-interfaces', data)
         else:
             self.cache.set('interfaces', data)
 
-    def _get_interfaces(self, namespaces=False):
+    def _extract_iface_info(self, seqdef, section, search_obj):
+        addrs = []
+        encap_info = None
+        hwaddr = None
+        name = None
+        mtu = None
+        state = None
+        for result in section:
+            # infer ns name from filename prefix
+            ns_name = None
+            source = search_obj.resolve_source_id(result.source_id)
+            ret = re.match(r'^__ns_start__(\S+)__ns__end__',
+                           os.path.basename(source))
+            if ret:
+                ns_name = ret.group(1)
+
+            if result.tag == seqdef.start_tag:
+                name = result.get(1)
+                mtu = int(result.get(2))
+                state = result.get(3)
+            elif result.tag == seqdef.body_tag:
+                if result.get(1) in ['inet', 'inet6']:
+                    addrs.append(result.get(2))
+                elif result.get(1) in ['vxlan']:
+                    encap_info = {result.get(1): {
+                                      'id': result.get(2),
+                                      'local_ip': result.get(3),
+                                      'dev': result.get(4)}}
+                else:
+                    hwaddr = result.get(2)
+
+        return {'name': name, 'addresses': addrs, 'hwaddr': hwaddr, 'mtu': mtu,
+                'state': state, 'encap_info': encap_info, 'namespace': ns_name}
+
+    @property
+    def _ip_addr_show_iface_sequence_def(self):
+        return SequenceSearchDef(start=SearchDef(IP_IFACE_NAME),
+                                 body=SearchDef([IP_IFACE_V4_ADDR,
+                                                 IP_IFACE_V6_ADDR,
+                                                 IP_IFACE_HW_ADDR,
+                                                 IP_IFACE_VXLAN_INFO]),
+                                 tag='ip_addr_show')
+
+    def get_ns_interfaces(self, namespace):
+        """ Get all network ports for the given namespace.
+
+        @param namespace: name of namespace
+        @return: generator of NetworkPort objects
+        """
+        interfaces_raw = self.cache_load(namespace=namespace) or []
+        if not interfaces_raw:
+            seq = self._ip_addr_show_iface_sequence_def
+            search_obj = FileSearcher()
+            ip_addr = self.cli.ns_ip_addr(namespace=namespace)
+            prefix = "__ns_start__{}__ns__end__".format(namespace)
+            path = mktemp_dump(''.join(ip_addr), prefix=prefix)
+            try:
+                search_obj.add(seq, path)
+                r = search_obj.run()
+                sections = r.find_sequence_sections(seq, path).values()
+                for section in sections:
+                    interfaces_raw.append(self._extract_iface_info(seq,
+                                                                   section,
+                                                                   search_obj))
+            finally:
+                os.unlink(path)
+
+            self.cache_save(interfaces_raw, namespace=namespace)
+
+        for iface in interfaces_raw:
+            yield NetworkPort(**iface)
+
+    def _get_interfaces(self, all_namespaces=False):
         """
         Get all interfaces in ip address show.
 
-        @param namespaces: if set to True will get interfaces from all
+        @param all_namespaces: if set to True will get interfaces from all
         namespaces on the host.
         @return: list of NetworkPort objects for each interface found.
         """
-        interfaces = []
-
-        interfaces_raw = self.cache_load(namespaces=namespaces) or []
-        if interfaces_raw:
-            for iface in interfaces_raw:
-                interfaces.append(NetworkPort(**iface))
-
-            return interfaces
-
-        seq = SequenceSearchDef(start=SearchDef(IP_IFACE_NAME),
-                                body=SearchDef([IP_IFACE_V4_ADDR,
-                                                IP_IFACE_V6_ADDR,
-                                                IP_IFACE_HW_ADDR,
-                                                IP_IFACE_VXLAN_INFO]),
-                                tag='ip_addr_show')
-        search_obj = FileSearcher()
-        if namespaces:
-            for ns in self.cli.ip_netns():
-                ns_name = ns.partition(" ")[0]
-                ip_addr = self.cli.ns_ip_addr(namespace=ns_name)
-                prefix = "__ns_start__{}__ns__end__".format(ns_name)
-                path = mktemp_dump(''.join(ip_addr), prefix=prefix)
+        interfaces_raw = self.cache_load(all_namespaces=all_namespaces) or []
+        if not interfaces_raw:
+            seq = self._ip_addr_show_iface_sequence_def
+            search_obj = FileSearcher()
+            if all_namespaces:
+                for ns in self.cli.ip_netns():
+                    ns_name = ns.partition(" ")[0]
+                    ip_addr = self.cli.ns_ip_addr(namespace=ns_name)
+                    prefix = "__ns_start__{}__ns__end__".format(ns_name)
+                    path = mktemp_dump(''.join(ip_addr), prefix=prefix)
+                    search_obj.add(seq, path)
+            else:
+                path = mktemp_dump(''.join(self.cli.ip_addr()))
                 search_obj.add(seq, path)
-        else:
-            path = mktemp_dump(''.join(self.cli.ip_addr()))
-            search_obj.add(seq, path)
 
-        if not search_obj.files:
-            log.debug("no network info found (namespaces=%s)", namespaces)
-            return []
+            if not search_obj.files:
+                log.debug("no network info found (all_namespaces=%s)",
+                          all_namespaces)
+                return []
 
-        r = search_obj.run()
-        for path in search_obj.files:
-            # we no longer need this file so can delete it
-            os.unlink(path)
-            sections = r.find_sequence_sections(seq, path).values()
-            for section in sections:
-                addrs = []
-                encap_info = None
-                hwaddr = None
-                name = None
-                mtu = None
-                state = None
-                for result in section:
-                    # infer ns name from filename prefix
-                    ns_name = None
-                    source = search_obj.resolve_source_id(result.source_id)
-                    ret = re.match(r'^__ns_start__(\S+)__ns__end__',
-                                   os.path.basename(source))
-                    if ret:
-                        ns_name = ret.group(1)
+            r = search_obj.run()
+            for path in search_obj.files:
+                try:
+                    sections = r.find_sequence_sections(seq, path).values()
+                    for section in sections:
+                        interfaces_raw.append(self._extract_iface_info(
+                                                                seq,
+                                                                section,
+                                                                search_obj))
+                finally:
+                    os.unlink(path)
 
-                    if result.tag == seq.start_tag:
-                        name = result.get(1)
-                        mtu = int(result.get(2))
-                        state = result.get(3)
-                    elif result.tag == seq.body_tag:
-                        if result.get(1) in ['inet', 'inet6']:
-                            addrs.append(result.get(2))
-                        elif result.get(1) in ['vxlan']:
-                            encap_info = {result.get(1): {
-                                              'id': result.get(2),
-                                              'local_ip': result.get(3),
-                                              'dev': result.get(4)}}
-                        else:
-                            hwaddr = result.get(2)
+            self.cache_save(interfaces_raw, all_namespaces=all_namespaces)
 
-                interfaces_raw.append({'name': name, 'addresses': addrs,
-                                       'hwaddr': hwaddr, 'mtu': mtu,
-                                       'state': state,
-                                       'encap_info': encap_info,
-                                       'namespace': ns_name})
-
-        self.cache_save(interfaces_raw, namespaces=namespaces)
         for iface in interfaces_raw:
-            interfaces.append(NetworkPort(**iface))
-
-        return interfaces
+            yield NetworkPort(**iface)
 
     @property
     def host_interfaces(self):
         if self._host_interfaces is not None:
             return self._host_interfaces
 
-        self._host_interfaces = self._get_interfaces()
+        self._host_interfaces = list(self._get_interfaces())
         return self._host_interfaces
 
     @property
@@ -285,7 +326,8 @@ class HostNetworkingHelper(HostHelpersBase):
         if self._host_ns_interfaces is not None:
             return self._host_ns_interfaces
 
-        self._host_ns_interfaces = self._get_interfaces(namespaces=True)
+        self._host_ns_interfaces = list(
+                                     self._get_interfaces(all_namespaces=True))
         return self._host_ns_interfaces
 
     @property

--- a/hotsos/core/plugins/openstack/neutron.py
+++ b/hotsos/core/plugins/openstack/neutron.py
@@ -10,6 +10,11 @@ from hotsos.core.plugins.openstack.openstack import (
     OSTServiceBase,
 )
 
+# See https://github.com/openstack/neutron-lib/blob/master/neutron_lib/constants.py#L346  # noqa, pylint: disable=C0301
+IP_HEADER_BYTES = 20
+GRE_HEADER_BYTES = 22
+VXLAN_HEADER_BYTES = 30
+
 
 class NeutronBase(OSTServiceBase):
 

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -182,6 +182,14 @@ class TestHostNetworkingHelper(utils.BaseTestCase):
 
         self.assertTrue(iface_found)
 
+    def test_get_ns_interfaces(self):
+        expected = ['lo', 'rfp-984c22fd-6@if2', 'qr-3a70b31c-3f']
+        helper = host_helpers.HostNetworkingHelper()
+        ns = 'qrouter-984c22fd-64b3-4fa1-8ddd-87090f401ce5'
+        ifaces = helper.get_ns_interfaces(ns)
+        names = [iface.name for iface in ifaces]
+        self.assertEqual(names, expected)
+
 
 class TestCLIHelper(utils.BaseTestCase):
     """


### PR DESCRIPTION
Adds a check to ensure that ml2-ovs router ports have an mtu less than the physical network and raise an OpenstackWarning if any found not to match this. Also adds neutron port mtu info to summary.

Resolves: #747