### PR TITLE
Add huge pages check

### DIFF
--- a/hotsos/defs/scenarios/kernel/memory.yaml
+++ b/hotsos/defs/scenarios/kernel/memory.yaml
@@ -8,12 +8,26 @@ vars:
   # and is not necessarily representative of current state.
   min_compaction_success: 10000
   max_compaction_failures_pcent: 10
+  hugetlb_to_mem_total_percentage: '@hotsos.core.plugins.kernel.memory.MemInfo.hugetlb_to_mem_total_percentage'
+  mem_avail_to_mem_total_percentage: '@hotsos.core.plugins.kernel.memory.MemInfo.mem_avail_to_mem_total_percentage'
+  hugep_used_to_hugep_total_percentage: '@hotsos.core.plugins.kernel.memory.MemInfo.hugep_used_to_hugep_total_percentage'
+  mem_total_gb: '@hotsos.core.plugins.kernel.memory.MemInfo.mem_total_gb'
+  mem_available_gb: '@hotsos.core.plugins.kernel.memory.MemInfo.mem_available_gb'
+  hugetlb_gb: '@hotsos.core.plugins.kernel.memory.MemInfo.hugetlb_gb'
+  # Arbitrary thresholds set for the memory allocated for the huge
+  # pages to total memory and memory available to total memory.
+  hugetlb_to_mem_total_threshold_percent: 80
+  mem_available_to_mem_total_thershold_percent: 3
 checks:
   low_free_high_order_mem_blocks:
     varops: [[$nodes_with_limited_high_order_memory], [length_hint]]
   high_compaction_failures:
     - varops: [[$compact_success], [gt, $min_compaction_success]]
     - varops: [[$compaction_failures_percent], [gt, $max_compaction_failures_pcent]]
+  too_many_free_hugepages:
+    - property: hotsos.core.plugins.kernel.memory.MemInfo.huge_pages_enabled
+    - varops: [[$hugetlb_to_mem_total_percentage], [gt, $hugetlb_to_mem_total_threshold_percent]]
+    - varops: [[$mem_avail_to_mem_total_percentage], [lt, $mem_available_to_mem_total_thershold_percent]]
 conclusions:
   low_free_high_order_mem_blocks:
     decision: low_free_high_order_mem_blocks
@@ -44,4 +58,21 @@ conclusions:
         for more info.
       format-dict:
         pcent: $compaction_failures_percent
-
+  too_many_free_hugepages:
+    decision: too_many_free_hugepages
+    raises:
+      type: MemoryWarning
+      message: >-
+        This host is using hugepages which are consuming {hugetlb}GB out of {memtotal}GB total system
+        memory i.e. {hugepcent}%. This leaves {memavail}GB available memory for processes not using
+        hugepages. Also, only {hpusedpcent}% of the hugepages are being actively used. Memory
+        reserved for hugepages can't be used for any other purpose which may starve the system of
+        available memory. Please review /proc/meminfo and your current hugepages configuration to see
+        if you can reduce the hugepages allocation. For details, see the kernel documentation at
+        https://docs.kernel.org/admin-guide/mm/hugetlbpage.html.
+      format-dict:
+        hugetlb: $hugetlb_gb
+        hugepcent: $hugetlb_to_mem_total_percentage
+        memtotal: $mem_total_gb
+        memavail: $mem_available_gb
+        hpusedpcent: $hugep_used_to_hugep_total_percentage

--- a/hotsos/defs/tests/scenarios/kernel/hugepages_fail.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/hugepages_fail.yaml
@@ -1,0 +1,18 @@
+target-name: memory.yaml
+data-root:
+  files:
+    proc/meminfo: |
+      MemTotal:       395397124 kB
+      MemAvailable:    1907936 kB
+      HugePages_Total:     320
+      HugePages_Free:      306
+      Hugetlb:        335544320 kB
+raised-issues:
+  MemoryWarning: >-
+    This host is using hugepages which are consuming 320GB out of 377GB total system
+    memory i.e. 85%. This leaves 2GB available memory for processes not using
+    hugepages. Also, only 4% of the hugepages are being actively used. Memory
+    reserved for hugepages can't be used for any other purpose which may starve the system of
+    available memory. Please review /proc/meminfo and your current hugepages configuration to see
+    if you can reduce the hugepages allocation. For details, see the kernel documentation at
+    https://docs.kernel.org/admin-guide/mm/hugetlbpage.html.

--- a/hotsos/defs/tests/scenarios/kernel/hugepages_pass_1.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/hugepages_pass_1.yaml
@@ -1,0 +1,11 @@
+target-name: memory.yaml
+data-root:
+  files:
+    proc/meminfo: |
+      MemTotal:       395397124 kB
+      MemAvailable:    1907936 kB
+      # 0 huge pages configured -> HP disabled
+      HugePages_Total:     0
+      HugePages_Free:      306
+      Hugetlb:        335544320 kB
+raised-issues: # none expected

--- a/hotsos/defs/tests/scenarios/kernel/hugepages_pass_2.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/hugepages_pass_2.yaml
@@ -1,0 +1,11 @@
+target-name: memory.yaml
+data-root:
+  files:
+    proc/meminfo: |
+      MemTotal:       395397124 kB
+      MemAvailable:    1907936 kB
+      HugePages_Total:     320
+      HugePages_Free:      306
+      # Hugetlb consuming less then 80% of total memory
+      Hugetlb:        157286400 kB
+raised-issues: # none expected

--- a/hotsos/defs/tests/scenarios/kernel/hugepages_pass_3.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/hugepages_pass_3.yaml
@@ -1,0 +1,11 @@
+target-name: memory.yaml
+data-root:
+  files:
+    proc/meminfo: |
+      MemTotal:       395397124 kB
+      # available memory is more than 3% of total memory
+      MemAvailable:    19079360 kB
+      HugePages_Total:     320
+      HugePages_Free:      306
+      Hugetlb:        335544320 kB
+raised-issues: # none expected


### PR DESCRIPTION
The patch adds logic for testing if there are too many huge pages defined in the system, which are not being fully utilised, but occupy memory which can't be used for any other purpose. Such situations can negatively impact performance or even lead to the out of memory situations.

This patch also introduces a small refactoring of the VMStat class in the hotsos/core/plugins/kernel/memory.py, in order to avoid code duplication (between VMStat and MemInfo classes).