### PR TITLE
Include microceph services in Ceph

### DIFF
--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -34,7 +34,8 @@ from hotsos.core.utils import (
 from hotsos.core.ycheck.events import EventCallbackBase
 
 CEPH_SERVICES_EXPRS = [r"ceph-[a-z0-9-]+",
-                       r"rados[a-z0-9-:]+"]
+                       r"rados[a-z0-9-:]+",
+                       r"microceph.(mon|mgr|mds|osd|rgw)"]
 CEPH_PKGS_CORE = [r"ceph",
                   r"rados",
                   r"rbd",


### PR DESCRIPTION
Partially fixes #804 - addresses the `ps` part.

Test run:
```
hotsos:
  version: 1.17.0+1235.ubuntu22.4.1
  repo-info: 962c92a1
system:
  hostname: microceph-1
  os: ubuntu jammy
  num-cpus: 1
  load: 0.57, 0.60, 0.45
  virtualisation: qemu
  rootfs: /dev/root        9974088 4327644   5630060  44% /
  unattended-upgrades: ENABLED
  date: Wed Apr 10 08:14:04 UTC 2024
  ubuntu-pro:
    status: not-attached
  uptime: 0d:21h:16m
  potential-issues:
    SystemWarnings:
      - Unattended upgrades are enabled which can lead to uncontrolled changes to
        this environment. If maintenance windows are required please consider disabling
        unattended upgrades.
storage:
  ceph:
    release:
      name: reef
      days-to-eol: 3671
    services:
      systemd:
        mds:
          - snap.microceph.mds
        mgr:
          - snap.microceph.mgr
        mon:
          - snap.microceph.mon
        osd:
          - snap.microceph.osd
        rgw:
          - snap.microceph.rgw
      ps:
        - ceph-mds (1)
        - ceph-mgr (1)
        - ceph-mon (1)
        - ceph-osd (1)
        - radosgw (1)
    dpkg:
      - microceph 18.2.0+snap450240f5dd
    status: HEALTH_OK
    versions:
      mon:
        - 18.2.0
      mgr:
        - 18.2.0
      osd:
        - 18.2.0
      mds:
        - 18.2.0
      rgw:
        - 18.2.0
```