### PR TITLE
Add checks for neutron frequent ovndb leader reconnect

### DIFF
--- a/hotsos/defs/events/openstack/neutron/agents.yaml
+++ b/hotsos/defs/events/openstack/neutron/agents.yaml
@@ -1,4 +1,11 @@
 # NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
+neutron-server:
+  input:
+    path: 'var/log/neutron/neutron-server.log'
+  ovsdbapp-nb-leader-reconnect:
+    expr: '([\d-]+) [\d:]+\.\d{3} .+ ovsdbapp.backend.ovs_idl.vlog \[-\] ssl:\S+:(6641): clustered database server is not cluster leader; trying another server'
+  ovsdbapp-sb-leader-reconnect:
+    expr: '([\d-]+) [\d:]+\.\d{3} .+ ovsdbapp.backend.ovs_idl.vlog \[-\] ssl:\S+:(1?6642): clustered database server is not cluster leader; trying another server'
 neutron-ovs-agent:
   input:
     path: 'var/log/neutron/neutron-openvswitch-agent.log'

--- a/hotsos/defs/scenarios/openstack/neutron/ovndb_leader_bouncing.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/ovndb_leader_bouncing.yaml
@@ -1,0 +1,49 @@
+checks:
+  is_neutron_server:
+    apt: neutron-server
+  has_nbdb_log:
+    input: var/log/neutron/neutron-server.log
+    expr: '([\d-]+) ([\d:]+)\.\d{3} .+ ovsdbapp.backend.ovs_idl.vlog \[-\] ssl:\S+:(6641): clustered database server is not cluster leader; trying another server'
+    constraints:
+      min-results: 50
+      search-result-age-hours: 24
+  has_sbdb_log:
+    input: var/log/neutron/neutron-server.log
+    expr: '([\d-]+) ([\d:]+)\.\d{3} .+ ovsdbapp.backend.ovs_idl.vlog \[-\] ssl:\S+:(1?6642): clustered database server is not cluster leader; trying another server'
+    constraints:
+      min-results: 50
+      search-result-age-hours: 24
+conclusions:
+  has_frequent_nbdb_reconnections:
+    decision:
+      - is_neutron_server
+      - has_nbdb_log
+    raises:
+      type: OpenstackWarning
+      message: >-
+        The neutron-server service on this host is having to frequently
+        reconnect to a different OVN Northbound database server (port={port})
+        because the leader is frequently changing (see summary output for exact
+        numbers). This is a sign of instability in the OVN Northbound database
+        that will have a knock-on effect on Neutron API performance and should
+        be investigated.
+      format-dict:
+        port: '@checks.has_nbdb_log.search.results_group_3:unique_comma_join'
+        num: '@checks.has_nbdb_log.search.num_results'
+  has_frequent_sbdb_reconnections:
+    decision:
+      - is_neutron_server
+      - has_sbdb_log
+    raises:
+      type: OpenstackWarning
+      message: >-
+        The neutron-server service on this host is having to frequently
+        reconnect to a different OVN Southbound database server (port={port})
+        because the leader is frequently changing (see summary output for exact
+        numbers). This is a sign of instability in the OVN Southbound database
+        that will have a knock-on effect on Neutron API performance and should
+        be investigated.
+      format-dict:
+        port: '@checks.has_sbdb_log.search.results_group_3:unique_comma_join'
+        num: '@checks.has_sbdb_log.search.num_results'
+

