### PR TITLE
Fix bcache config check with multiple cachesets

### DIFF
--- a/hotsos/core/plugins/storage/bcache.py
+++ b/hotsos/core/plugins/storage/bcache.py
@@ -175,24 +175,76 @@ class BcacheBase(StorageBase):
         return False
 
 
-class BDevsConfig(BcacheBase):
+class BDevsInfo(BcacheBase):
 
-    def get(self, key):
-        """
-        This currently assumes there is only one cacheset on the host.
-        """
-        if self.cachesets and self.cachesets[0].bdevs:
-            return self.cachesets[0].bdevs[0].cfg.get(key)
+    @property
+    def sequential_cutoff(self):
+        ret = self._get_parameter("sequential_cutoff")
+        ret.sort(reverse=True)
+
+        return ret
+
+    @property
+    def cache_mode(self):
+        ret = self._get_parameter("cache_mode")
+        # send [writeback] to the end of the list
+        ret.sort(key='writethrough [writeback] writearound none'.__eq__)
+
+        return ret
+
+    @property
+    def writeback_percent(self):
+        ret = self._get_parameter("writeback_percent")
+        # convert str to int
+        ret = list(map(int, ret))
+        ret.sort()
+
+        return ret
+
+    def _get_parameter(self, key):
+        all_values = []
+        for cset in self.cachesets:
+            for bdev in cset.bdevs:
+                all_values.append(bdev.cfg.get(key))
+
+        return all_values
 
 
-class CachesetsConfig(BcacheBase):
+class CachesetsInfo(BcacheBase):
 
-    def get(self, key):
-        """
-        This currently assumes there is only one cacheset on the host.
-        """
-        if self.cachesets:
-            return self.cachesets[0].cfg.get(key)
+    @property
+    def congested_read_threshold_us(self):
+        ret = self._get_parameter("congested_read_threshold_us")
+        # convert str to int
+        ret = list(map(int, ret))
+        ret.sort(reverse=True)
+
+        return ret
+
+    @property
+    def congested_write_threshold_us(self):
+        ret = self._get_parameter("congested_write_threshold_us")
+        # convert str to int
+        ret = list(map(int, ret))
+        ret.sort(reverse=True)
+
+        return ret
+
+    @property
+    def cache_available_percent(self):
+        ret = self._get_parameter("cache_available_percent")
+        # convert str to int
+        ret = list(map(int, ret))
+        ret.sort()
+
+        return ret
+
+    def _get_parameter(self, key):
+        all_values = []
+        for cset in self.cachesets:
+            all_values.append(cset.cfg.get(key))
+
+        return all_values
 
 
 class BcacheChecksBase(BcacheBase):

--- a/hotsos/core/plugins/storage/bcache.py
+++ b/hotsos/core/plugins/storage/bcache.py
@@ -12,6 +12,7 @@ from hotsos.core.search import (
     SequenceSearchDef,
     SearchDef
 )
+from hotsos.core.utils import sort_suffixed_integers
 
 
 class BcacheConfig(ConfigBase):
@@ -179,13 +180,21 @@ class BDevsInfo(BcacheBase):
 
     @property
     def sequential_cutoff(self):
+        """
+        @return: list of <str> sequential_cutoff from each bdev sorted in
+        descending order.
+        """
         ret = self._get_parameter("sequential_cutoff")
-        ret.sort(reverse=True)
+        ret = sort_suffixed_integers(ret, reverse=True)
 
         return ret
 
     @property
     def cache_mode(self):
+        """
+        @return: list of <str> cache_mode from each bdev sorted so that the
+        settings with writeback mode selected are at the end of the list
+        """
         ret = self._get_parameter("cache_mode")
         # send [writeback] to the end of the list
         ret.sort(key='writethrough [writeback] writearound none'.__eq__)
@@ -194,6 +203,10 @@ class BDevsInfo(BcacheBase):
 
     @property
     def writeback_percent(self):
+        """
+        @return: list of <int> writeback_percent from each bdev sorted in
+        ascending order
+        """
         ret = self._get_parameter("writeback_percent")
         # convert str to int
         ret = list(map(int, ret))
@@ -214,6 +227,10 @@ class CachesetsInfo(BcacheBase):
 
     @property
     def congested_read_threshold_us(self):
+        """
+        @return: list of <int> congested_read_threshold_us from each cacheset
+        sorted in descending order
+        """
         ret = self._get_parameter("congested_read_threshold_us")
         # convert str to int
         ret = list(map(int, ret))
@@ -223,6 +240,10 @@ class CachesetsInfo(BcacheBase):
 
     @property
     def congested_write_threshold_us(self):
+        """
+        @return: list of <int> congested_write_threshold_us from each cacheset
+        sorted in descending order
+        """
         ret = self._get_parameter("congested_write_threshold_us")
         # convert str to int
         ret = list(map(int, ret))
