### PR TITLE
Improve ovn version mismatch checks

### DIFF
--- a/hotsos/defs/events/openvswitch/ovn/ovn-controller.yaml
+++ b/hotsos/defs/events/openvswitch/ovn/ovn-controller.yaml
@@ -11,5 +11,3 @@ involuntary-context-switches:
   # we capture date and hour as subgroups
   expr: '([\d-]+)T(\d+):[\d:]+\.\d+Z.+\|timeval\|WARN\|context switches: \d+ voluntary, (\d+) involuntary'
   hint: timeval
-northd-version-mismatch:
-  expr: '([\d-]+)T[\d:]+\.\d+Z\|\S+\|controller version - (\S+) mismatch with northd version - (\S+)'

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_upgrades.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_upgrades.yaml
@@ -1,6 +1,10 @@
 vars:
   dbkey: 'ovn-match-northd-version'
   external_ids: '@hotsos.core.plugins.openvswitch.OVSDB.external_ids'
+  message_boilerplate: >-
+    The ovn-controller service on this node is reporting northd version
+    mismatch errors. This happens when the version of OVN differs between
+    ovn-central and ovn-controller
 checks:
   is_ovn_controller:
     systemd: ovn-controller
@@ -32,10 +36,10 @@ conclusions:
       bug-id: 2030944
       message: >-
         This node has '{dbkey}=true' set in the local ovsdb. This will cause
-        unnecessary errors if a minor release upgrade of OVN packages is
-        performed. There is fix available in the OVN charms to unset this or
-        alternatively it can be done manually with 'ovs-vsctl set
-        Open_vSwitch . external-ids:{dbkey}="false"'
+        unnecessary ovn-controller service interruption if a minor release
+        upgrade of OVN packages is performed. There is a fix available in the
+        OVN charms to unset this or alternatively it can be done manually with
+        'ovs-vsctl set Open_vSwitch . external-ids:{dbkey}="false"'
       format-dict:
         dbkey: $dbkey
   has_northd_version_mismatch_package_fixed_flag_set:
@@ -48,14 +52,19 @@ conclusions:
     raises:
       type: OVNError
       message: >-
-        OVN controller is reporting a version mismatch between itself ({vlocal}) and northd ({vremote}).
-        This usually means ovn-central (ovn-northd etc) services have been upgraded before
-        ovn-controller using a version of OVN that does not support this. To fix this issue
-        you may need to upgrade ovn-controller on this host (current={controller-ver}). Note that
-        since you have '{dbkey}=true' in the local ovsdb this error will also trigger
-        unnecessarily for minor release upgrades and unsetting it will resolve the problem.
+        {boilerplate} and you have ovn-match-northd-version=true
+        set locally. This flag is intended to protect against downtime during
+        major release upgrades by preventing the ovn-controller from getting
+        updates from the southbound database until the versions match. It is
+        not necessary for this flag to be set to 'true' during minor release
+        upgrades. The version difference is reported as {vlocal} vs. {vremote}.
+        If you are performing a major version upgrade this problem should
+        disappear once the upgrade has completed on both ovn-central and
+        locally. If you are performing a minor release upgrade you can safely
+        do 'ovs-vsctl set Open_vSwitch . external-ids:{dbkey}="false"' and that
+        should allow ovn-controller to resume service.
       format-dict:
-        controller-ver: '@checks.ovn_controller_pkg_has_upgrade_bug.requires.version'
+        boilerplate: $message_boilerplate
         dbkey: $dbkey
         vlocal: '@checks.has_northd_version_mismatch.search.results_group_3:first'
         vremote: '@checks.has_northd_version_mismatch.search.results_group_4:first'
@@ -68,12 +77,13 @@ conclusions:
     raises:
       type: OVNError
       message: >-
-        OVN controller is reporting a version mismatch between itself ({vlocal}) and northd ({vremote}).
-        This usually means ovn-central (ovn-northd etc) services have been upgraded before
-        ovn-controller using a version of OVN that does not support this. To fix this issue
-        you may need to upgrade ovn-controller on this host (current={controller-ver}). See
-        https://bugs.launchpad.net/charm-ovn-chassis/+bug/1940043 for more details.
+        {boilerplate}. The version difference is reported as {vlocal} vs.
+        {vremote} and the local version of ovn-controller ({controller-ver}) is
+        impacted by a bug that results in service downtime during an upgrade.
+        See https://bugs.launchpad.net/charm-ovn-chassis/+bug/1940043 for more
+        details.
       format-dict:
+        boilerplate: $message_boilerplate
         controller-ver: '@checks.ovn_controller_pkg_has_upgrade_bug.requires.version'
         vlocal: '@checks.has_northd_version_mismatch.search.results_group_3:first'
         vremote: '@checks.has_northd_version_mismatch.search.results_group_4:first'
