### PR TITLE
Fix missing attribute

### DIFF
--- a/hotsos/core/host_helpers/ssl.py
+++ b/hotsos/core/host_helpers/ssl.py
@@ -29,7 +29,9 @@ class SSLCertificate(object):
 
         cert = x509.load_pem_x509_certificate(self.certificate,
                                               default_backend())
-        return cert.not_valid_after_utc
+        if hasattr(cert, 'not_valid_after_utc'):
+            return cert.not_valid_after_utc
+        return cert.not_valid_after.replace(tzinfo=timezone.utc)
 
     @property
     def days_to_expire(self):


### PR DESCRIPTION
The attribute `not_valid_after_utc` was introduced with cryptograpy
42.0.0 and the attribute 'not_valid_after` was deprecated. We still need
to support both attribute versions for a while. This change checks
whether the new attribute exists and uses it in that case but falls back
to the old attribute if necessary.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>