### PR TITLE
[tests] Ignore swp files from tests

### DIFF
--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -31,7 +31,7 @@ def find_all_templated_tests(path):
     @return: path to test.
     """
     for testdef in os.listdir(path):
-        if testdef.endswith('.disabled'):
+        if testdef.endswith(('.disabled', '.swp')):
             continue
 
         defpath = os.path.join(path, testdef)


### PR DESCRIPTION
In case there's any leftover .swp file or a scenario file is kept open while running tox, it produces a weird error message. It should just ignore them instead.