@@ -85,13 +95,18 @@ conclusions:
     raises:
       type: OVNError
       message: >-
-        OVN controller is reporting a version mismatch between itself ({vlocal}) and northd ({vremote}).
-        This usually means ovn-central (ovn-northd etc) services have been upgraded before
-        ovn-controller using a version of OVN that does not support this. See
-        related bug https://bugs.launchpad.net/charm-ovn-chassis/+bug/1940043 for context
-        although the installed version ({controller-ver}) of ovn-controller
-        should already have that fix.
+        {boilerplate} and you have ovn-match-northd-version=false set locally.
+        This flag is intended to protect against downtime during major release
+        upgrades by preventing the ovn-controller from getting updates from
+        the southbound database until the versions match. The version
+        difference is reported as {vlocal} vs. {vremote} and the local version
+        of ovn-controller ({controller-ver}). If this is a major release
+        upgrade you will need to set the following locally prior to upgrade to
+        prevent ovn-controller downtime during the upgrade:
+        'ovs-vsctl set Open_vSwitch . external-ids:{dbkey}="true"'
       format-dict:
+        boilerplate: $message_boilerplate
+        dbkey: $dbkey
         controller-ver: '@checks.ovn_controller_pkg_has_upgrade_bug.requires.version'
         vlocal: '@checks.has_northd_version_mismatch.search.results_group_3:first'
         vremote: '@checks.has_northd_version_mismatch.search.results_group_4:first'

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/ovn_upgrades_no_mismatch_dbflag_set.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/ovn_upgrades_no_mismatch_dbflag_set.yaml
@@ -21,7 +21,7 @@ data-root:
 raised-bugs:
   https://bugs.launchpad.net/bugs/2030944: >-
     This node has 'ovn-match-northd-version=true' set in the local ovsdb. This
-    will cause unnecessary errors if a minor release upgrade of OVN packages is
-    performed. There is fix available in the OVN charms to unset this or
-    alternatively it can be done manually with 'ovs-vsctl set
-    Open_vSwitch . external-ids:ovn-match-northd-version="false"'
+    will cause unnecessary ovn-controller service interruption if a minor
+    release upgrade of OVN packages is performed. There is a fix available in
+    the OVN charms to unset this or alternatively it can be done manually with
+    'ovs-vsctl set Open_vSwitch . external-ids:ovn-match-northd-version="false"'

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/ovn_upgrades_northd_mismatch.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/ovn_upgrades_northd_mismatch.yaml
@@ -20,10 +20,10 @@ data-root:
     - sos_commands/date/date
 raised-issues:
   OVNError: >-
-    OVN controller is reporting a version mismatch between itself
-    (20.03.2-2.7.0-42.0) and northd (20.03.2-2.7.0-42.1). This usually means
-    ovn-central (ovn-northd etc) services have been upgraded before
-    ovn-controller using a version of OVN that does not support this. To fix
-    this issue you may need to upgrade ovn-controller on this host
-    (current=20.03.2-0ubuntu0.20.04.3). See
+    The ovn-controller service on this node is reporting northd version
+    mismatch errors. This happens when the version of OVN differs between
+    ovn-central and ovn-controller. The version difference is reported as
+    20.03.2-2.7.0-42.0 vs. 20.03.2-2.7.0-42.1 and the local version of
+    ovn-controller (20.03.2-0ubuntu0.20.04.3) is impacted by a bug that results
+    in service downtime during an upgrade. See
     https://bugs.launchpad.net/charm-ovn-chassis/+bug/1940043 for more details.

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/ovn_upgrades_northd_mismatch_dbflag_set.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/ovn_upgrades_northd_mismatch_dbflag_set.yaml
@@ -22,11 +22,16 @@ data-root:
     - sos_commands/date/date
 raised-issues:
   OVNError: >-
-    OVN controller is reporting a version mismatch between itself
-    (22.03.2-1.2.3) and northd (22.03.1-1.2.3). This usually means ovn-central
-    (ovn-northd etc) services have been upgraded before ovn-controller using a
-    version of OVN that does not support this. To fix this issue you may need
-    to upgrade ovn-controller on this host (current=22.03.2-0ubuntu0.22.04.1~cloud1).
-    Note that since you have 'ovn-match-northd-version=true' in the local ovsdb
-    this error will also trigger unnecessarily for minor release upgrades and
-    unsetting it will resolve the problem.
+    The ovn-controller service on this node is reporting northd version
+    mismatch errors. This happens when the version of OVN differs between
+    ovn-central and ovn-controller and you have ovn-match-northd-version=true
+    set locally. This flag is intended to protect against downtime during major
+    release upgrades by preventing the ovn-controller from getting updates from
+    the southbound database until the versions match. It is not necessary for
+    this flag to be set to 'true' during minor release upgrades. The version
+    difference is reported as 22.03.2-1.2.3 vs. 22.03.1-1.2.3. If you are
+    performing a major version upgrade this problem should disappear once the
+    upgrade has completed on both ovn-central and locally. If you are
+    performing a minor release upgrade you can safely do 'ovs-vsctl set
+    Open_vSwitch . external-ids:ovn-match-northd-version="false"' and that
+    should allow ovn-controller to resume service.