@@ -232,6 +253,10 @@ class CachesetsInfo(BcacheBase):
 
     @property
     def cache_available_percent(self):
+        """
+        @return: list of <int> cache_available_percent from each cacheset
+        sorted in ascending order
+        """
         ret = self._get_parameter("cache_available_percent")
         # convert str to int
         ret = list(map(int, ret))

--- a/hotsos/defs/scenarios/storage/bcache/bdev.yaml
+++ b/hotsos/defs/scenarios/storage/bcache/bdev.yaml
@@ -1,26 +1,47 @@
+vars:
+  sequential_cutoff: '@hotsos.core.plugins.storage.bcache.BDevsInfo.sequential_cutoff'
+  cache_mode: '@hotsos.core.plugins.storage.bcache.BDevsInfo.cache_mode'
+  writeback_percent: '@hotsos.core.plugins.storage.bcache.BDevsInfo.writeback_percent'
 checks:
   bcache_enabled:
     property: hotsos.core.plugins.storage.bcache.BcacheBase.bcache_enabled
-  has_invalid_bdev_config:
-    config:
-      handler: hotsos.core.plugins.storage.bcache.BDevsConfig
-      assertions:
-        not:
-          - key: sequential_cutoff
-            ops: [[eq, '0.0k']]
-          - key: cache_mode
-            ops: [[eq, 'writethrough [writeback] writearound none']]
-          - key: writeback_percent
-            ops: [[ge, 10]]
+  has_invalid_bdev_cutoff:
+    varops: [[$sequential_cutoff], [getitem, 0], [ne, '0.0k']]
+  has_invalid_bdev_cache_mode:
+    varops: [[$cache_mode], [getitem, 0], [ne, 'writethrough [writeback] writearound none']]
+  has_invalid_bdev_writeback_percent:
+    varops: [[$writeback_percent], [getitem, 0], [lt, 10]]
 conclusions:
-  invalid-bdev-config:
+  invalid-bdev-cutoff-config:
     decision:
       - bcache_enabled
-      - has_invalid_bdev_config
+      - has_invalid_bdev_cutoff
     raises:
       type: BcacheWarning
       message: >-
-        One or more of the following bcache bdev config assertions failed:
-        {assertions}
+        One or more of the bcache bdevs have a sequential_cutoff greater than 0:
+        {cutoff}
       format-dict:
-        assertions: '@checks.has_invalid_bdev_config.requires.assertion_results'
+        cutoff: $sequential_cutoff
+  invalid-bdev-cache-mode-config:
+    decision:
+      - bcache_enabled
+      - has_invalid_bdev_cache_mode
+    raises:
+      type: BcacheWarning
+      message: >-
+        One or more of the bcache bdevs have a cache_mode config that is not
+        writeback: {mode}
+      format-dict:
+        mode: $cache_mode
+  invalid-bdev-writeback-percent-config:
+    decision:
+      - bcache_enabled
+      - has_invalid_bdev_writeback_percent
+    raises:
+      type: BcacheWarning
+      message: >-
+        One or more of the bcache bdevs have a writeback_percent less than 10:
+        {writeback}
+      format-dict:
+        writeback: $writeback_percent

--- a/hotsos/defs/scenarios/storage/bcache/cacheset.yaml
+++ b/hotsos/defs/scenarios/storage/bcache/cacheset.yaml
@@ -1,35 +1,41 @@
+vars:
+  congested_read_threshold_us: '@hotsos.core.plugins.storage.bcache.CachesetsInfo.congested_read_threshold_us'
+  congested_write_threshold_us: '@hotsos.core.plugins.storage.bcache.CachesetsInfo.congested_write_threshold_us'
+  cache_available_percent: '@hotsos.core.plugins.storage.bcache.CachesetsInfo.cache_available_percent'
 checks:
   bcache_enabled:
     property: hotsos.core.plugins.storage.bcache.BcacheBase.bcache_enabled
-  cset_has_invalid_config:
-    config:
-      handler: hotsos.core.plugins.storage.bcache.CachesetsConfig
-      assertions:
-        not:
-          - key: congested_read_threshold_us
-            ops: [[eq, 0]]
-          - key: congested_write_threshold_us
-            ops: [[eq, 0]]
+  has_invalid_cset_congested_read_threshold_us:
+    varops: [[$congested_read_threshold_us], [getitem, 0], [ne, 0]]
+  has_invalid_cset_congested_write_threshold_us:
+    varops: [[$congested_write_threshold_us], [getitem, 0], [ne, 0]]
   cset_config_lp1900438_limit:
-    config:
-      handler: hotsos.core.plugins.storage.bcache.CachesetsConfig
-      assertions:
-        # The real limit is 30 but we go just above in case bcache is flapping
-        # just above and below the limit.
-        key: cache_available_percent
-        ops: [[le, 33]]
+    # The real limit is 30 but we go just above in case bcache is flapping
+    # just above and below the limit.
+    varops: [[$cache_available_percent], [getitem, 0], [le, 33]]
 conclusions:
-  cset-has-invalid-config:
+  invalid-cset-congested-read-threshold-us:
     decision:
       - bcache_enabled
-      - cset_has_invalid_config
+      - has_invalid_cset_congested_read_threshold_us
     raises:
       type: BcacheWarning
       message: >-
-        One or more of the following bcache cacheset config assertions failed:
-        {assertions}
+        One or more of the bcache cachesets have a congested_read_threshold_us
+        greater than 0: {read_threshhold}
       format-dict:
-        assertions: '@checks.cset_has_invalid_config.requires.assertion_results'
+        read_threshhold: $congested_read_threshold_us
+  invalid-cset-congested-write-threshold-us:
+    decision:
+      - bcache_enabled
+      - has_invalid_cset_congested_write_threshold_us
+    raises:
+      type: BcacheWarning
+      message: >-
+        One or more of the bcache cachesets have a congested_write_threshold_us
+        greater than 0: {write_threshhold}
+      format-dict:
+        write_threshhold: $congested_write_threshold_us
   bcache-bug-lp1900438:
     decision:
       - bcache_enabled
@@ -38,7 +44,8 @@ conclusions:
       type: LaunchpadBug
       bug-id: 1900438
       message: >-
-        bcache cache_available_percent is {actual} (i.e. approx. 30%) which
-        implies this node could be suffering from bug LP 1900438 - please check.
+        bcache cache_available_percent is low (i.e. approx. 30%) for some
+        cachesets: {actual}. This implies this node could be suffering from bug
+        LP 1900438 - please check.
       format-dict:
-        actual: '@checks.cset_config_lp1900438_limit.requires.value_actual'
+        actual: $cache_available_percent

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/bugs/lp1936136.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/bugs/lp1936136.yaml
@@ -1,3 +1,5 @@
+vars:
+  cache_available_percent: '@hotsos.core.plugins.storage.bcache.CachesetsInfo.cache_available_percent'
 checks:
   node_is_ceph_osd_and_has_version:
     # Get version of osd based on package installed. This is prone to
@@ -27,11 +29,7 @@ checks:
         key: bluefs_buffered_io
         ops: [[eq, true]]
   bcache_cache_available_percent_check:
-    config:
-      handler: hotsos.core.plugins.storage.bcache.CachesetsConfig
-      assertions:
-        key: cache_available_percent
-        ops: [[lt, 70]]
+    varops: [[$cache_available_percent], [getitem, 0], [lt, 70]]
 conclusions:
   node_affected_by_bug_1936136:
     decision:
@@ -46,10 +44,9 @@ conclusions:
       message: >-
         This host has Ceph OSDs using bcache block devices and may be
         vulnerable to bcache bug LP 1936136 since bcache
-        cache_available_percent is {op} (actual={actual}). The current
-        workaround is to set bluefs_buffered_io=false in Ceph or upgrade to a
-        kernel >= 5.4.
+        cache_available_percent is < 70 for some cacheset (actual={actual}).
+        The current workaround is to set bluefs_buffered_io=false in Ceph or
+        upgrade to a kernel >= 5.4.
       format-dict:
-        op: '@checks.bcache_cache_available_percent_check.requires.ops'
-        actual: '@checks.bcache_cache_available_percent_check.requires.value_actual'
+        actual: $cache_available_percent
 

--- a/hotsos/defs/tests/scenarios/storage/bcache/bdev.yaml
+++ b/hotsos/defs/tests/scenarios/storage/bcache/bdev.yaml
@@ -4,13 +4,24 @@ data-root:
     sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/congested_write_threshold_us: '0'
     sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/cache_available_percent: '34'
     sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/bdev1/sequential_cutoff: '0.0k'
-    sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/bdev1/cache_mode: 'writethrough [writeback] writearound none'
-    sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/bdev1/writeback_percent: '1'
+    sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/bdev1/cache_mode: '[writethrough] writeback writearound none'
+    sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/bdev1/writeback_percent: '11'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/congested_read_threshold_us: '0'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/congested_write_threshold_us: '0'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/cache_available_percent: '34'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/bdev0/sequential_cutoff: '1.0k'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/bdev0/cache_mode: 'writethrough [writeback] writearound none'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/bdev0/writeback_percent: '1'
+
 raised-issues:
-  BcacheWarning: >-
-    One or more of the following bcache bdev config
-    assertions failed: sequential_cutoff eq
-    "0.0k"/actual="0.0k", cache_mode eq "writethrough
-    [writeback] writearound none"/actual="writethrough
-    [writeback] writearound none", writeback_percent ge
-    10/actual="1"
+  BcacheWarning:
+    - >-
+      One or more of the bcache bdevs have a cache_mode config that is not
+      writeback: ['[writethrough] writeback writearound none', 'writethrough
+      [writeback] writearound none']
+    - >-
+      One or more of the bcache bdevs have a sequential_cutoff greater than 0:
+      ['1.0k', '0.0k']
+    - >-
+      One or more of the bcache bdevs have a writeback_percent less than 10:
+      [1, 11]

--- a/hotsos/defs/tests/scenarios/storage/bcache/cacheset.yaml
+++ b/hotsos/defs/tests/scenarios/storage/bcache/cacheset.yaml
@@ -1,18 +1,27 @@
 data-root:
   files:
-    sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/congested_read_threshold_us: '100'
+    sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/congested_read_threshold_us: '0'
     sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/congested_write_threshold_us: '100'
     sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/cache_available_percent: '33'
     sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/bdev1/sequential_cutoff: '0.0k'
     sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/bdev1/cache_mode: 'writethrough [writeback] writearound none'
     sys/fs/bcache/92234c28-6b9c-4501-89bb-fc1e0949c438/bdev1/writeback_percent: '10'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/congested_read_threshold_us: '50'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/congested_write_threshold_us: '0'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/cache_available_percent: '34'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/bdev0/sequential_cutoff: '1.0k'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/bdev0/cache_mode: 'writethrough [writeback] writearound none'
+    sys/fs/bcache/e7301a91-2a81-4653-960a-e5a2508f539f/bdev0/writeback_percent: '1'
 raised-bugs:
   https://bugs.launchpad.net/bugs/1900438: >-
-    bcache cache_available_percent is 33 (i.e. approx. 30%)
-    which implies this node could be suffering from bug LP
-    1900438 - please check.
+    bcache cache_available_percent is low (i.e. approx. 30%) for some
+    cachesets: [33, 34]. This implies this node could be suffering from bug
+    LP 1900438 - please check.
 raised-issues:
-  BcacheWarning: >-
-    One or more of the following bcache cacheset config assertions
-    failed: congested_read_threshold_us eq 0/actual="100",
-    congested_write_threshold_us eq 0/actual="100"
+  BcacheWarning:
+    - >-
+      One or more of the bcache cachesets have a congested_read_threshold_us
+      greater than 0: [50, 0]
+    - >-
+      One or more of the bcache cachesets have a congested_write_threshold_us
+      greater than 0: [100, 0]

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-osd/bugs/lp1936136.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-osd/bugs/lp1936136.yaml
@@ -21,5 +21,5 @@ raised-bugs:
   https://bugs.launchpad.net/bugs/1936136: >-
     This host has Ceph OSDs using bcache block devices and may be
     vulnerable to bcache bug LP 1936136 since bcache cache_available_percent
-    is lt 70 (actual=69). The current workaround is to set
+    is < 70 for some cacheset (actual=[69]). The current workaround is to set
     bluefs_buffered_io=false in Ceph or upgrade to a kernel >= 5.4.

--- a/tests/unit/storage/test_bcache.py
+++ b/tests/unit/storage/test_bcache.py
@@ -49,6 +49,38 @@ class TestBcacheBase(BCacheTestsBase):
                                            '427e-9d82-c411c73d900a'))
 
 
+class TestBDevsInfo(BCacheTestsBase):
+
+    def test_sequential_cutoff(self):
+        b = bcache_core.BDevsInfo()
+        self.assertEqual(b.sequential_cutoff, ['4.0M', '4.0M'])
+
+    def test_cache_mode(self):
+        b = bcache_core.BDevsInfo()
+        self.assertEqual(b.cache_mode,
+                         ['writethrough [writeback] writearound none',
+                          'writethrough [writeback] writearound none'])
+
+    def test_writeback_percent(self):
+        b = bcache_core.BDevsInfo()
+        self.assertEqual(b.writeback_percent, [10, 10])
+
+
+class TestCachesetsInfo(BCacheTestsBase):
+
+    def test_congested_read_threshold_us(self):
+        c = bcache_core.CachesetsInfo()
+        self.assertEqual(c.congested_read_threshold_us, [2000])
+
+    def test_congested_write_threshold_us(self):
+        c = bcache_core.CachesetsInfo()
+        self.assertEqual(c.congested_write_threshold_us, [20000])
+
+    def test_cache_available_percent(self):
+        c = bcache_core.CachesetsInfo()
+        self.assertEqual(c.cache_available_percent, [99])
+
+
 class TestBCacheSummary(BCacheTestsBase):
 
     def test_get_cacheset_info(self):


### PR DESCRIPTION
Change the code to return the list of values for every cacheset as a var. The list is ordered with the worst cases at the front so the status can be verified by just checking the first value.
Split checks in different cases to give a more specific error message.

Resolves: #749