### PR TITLE
Add dpdk config checks

### DIFF
--- a/hotsos/core/plugins/openvswitch/__init__.py
+++ b/hotsos/core/plugins/openvswitch/__init__.py
@@ -4,4 +4,5 @@ from .ovs import (  # noqa: F403,F401
     OVSDB,
     OVSDPLookups,
     OVSBridge,
+    OVSDPDK,
 )

--- a/hotsos/core/plugins/openvswitch/ovs.py
+++ b/hotsos/core/plugins/openvswitch/ovs.py
@@ -199,13 +199,28 @@ class OpenvSwitchBase(object):
 
         return False
 
-    @cached_property
-    def dpdk_enabled(self):
-        config = self.ovsdb.Open_vSwitch.other_config
-        if not config:
-            return False
 
-        if config.get('dpdk-init') == "true":
+class OVSDPDK(OpenvSwitchBase):
+
+    @cached_property
+    def config(self):
+        return self.ovsdb.Open_vSwitch.other_config or {}
+
+    @property
+    def enabled(self):
+        if self.config.get('dpdk-init') == "true":
             return True
 
         return False
+
+    @property
+    def pmd_cpu_mask(self):
+        mask = self.config.get('pmd-cpu-mask')
+        if mask is not None:
+            return int(mask, 16)
+
+    @property
+    def dpdk_lcore_mask(self):
+        mask = self.config.get('dpdk-lcore-mask')
+        if mask is not None:
+            return int(mask, 16)

--- a/hotsos/defs/scenarios/openvswitch/dpdk_config.yaml
+++ b/hotsos/defs/scenarios/openvswitch/dpdk_config.yaml
@@ -1,0 +1,56 @@
+vars:
+  pmd_cpu_mask_key: 'pmd-cpu-mask'
+  pmd_cpu_mask: '@hotsos.core.plugins.openvswitch.OVSDPDK.pmd_cpu_mask'
+  lcore_mask_key: 'dpdk-lcore-mask'
+  lcore_mask: '@hotsos.core.plugins.openvswitch.OVSDPDK.dpdk_lcore_mask'
+  other_config: '@hotsos.core.plugins.openvswitch.OVSDB.other_config:Open_vSwitch'
+checks:
+  ovs_dpdk_enabled:
+    # see https://docs.openvswitch.org/en/latest/intro/install/dpdk/#setup-ovs
+    property: hotsos.core.plugins.openvswitch.OVSDPDK.enabled
+  dpdk_installed:
+    apt: [openvswitch-switch-dpdk, dpdk]
+  pmd_mask_is_set:
+    - varops: [[$other_config], [truth]]  # check not None
+    - varops: [[$other_config], [contains, $pmd_cpu_mask_key]]
+  lcore_mask_is_set:
+    - varops: [[$other_config], [truth]]  # check not None
+    - varops: [[$other_config], [contains, $lcore_mask_key]]
+  lcore_mask_overlap_pmd_cpu_mask:
+    - varops: [[$lcore_mask], [and_, $pmd_cpu_mask], [ne, 0]]
+conclusions:
+  ovs_dpdk_missing_config:
+    decision:
+      - ovs_dpdk_enabled
+      - dpdk_installed
+      - or:
+        - not: pmd_mask_is_set
+        - not: lcore_mask_is_set
+    raises:
+      type: OpenvSwitchWarning
+      message: >-
+        OpenvSwitch DPDK is enabled on this host but one or more of
+        '{pmd_cpu_mask}, {lcore_mask}' is not set in OVSDB Open_vSwitch table.
+        Current config is: {other_config}.
+      format-dict:
+        pmd_cpu_mask: '$pmd_cpu_mask_key'
+        lcore_mask: '$lcore_mask_key'
+        other_config: '$other_config'
+  ovs_dpdk_overlapping_masks:
+    decision:
+      - ovs_dpdk_enabled
+      - dpdk_installed
+      - pmd_mask_is_set
+      - lcore_mask_is_set
+      - lcore_mask_overlap_pmd_cpu_mask
+    raises:
+      type: OpenvSwitchWarning
+      message: >-
+        OpenvSwitch DPDK is enabled on this host but one or more core exists
+        in both {pmd_cpu_mask} and {lcore_mask} (see OVSDB Open_vSwitch table).
+        This will lead to performance degradation due to contention between
+        Poll Mode Driver threads and the rest of the system.
+      format-dict:
+        pmd_cpu_mask: '$pmd_cpu_mask_key'
+        lcore_mask: '$lcore_mask_key'
+

--- a/hotsos/defs/scenarios/openvswitch/service_restarts.yaml
+++ b/hotsos/defs/scenarios/openvswitch/service_restarts.yaml
@@ -15,7 +15,7 @@ checks:
     apt: [openvswitch-switch-dpdk, dpdk]
   ovs_dpdk_enabled:
     # see https://docs.openvswitch.org/en/latest/intro/install/dpdk/#setup-ovs
-    property: hotsos.core.plugins.openvswitch.OpenvSwitchBase.dpdk_enabled
+    property: hotsos.core.plugins.openvswitch.OVSDPDK.enabled
 conclusions:
   ovs_frequent_restarts_dpdk:
     priority: 2

