### PR TITLE
Add util to sort suffixed integers

### DIFF
--- a/hotsos/core/utils.py
+++ b/hotsos/core/utils.py
@@ -62,3 +62,52 @@ def sample_set_regressions(samples, ascending=True):
             prev = prev_reset
 
     return repetitions
+
+
+def sort_suffixed_integers(values, reverse=False):
+    """
+    Given a list of values that contain numbers suffixed with a
+    k/K/m/M/g/G/t/T/p/P, sort them taking into account their suffix.
+
+    @param values: list of integer or string values
+    @param reverse: sort order
+    @return: sorted list of values (original type is maintained)
+    """
+    bysuffix = {}
+    if reverse:
+        valid_suffixes = ('p', 't', 'g', 'm', 'k', '_')
+    else:
+        valid_suffixes = ('_', 'k', 'm', 'g', 't', 'p')
+
+    for item in values:
+        if isinstance(item, str):
+            if len(item) > 1:
+                suffix = item[-1].lower()
+                if suffix in valid_suffixes:
+                    if suffix not in bysuffix:
+                        bysuffix[suffix] = []
+
+                    bysuffix[suffix].append(item)
+                    continue
+
+        if '_' not in bysuffix:
+            bysuffix['_'] = []
+
+        bysuffix['_'].append(item)
+
+    if len(bysuffix.keys()) == 1 and '_' in bysuffix:
+        return sorted(bysuffix['_'], key=lambda e: int(e), reverse=reverse)
+
+    _sorted = []
+    for suffix in valid_suffixes:
+        if suffix not in bysuffix:
+            continue
+
+        if suffix == '_':
+            _sorted += sorted(bysuffix[suffix], reverse=reverse,
+                              key=lambda e: int(e))
+        else:
+            _sorted += sorted(bysuffix[suffix], reverse=reverse,
+                              key=lambda e: int(e[:-1]))
+
+    return _sorted

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -33,3 +33,23 @@ class TestUtils(utils.BaseTestCase):
         samples = [100, 99, 98, 100, 60, 60]
         self.assertEqual(core_utils.sample_set_regressions(samples,
                                                            ascending=False), 1)
+
+    def test_sort_suffixed_integers(self):
+        self.assertEqual(core_utils.sort_suffixed_integers(
+                         [1, '300', 2]),
+                         [1, 2, '300'])
+        self.assertEqual(core_utils.sort_suffixed_integers(
+                         [1, '300', 2], reverse=True),
+                         ['300', 2, 1])
+        self.assertEqual(core_utils.sort_suffixed_integers(
+                         ['1', '3', '2']),
+                         ['1', '2', '3'])
+        self.assertEqual(core_utils.sort_suffixed_integers(
+                         [1, 3, '22k', '111k']),
+                         [1, 3, '22k', '111k'])
+        self.assertEqual(core_utils.sort_suffixed_integers(
+                         [1, 3, '22k', '111k'], reverse=True),
+                         ['111k', '22k', 3, 1])
+        self.assertEqual(core_utils.sort_suffixed_integers(
+                         ['111k', '22k', '12P', 3, '1', '3g'], reverse=True),
+                         ['12P', '3g', '111k', '22k', 3, '1'])


### PR DESCRIPTION
Adds a new helper function to sort lists of
int strings with suffixes e.g. 'k', 'm' etc