### PR TITLE
Added two more apparmor profiles

### DIFF
--- a/hotsos/core/host_helpers/apparmor.py
+++ b/hotsos/core/host_helpers/apparmor.py
@@ -29,9 +29,9 @@ class ApparmorHelper(object):
         """
         s = FileSearcher()
         seqdef = SequenceSearchDef(
-                            start=SearchDef(r"(\d+) (\S+) are in (\S+) mode."),
-                            body=SearchDef(r"\s+(\S+)"),
-                            tag="aastatus")
+                     start=SearchDef(r"(\d+) profiles are in (\S+) mode."),
+                     body=SearchDef(r"\s+(\S+)"),
+                     tag="aastatus")
         info = {}
         with CLIHelperFile() as cli:
             s.add(seqdef, path=cli.apparmor_status())
@@ -39,16 +39,14 @@ class ApparmorHelper(object):
             for section in results.find_sequence_sections(seqdef).values():
                 count = 0
                 mode = None
-                is_profiles = False
                 for result in section:
                     if result.tag == seqdef.start_tag:
                         count = int(result.get(1))
-                        is_profiles = result.get(2) == 'profiles'
-                        mode = result.get(3)
+                        mode = result.get(2)
                         if mode not in info:
                             info[mode] = {'profiles': [], 'count': count}
                     elif result.tag == seqdef.body_tag:
-                        if not is_profiles or count == 0:
+                        if count == 0:
                             continue
 
                         info[mode]['profiles'].append(result.get(1))
@@ -67,6 +65,14 @@ class ApparmorHelper(object):
     @property
     def profiles_complain(self):
         return self.profiles.get('complain', {}).get('profiles', [])
+
+    @property
+    def profiles_kill(self):
+        return self.profiles.get('kill', {}).get('profiles', [])
+
+    @property
+    def profiles_unconfined(self):
+        return self.profiles.get('unconfined', {}).get('profiles', [])
 
 
 class AAProfileFactory(FactoryBase):

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -627,7 +627,7 @@ class TestApparmorHelper(utils.BaseTestCase):
     def test_aa_status_profiles(self):
         helper = host_helpers.ApparmorHelper()
         profiles = helper.profiles
-        self.assertEqual(len(profiles), 2)
+        num_profiles = 2
         self.assertEqual(profiles['enforce']['count'], 253)
         self.assertEqual(len(profiles['enforce']['profiles']), 253)
         self.assertEqual(profiles['enforce']['profiles'][-1], 'virt-aa-helper')
@@ -636,6 +636,17 @@ class TestApparmorHelper(utils.BaseTestCase):
         self.assertEqual(profiles['complain']['count'], 0)
         self.assertEqual(len(profiles['complain']['profiles']), 0)
         self.assertEqual(helper.profiles_complain, [])
+        if 'kill' in profiles:
+            num_profiles += 1
+            self.assertEqual(profiles['kill']['count'], 0)
+            self.assertEqual(len(profiles['kill']['profiles']), 0)
+            self.assertEqual(helper.profiles_kill, [])
+        if 'unconfined' in profiles:
+            num_profiles += 1
+            self.assertEqual(profiles['unconfined']['count'], 0)
+            self.assertEqual(len(profiles['unconfined']['profiles']), 0)
+            self.assertEqual(helper.profiles_unconfined, [])
+        self.assertEqual(len(profiles), num_profiles)
 
     def test_aa_profile_factory(self):
         profile = getattr(host_helpers.apparmor.AAProfileFactory(),


### PR DESCRIPTION
On my system, apparmor_status also reports modes
'kill' and 'unconfined', so add them to the parser.

While testing I noticed the unit test kept matching the processes section in addition to the profiles
one, leading to more profiles than were in the list. Changing the regex to be stricter resolved the issue.

Updated the openstack fake_data_root to add these
profiles so they could be tested, even though that is frowned upon.

TrivialFix