--- a/hotsos/defs/tests/scenarios/openstack/neutron/ovndb_nb_leader_bouncing.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/neutron/ovndb_nb_leader_bouncing.yaml
@@ -1,0 +1,141 @@
+target-name: ovndb_leader_bouncing.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l:
+      ii  neutron-server 2:16.4.2-0ubuntu6.3 all
+    var/log/neutron/neutron-server.log: |
+        2023-11-23 02:53:06.204 2232 INFO ovsdbapp.backend.ovs_idl.vlog [req-e7457236-e20d-4364-965a-2702b2d9a48b - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.208 5615 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.210 2235 INFO ovsdbapp.backend.ovs_idl.vlog [req-8c4cae75-294d-429d-8b0b-e6420de5eacc - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.211 2173 INFO ovsdbapp.backend.ovs_idl.vlog [req-aa54d9b7-9dd8-48c3-ad58-f2cd8502d276 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.214 5608 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.215 5566 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.217 2272 INFO ovsdbapp.backend.ovs_idl.vlog [req-83b7bc75-8ceb-4019-94a3-7ef4b6ab996b - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.223 2164 INFO ovsdbapp.backend.ovs_idl.vlog [req-eb958352-3cda-48b8-9662-f44dc5958ed1 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.226 5571 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.227 5551 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.228 2212 INFO ovsdbapp.backend.ovs_idl.vlog [req-7b06cdfb-7117-443f-85bb-d24017434107 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.229 2259 INFO ovsdbapp.backend.ovs_idl.vlog [req-dddf4a2e-8e8e-4980-ab68-8eb0451ced42 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.231 5587 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.232 2188 INFO ovsdbapp.backend.ovs_idl.vlog [req-29f71c5c-5924-4ffa-bcd7-d36e44ee5202 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.233 2240 INFO ovsdbapp.backend.ovs_idl.vlog [req-2153ade3-6de6-49cb-9dfd-86ec01d2ed70 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.239 5549 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.239 5543 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.239 5552 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.240 2227 INFO ovsdbapp.backend.ovs_idl.vlog [req-09300f3e-a0bc-4b74-99a9-ae29fb4cbee0 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.242 5581 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.249 2235 INFO ovsdbapp.backend.ovs_idl.vlog [req-8c4cae75-294d-429d-8b0b-e6420de5eacc - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.252 2173 INFO ovsdbapp.backend.ovs_idl.vlog [req-aa54d9b7-9dd8-48c3-ad58-f2cd8502d276 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.258 2164 INFO ovsdbapp.backend.ovs_idl.vlog [req-eb958352-3cda-48b8-9662-f44dc5958ed1 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.259 2272 INFO ovsdbapp.backend.ovs_idl.vlog [req-83b7bc75-8ceb-4019-94a3-7ef4b6ab996b - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.259 5555 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.260 5615 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.273 2259 INFO ovsdbapp.backend.ovs_idl.vlog [req-dddf4a2e-8e8e-4980-ab68-8eb0451ced42 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.275 2212 INFO ovsdbapp.backend.ovs_idl.vlog [req-7b06cdfb-7117-443f-85bb-d24017434107 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.278 5552 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:06.284 2227 INFO ovsdbapp.backend.ovs_idl.vlog [req-09300f3e-a0bc-4b74-99a9-ae29fb4cbee0 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.174 5591 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.177 5585 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.182 2149 INFO ovsdbapp.backend.ovs_idl.vlog [req-aec776e4-f989-4fb7-bb15-9aff7ea30b57 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.191 2186 INFO ovsdbapp.backend.ovs_idl.vlog [req-d26a7456-ee8a-4c30-863a-2f3d9921c1e1 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.192 5568 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.192 2169 INFO ovsdbapp.backend.ovs_idl.vlog [req-a0371fd6-2f41-491d-8c29-74a3950c994c - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.193 5618 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.194 5595 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.196 2230 INFO ovsdbapp.backend.ovs_idl.vlog [req-8ad15dfa-f15e-444c-8b32-454cdd4b5846 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.197 5556 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.200 5610 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.201 2255 INFO ovsdbapp.backend.ovs_idl.vlog [req-4fa38474-4eca-4836-a26a-deff4d63cd25 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.206 5617 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.209 2222 INFO ovsdbapp.backend.ovs_idl.vlog [req-3402ca53-8252-414e-a0da-28b946ad64ea - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.210 2202 INFO ovsdbapp.backend.ovs_idl.vlog [req-20b39891-b861-4c11-9383-4824fc7c2919 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.212 2183 INFO ovsdbapp.backend.ovs_idl.vlog [req-ef4eb2f8-60e9-4045-8a67-ef3144782ee9 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.218 2214 INFO ovsdbapp.backend.ovs_idl.vlog [req-0814e141-b6b2-43af-a84e-6db8da42879c - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.221 5603 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.235 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.257 5566 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.257 5571 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.267 2240 INFO ovsdbapp.backend.ovs_idl.vlog [req-2153ade3-6de6-49cb-9dfd-86ec01d2ed70 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.268 2188 INFO ovsdbapp.backend.ovs_idl.vlog [req-29f71c5c-5924-4ffa-bcd7-d36e44ee5202 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.275 5549 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.291 5555 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.399 2242 INFO ovsdbapp.backend.ovs_idl.vlog [req-11e58953-fbf0-48e1-893f-5103aa446820 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.405 5565 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:07.420 5586 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.207 5591 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.209 5585 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.214 2149 INFO ovsdbapp.backend.ovs_idl.vlog [req-aec776e4-f989-4fb7-bb15-9aff7ea30b57 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.223 2186 INFO ovsdbapp.backend.ovs_idl.vlog [req-d26a7456-ee8a-4c30-863a-2f3d9921c1e1 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.225 5618 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.226 5595 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.229 5556 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.231 2230 INFO ovsdbapp.backend.ovs_idl.vlog [req-8ad15dfa-f15e-444c-8b32-454cdd4b5846 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.237 5617 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.238 5610 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.245 2255 INFO ovsdbapp.backend.ovs_idl.vlog [req-4fa38474-4eca-4836-a26a-deff4d63cd25 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.254 2214 INFO ovsdbapp.backend.ovs_idl.vlog [req-0814e141-b6b2-43af-a84e-6db8da42879c - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:08.254 2222 INFO ovsdbapp.backend.ovs_idl.vlog [req-3402ca53-8252-414e-a0da-28b946ad64ea - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.184 2168 INFO ovsdbapp.backend.ovs_idl.vlog [req-9939559f-b4f9-4ccb-b60a-0a5119a5ce06 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.186 2265 INFO ovsdbapp.backend.ovs_idl.vlog [req-fc11d441-b446-4c93-954b-541ed2aa0320 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.187 5611 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.192 2196 INFO ovsdbapp.backend.ovs_idl.vlog [req-0574238b-cbf4-4ead-8b0f-50f822a8cbec - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.198 2205 INFO ovsdbapp.backend.ovs_idl.vlog [req-77036502-0ffd-4cc7-9d55-adabc8f58f2b - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.205 2163 INFO ovsdbapp.backend.ovs_idl.vlog [req-73e3b1b9-ba1b-4fa7-8a86-42df9e42ed3c - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.212 5564 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.217 2190 INFO ovsdbapp.backend.ovs_idl.vlog [req-796b2dcc-d8b5-4047-a66f-8150311c8381 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.221 5600 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.235 2177 INFO ovsdbapp.backend.ovs_idl.vlog [req-04a43df0-e179-4f7a-b008-1ebba1aeb747 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:09.246 5574 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.194 2225 INFO ovsdbapp.backend.ovs_idl.vlog [req-4ada843f-707f-4c6a-8e7d-5c515116837f - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.201 5547 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.204 5583 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.209 5572 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.211 2185 INFO ovsdbapp.backend.ovs_idl.vlog [req-f02a8e4a-51f8-42ab-9c92-7d554cb21fbf - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.213 2275 INFO ovsdbapp.backend.ovs_idl.vlog [req-80be415f-dde4-443b-a1ec-4b5e62d6cf31 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.213 2220 INFO ovsdbapp.backend.ovs_idl.vlog [req-1fd0fa20-95d5-4d7b-b4d0-b009c08c0f06 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.215 5578 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.219 2174 INFO ovsdbapp.backend.ovs_idl.vlog [req-f784f096-b5eb-4965-a98e-1abbf797c90b - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.222 2184 INFO ovsdbapp.backend.ovs_idl.vlog [req-b1530566-8019-4b35-af7d-53bd82c421c1 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.223 2158 INFO ovsdbapp.backend.ovs_idl.vlog [req-8a89753a-f9bc-450c-a4d2-2ba5e79f5957 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.223 5545 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.236 2224 INFO ovsdbapp.backend.ovs_idl.vlog [req-2d0c21a8-fdc8-4a43-a49c-7a66204d747c - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:13.244 5561 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:13.245 5569 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.494 5569 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.572 2184 INFO ovsdbapp.backend.ovs_idl.vlog [req-b1530566-8019-4b35-af7d-53bd82c421c1 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.591 5545 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.664 2185 INFO ovsdbapp.backend.ovs_idl.vlog [req-f02a8e4a-51f8-42ab-9c92-7d554cb21fbf - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.768 5572 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.995 2158 INFO ovsdbapp.backend.ovs_idl.vlog [req-8a89753a-f9bc-450c-a4d2-2ba5e79f5957 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.019 2225 INFO ovsdbapp.backend.ovs_idl.vlog [req-4ada843f-707f-4c6a-8e7d-5c515116837f - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.036 2275 INFO ovsdbapp.backend.ovs_idl.vlog [req-80be415f-dde4-443b-a1ec-4b5e62d6cf31 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.063 5578 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.214 5561 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.298 5550 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.320 2220 INFO ovsdbapp.backend.ovs_idl.vlog [req-1fd0fa20-95d5-4d7b-b4d0-b009c08c0f06 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.340 5583 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.360 2250 INFO ovsdbapp.backend.ovs_idl.vlog [req-43efd036-3209-490c-bd81-546366665d52 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.363 2174 INFO ovsdbapp.backend.ovs_idl.vlog [req-f784f096-b5eb-4965-a98e-1abbf797c90b - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.396 2224 INFO ovsdbapp.backend.ovs_idl.vlog [req-2d0c21a8-fdc8-4a43-a49c-7a66204d747c - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.437 5547 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 04:54:52.122 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 04:55:40.020 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 04:55:40.076 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 07:25:22.145 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 07:27:12.190 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 07:27:12.415 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:53:14.298 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.344 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+  copy-from-original:
+    - uptime
+    - sos_commands/date/date
+raised-issues:
+  OpenstackWarning:
+    The neutron-server service on this host is having to frequently reconnect
+    to a different OVN Northbound database server (port=6641) because the
+    leader is frequently changing (see summary output for exact numbers). This
+    is a sign of instability in the OVN Northbound database that will have a
+    knock-on effect on Neutron API performance and should be investigated.
+

--- a/hotsos/defs/tests/scenarios/openstack/neutron/ovndb_sb_leader_bouncing.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/neutron/ovndb_sb_leader_bouncing.yaml
@@ -1,0 +1,95 @@
+target-name: ovndb_leader_bouncing.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l:
+      ii  neutron-server 2:16.4.2-0ubuntu6.3 all
+    var/log/neutron/neutron-server.log: |
+        2023-11-23 02:53:12.211 2185 INFO ovsdbapp.backend.ovs_idl.vlog [req-f02a8e4a-51f8-42ab-9c92-7d554cb21fbf - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.213 2275 INFO ovsdbapp.backend.ovs_idl.vlog [req-80be415f-dde4-443b-a1ec-4b5e62d6cf31 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.213 2220 INFO ovsdbapp.backend.ovs_idl.vlog [req-1fd0fa20-95d5-4d7b-b4d0-b009c08c0f06 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.215 5578 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.219 2174 INFO ovsdbapp.backend.ovs_idl.vlog [req-f784f096-b5eb-4965-a98e-1abbf797c90b - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.222 2184 INFO ovsdbapp.backend.ovs_idl.vlog [req-b1530566-8019-4b35-af7d-53bd82c421c1 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.223 2158 INFO ovsdbapp.backend.ovs_idl.vlog [req-8a89753a-f9bc-450c-a4d2-2ba5e79f5957 - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.223 5545 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:12.236 2224 INFO ovsdbapp.backend.ovs_idl.vlog [req-2d0c21a8-fdc8-4a43-a49c-7a66204d747c - - - - -] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:13.244 5561 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:13.245 5569 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.494 5569 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.572 2184 INFO ovsdbapp.backend.ovs_idl.vlog [req-b1530566-8019-4b35-af7d-53bd82c421c1 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.591 5545 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.664 2185 INFO ovsdbapp.backend.ovs_idl.vlog [req-f02a8e4a-51f8-42ab-9c92-7d554cb21fbf - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.768 5572 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:17.995 2158 INFO ovsdbapp.backend.ovs_idl.vlog [req-8a89753a-f9bc-450c-a4d2-2ba5e79f5957 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.019 2225 INFO ovsdbapp.backend.ovs_idl.vlog [req-4ada843f-707f-4c6a-8e7d-5c515116837f - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.036 2275 INFO ovsdbapp.backend.ovs_idl.vlog [req-80be415f-dde4-443b-a1ec-4b5e62d6cf31 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.063 5578 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.214 5561 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.298 5550 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.320 2220 INFO ovsdbapp.backend.ovs_idl.vlog [req-1fd0fa20-95d5-4d7b-b4d0-b009c08c0f06 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.340 5583 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.360 2250 INFO ovsdbapp.backend.ovs_idl.vlog [req-43efd036-3209-490c-bd81-546366665d52 - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.363 2174 INFO ovsdbapp.backend.ovs_idl.vlog [req-f784f096-b5eb-4965-a98e-1abbf797c90b - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.396 2224 INFO ovsdbapp.backend.ovs_idl.vlog [req-2d0c21a8-fdc8-4a43-a49c-7a66204d747c - - - - -] ssl:10.22.0.244:6641: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.415 5567 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 02:53:18.437 5547 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 04:54:52.122 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 04:55:40.020 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 04:55:40.076 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 07:25:22.145 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 07:27:12.190 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 07:27:12.415 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:53:14.298 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.244:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.344 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.243:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+        2023-11-23 09:54:39.458 5620 INFO ovsdbapp.backend.ovs_idl.vlog [-] ssl:10.22.0.242:16642: clustered database server is not cluster leader; trying another server
+  copy-from-original:
+    - uptime
+    - sos_commands/date/date
+raised-issues:
+  OpenstackWarning:
+    The neutron-server service on this host is having to frequently reconnect
+    to a different OVN Southbound database server (port=16642) because the
+    leader is frequently changing (see summary output for exact numbers). This
+    is a sign of instability in the OVN Southbound database that will have a
+    knock-on effect on Neutron API performance and should be investigated.
+


### PR DESCRIPTION
Checks for logs indicating that neutron is frequently reconnecting to the ovn north or southbound databases because the leader is changing.

Resolves: #776