--- a/hotsos/defs/tests/scenarios/openvswitch/ovn/ovn_upgrades_northd_mismatch_fixed.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/ovn/ovn_upgrades_northd_mismatch_fixed.yaml
@@ -20,10 +20,14 @@ data-root:
     - sos_commands/date/date
 raised-issues:
   OVNError: >-
-    OVN controller is reporting a version mismatch between itself
-    (22.03.2-20.21.0-61.4) and northd (22.03.0-20.21.0-58.3). This usually
-    means ovn-central (ovn-northd etc) services have been upgraded before
-    ovn-controller using a version of OVN that does not support this. See
-    related bug https://bugs.launchpad.net/charm-ovn-chassis/+bug/1940043
-    for context although the installed version (22.03.2-0ubuntu0.22.04.1~cloud1)
-    of ovn-controller should already have that fix.
+    The ovn-controller service on this node is reporting northd version
+    mismatch errors. This happens when the version of OVN differs between
+    ovn-central and ovn-controller and you have ovn-match-northd-version=false
+    set locally. This flag is intended to protect against downtime during major
+    release upgrades by preventing the ovn-controller from getting updates from
+    the southbound database until the versions match. The version difference is
+    reported as 22.03.2-20.21.0-61.4 vs. 22.03.0-20.21.0-58.3 and the local
+    version of ovn-controller (22.03.2-0ubuntu0.22.04.1~cloud1). If this is a
+    major release upgrade you will need to set the following locally prior to
+    upgrade to prevent ovn-controller downtime during the upgrade: 'ovs-vsctl
+    set Open_vSwitch . external-ids:ovn-match-northd-version="true"'

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -1,8 +1,7 @@
 import re
 
-from hotsos.core.log import log
 from hotsos.core.issues import IssuesManager, OpenvSwitchWarning
-from hotsos.core.plugins.openvswitch import OpenvSwitchBase, OVSDB
+from hotsos.core.plugins.openvswitch import OpenvSwitchBase
 from hotsos.core.plugins.openvswitch.common import (
     OpenvSwitchEventHandlerBase,
     OpenvSwitchEventCallbackBase,
@@ -262,41 +261,6 @@ class OVNEventCallbackContextSwitches(OpenvSwitchEventCallbackBase):
             aggregated[key] = sorted_dict(value)
 
         return {event.name: sorted_dict(aggregated)}, event.section
-
-
-class OVNEventCallbackNorthdVersionMismatch(OpenvSwitchEventCallbackBase):
-    event_group = 'ovn'
-    event_names = ['northd-version-mismatch']
-
-    def __call__(self, event):
-        """
-        If the versions in the mismatch are both from the same major release
-        and ovn-match-northd-version is set to 'true' we can avoid the error
-        by setting ovn-match-northd-version='false' since the mismatch is not
-        a problem for minor release upgrades.
-        """
-        vfrom = event.results[-1].get(2)
-        vto = event.results[-1].get(3)
-
-        major_match = r'(\d+\.\d+)'
-        from_major = re.match(major_match, vfrom)
-        to_major = re.match(major_match, vto)
-        if not all([from_major, to_major]):
-            log.info("could not match versions in northd mismatch log")
-        elif from_major.group(1) == to_major.group(1):
-            dbkey = 'ovn-match-northd-version'
-            dbval = OVSDB().external_ids.get('ovn-match-northd-version')
-            if dbval and dbval.lower() == 'true':
-                msg = ("ovn-controller is reporting northd version mismatch "
-                       "errors and the versions it is reporting ({vfrom} and "
-                       "{vto}) are from the same major release. This is "
-                       "failing because you have '{dbkey}' set to "
-                       "'true' in the local ovsdb which is only required if "
-                       "performing a major release upgrade. You can safely do "
-                       "the following to workaround the problem: 'ovs-vsctl "
-                       "set Open_vSwitch . external-ids:{dbkey}=\"false\"'".
-                       format(vfrom=vfrom, vto=vto, dbkey=dbkey))
-                IssuesManager().add(OpenvSwitchWarning(msg))
 
 
 class OVNEventChecks(OpenvSwitchEventHandlerBase):


### PR DESCRIPTION
Removes the event implementation and relies solely on scenarios with better wording to clearly cover
both cases of major and minor release upgrades.