--- a/hotsos/defs/tests/scenarios/openvswitch/dpdk_config_fail.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/dpdk_config_fail.yaml
@@ -1,0 +1,20 @@
+target-name: dpdk_config.yaml
+data-root:
+  files:
+    sos_commands/openvswitch/ovs-vsctl_-t_5_get_Open_vSwitch_._other_config: |
+      {dpdk-extra="-a 0000:4b:00.0 -a 0000:17:00.0", dpdk-init="true", dpdk-lcore-mask="0x03", dpdk-socket-mem="4096,4096", vlan-limit="0"}
+    sos_commands/dpkg/dpkg_-l: |
+      ii  dpdk                                  21.11.3-0ubuntu0.22.04.1                             amd64        Data Plane Development Kit (runtime)
+      ii  openvswitch-common                    2.17.5-0ubuntu0.22.04.2                              amd64        Open vSwitch common components
+      ii  openvswitch-switch                    2.17.5-0ubuntu0.22.04.2                              amd64        Open vSwitch switch implementations
+      ii  openvswitch-switch-dpdk               2.17.5-0ubuntu0.22.04.2                              amd64        DPDK enabled Open vSwitch switch implementation
+      ii  python3-openvswitch                   2.17.5-0ubuntu0.22.04.2                              all          Python 3 bindings for Open vSwitch
+  copy-from-original:
+    - sos_commands/systemd
+raised-issues:
+  OpenvSwitchWarning: >-
+    OpenvSwitch DPDK is enabled on this host but one or more of 'pmd-cpu-mask,
+    dpdk-lcore-mask' is not set in OVSDB Open_vSwitch table. Current config
+    is: {'dpdk-extra': '-a 0000:4b:00.0 -a 0000:17:00.0', 'dpdk-init': 'true',
+    'dpdk-lcore-mask': '0x03', 'dpdk-socket-mem': '4096,4096', 'vlan-limit':
+    '0'}.

--- a/hotsos/defs/tests/scenarios/openvswitch/dpdk_config_fail_mask_overlap.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/dpdk_config_fail_mask_overlap.yaml
@@ -1,0 +1,20 @@
+target-name: dpdk_config.yaml
+data-root:
+  files:
+    sos_commands/openvswitch/ovs-vsctl_-t_5_get_Open_vSwitch_._other_config: |
+      {dpdk-extra="-a 0000:4b:00.0 -a 0000:17:00.0", dpdk-init="true", dpdk-lcore-mask="0x10", dpdk-socket-mem="4096,4096", pmd-cpu-mask="0x57000000000000570", vlan-limit="0"}
+    sos_commands/dpkg/dpkg_-l: |
+      ii  dpdk                                  21.11.3-0ubuntu0.22.04.1                             amd64        Data Plane Development Kit (runtime)
+      ii  openvswitch-common                    2.17.5-0ubuntu0.22.04.2                              amd64        Open vSwitch common components
+      ii  openvswitch-switch                    2.17.5-0ubuntu0.22.04.2                              amd64        Open vSwitch switch implementations
+      ii  openvswitch-switch-dpdk               2.17.5-0ubuntu0.22.04.2                              amd64        DPDK enabled Open vSwitch switch implementation
+      ii  python3-openvswitch                   2.17.5-0ubuntu0.22.04.2                              all          Python 3 bindings for Open vSwitch
+  copy-from-original:
+    - sos_commands/systemd
+raised-issues:
+  OpenvSwitchWarning: >-
+    OpenvSwitch DPDK is enabled on this host but one or more core exists in
+    both pmd-cpu-mask and dpdk-lcore-mask (see OVSDB Open_vSwitch table). This
+    will lead to performance degradation due to contention between Poll Mode
+    Driver threads and the rest of the system.
+

--- a/hotsos/defs/tests/scenarios/openvswitch/dpdk_config_pass.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/dpdk_config_pass.yaml
@@ -1,0 +1,14 @@
+target-name: dpdk_config.yaml
+data-root:
+  files:
+    sos_commands/openvswitch/ovs-vsctl_-t_5_get_Open_vSwitch_._other_config: |
+      {dpdk-extra="-a 0000:4b:00.0 -a 0000:17:00.0", dpdk-init="true", dpdk-lcore-mask="0x03", dpdk-socket-mem="4096,4096", pmd-cpu-mask="0x57000000000000570", vlan-limit="0"}
+    sos_commands/dpkg/dpkg_-l: |
+      ii  dpdk                                  21.11.3-0ubuntu0.22.04.1                             amd64        Data Plane Development Kit (runtime)
+      ii  openvswitch-common                    2.17.5-0ubuntu0.22.04.2                              amd64        Open vSwitch common components
+      ii  openvswitch-switch                    2.17.5-0ubuntu0.22.04.2                              amd64        Open vSwitch switch implementations
+      ii  openvswitch-switch-dpdk               2.17.5-0ubuntu0.22.04.2                              amd64        DPDK enabled Open vSwitch switch implementation
+      ii  python3-openvswitch                   2.17.5-0ubuntu0.22.04.2                              all          Python 3 bindings for Open vSwitch
+  copy-from-original:
+    - sos_commands/systemd
+raised-issues:


### PR DESCRIPTION
Checks that Open_vSwitch table contains expected config for pmd and logical cores.

Resolves: #636