### PR TITLE
Put snaps into its own section in summary

### DIFF
--- a/hotsos/plugin_extensions/storage/ceph_summary.py
+++ b/hotsos/plugin_extensions/storage/ceph_summary.py
@@ -22,6 +22,7 @@ class CephSummary(CephChecksBase):
         if self.apt.core:
             return self.apt.all_formatted
 
+    def __2_summary_snaps(self):
         if self.snaps.core:
             return self.snaps.all_formatted
 


### PR DESCRIPTION
A previous commit added snap deps for microceph but they are disaplyed under "dpkg:" in the summary. This puts them under "snaps:".