### PR TITLE
Only execute conclusions until a match is found

### DIFF
--- a/hotsos/core/ycheck/engine/properties/conclusions.py
+++ b/hotsos/core/ycheck/engine/properties/conclusions.py
@@ -19,8 +19,7 @@ from hotsos.core.ycheck.engine.properties.common import (
 class YPropertyPriority(YPropertyOverrideBase):
     _override_keys = ['priority']
 
-    @cached_property
-    def value(self):
+    def __int__(self):
         return int(self.content or 1)
 
 


### PR DESCRIPTION
For a set of conclusions with varying priority, we want to execute them in order of priority and only go as far as the first set of matches of the same priority so as to avoid unecessarily executing conclusions where the result will never be used.