### PR TITLE
Dont error for start_time if svc not active

### DIFF
--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -97,6 +97,11 @@ class SystemdService(object):
         with CLIHelperFile() as cli:
             fs.add(seqdef, path=cli.systemctl_status_all())
             sections = list(fs.run().find_sequence_sections(seqdef).values())
+            if len(sections) == 0:
+                log.warning("no active status found for %s.service (state=%s)",
+                            self.name, self.state)
+                return
+
             if len(sections) > 1:
                 log.warning("more than one status found for %s.service",
                             self.name)
@@ -105,7 +110,8 @@ class SystemdService(object):
                 if result.tag == seqdef.body_tag:
                     return dateutil_parser.parse(result.get(1),
                                                  tzinfos=self._tzinfos)
-        log.debug("no start time identified for svc %s", self.name)
+        log.debug("no start time identified for svc %s (state=%s)", self.name,
+                  self.state)
 
     @cached_property
     def start_time_secs(self):

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -462,6 +462,20 @@ class TestSystemdHelper(utils.BaseTestCase):
         svc = s.services['nova-compute']
         self.assertEqual(svc.memory_current_kb, 7)
 
+    @utils.create_data_root(
+        {'sos_commands/systemd/systemctl_status_--all':
+         """
+         ● neutron-ovs-cleanup.service
+          Loaded: masked (Reason: Unit neutron-ovs-cleanup.service is masked.)
+          Active: inactive (dead)
+         """},
+        copy_from_original=['sos_commands/systemd/systemctl_list-units',
+                            'sos_commands/systemd/systemctl_list-unit-files'])
+    def test_start_time_svc_not_active(self):
+        svc = getattr(host_helpers.systemd.ServiceFactory(),
+                      'neutron-ovs-cleanup')
+        self.assertEqual(svc.start_time_secs, 0)
+
 
 class TestPebbleHelper(utils.BaseTestCase):
 


### PR DESCRIPTION
If a systemd service is not active we cant get its start time so need to account for this.

Resolves: #772