### PR TITLE
Fix tox command to run single test

### DIFF
--- a/doc/source/contrib/testing.rst
+++ b/doc/source/contrib/testing.rst
@@ -167,4 +167,4 @@ You can then re-run a failing test directly without running all tests and get th
 
 .. code-block:: console
 
-  tox -epy3 tests.unit.test_system.TestUbuntuPro.test_ubuntu_pro_attached
+  tox -epy3 -- tests.unit.test_system.TestUbuntuPro.test_ubuntu_pro_attached


### PR DESCRIPTION
The existing tox command is missing '--' and fails to run properly. Added this tiny fix.