### PR TITLE
Add CVE issue type

### DIFF
--- a/doc/source/contrib/language_ref/property_ref/main_properties.rst
+++ b/doc/source/contrib/language_ref/property_ref/main_properties.rst
@@ -155,11 +155,12 @@ Usage:
     raises:
       type: <type>
       bug-id: <str>
+      cve-id: <str>
       message: <str>
       format-dict: <dict>
 
-If *type* is a `bug type <https://github.com/canonical/hotsos/blob/main/hotsos/core/issues/issue_types.py>`_ then a *bug-id*
-must be provided.
+If *type* is a `bug or cve type <https://github.com/canonical/hotsos/blob/main/hotsos/core/issues/issue_types.py>`_ then a
+*bug-id* or *cve-id* must be provided respectively.
 
 If the *message* string contains format fields these can be filled
 using ```format-dict``` - a dictionary of key/value pairs where *key* matches a

--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -30,6 +30,10 @@ class BugTypeBase(abc.ABC, IssueTypeBase):
         pass
 
 
+class CVETypeBase(BugTypeBase):
+    ISSUE_TYPE = 'cve'
+
+
 class HotSOSScenariosWarning(IssueTypeBase):
     pass
 
@@ -168,6 +172,17 @@ class MAASWarning(IssueTypeBase):
 
 class VaultWarning(IssueTypeBase):
     pass
+
+
+class UbuntuCVE(CVETypeBase):
+
+    @property
+    def base_url(self):
+        return 'https://ubuntu.com/security/'
+
+    @property
+    def url(self):
+        return "{}{}".format(self.base_url, self.id)
 
 
 class LaunchpadBug(BugTypeBase):

--- a/hotsos/core/issues/utils.py
+++ b/hotsos/core/issues/utils.py
@@ -182,8 +182,8 @@ class IssuesManager(object):
         return issues
 
     def add(self, issue, context=None):
-        if issue.ISSUE_TYPE == 'bug':
-            log.debug("issue is a bug")
+        if issue.ISSUE_TYPE in ('bug', 'cve'):
+            log.debug("issue is a %s", issue.ISSUE_TYPE)
             self.bugstore.add(issue, context=context)
         else:
             self.issuestore.add(issue, context=context)

--- a/hotsos/defs/scenarios/openstack/cinder/bugs/lp2004555.yaml
+++ b/hotsos/defs/scenarios/openstack/cinder/bugs/lp2004555.yaml
@@ -32,8 +32,8 @@ conclusions:
       - not: pkg_has_fix
       - not: service_tokens_enabled
     raises:
-      type: LaunchpadBug
-      bug-id: 2004555
+      type: UbuntuCVE
+      cve-id: CVE-2023-2088
       message: >-
         The version of Openstack Cinder ({pkg}={version}) running on this host is
         impacted by security vulnerability CVE-2023-2088. There is a fix

--- a/hotsos/defs/scenarios/openstack/nova/bugs/lp2004555.yaml
+++ b/hotsos/defs/scenarios/openstack/nova/bugs/lp2004555.yaml
@@ -49,8 +49,8 @@ conclusions:
       - not: pkg_has_fix
       - not: service_tokens_enabled
     raises:
-      type: LaunchpadBug
-      bug-id: 2004555
+      type: UbuntuCVE
+      cve-id: CVE-2023-2088
       message: >-
         The version of Openstack Nova ({version}) running on this host is
         impacted by security vulnerability CVE-2023-2088. There is a fix

--- a/hotsos/defs/tests/scenarios/openstack/cinder/bugs/lp2004555_no_fix_no_st.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/cinder/bugs/lp2004555_no_fix_no_st.yaml
@@ -8,7 +8,7 @@ data-root:
       ii  cinder-volume                   2:20.2.0-0ubuntu1~cloud0          all          Cinder storage service - Volume server
       ii  python3-cinder                  2:20.2.0-0ubuntu1~cloud0          all          Cinder Python 3 libraries
 raised-bugs:
-  https://bugs.launchpad.net/bugs/2004555: >-
+  https://ubuntu.com/security/CVE-2023-2088: >-
     The version of Openstack Cinder (cinder-api=2:20.2.0-0ubuntu1~cloud0)
     running on this host is impacted by security vulnerability CVE-2023-2088.
     There is a fix available in the Ubuntu archives and upgrading is

--- a/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp2004555_no_fix_no_st.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/nova/bugs/lp2004555_no_fix_no_st.yaml
@@ -9,7 +9,7 @@ data-root:
       ii  nova-compute-libvirt                 3:25.1.0-0ubuntu1~cloud0                                    all          OpenStack Compute - compute node libvirt support
       ii  python3-nova                         3:25.1.0-0ubuntu1~cloud0                                    all          OpenStack Compute Python 3 libraries
 raised-bugs:
-  https://bugs.launchpad.net/bugs/2004555: >-
+  https://ubuntu.com/security/CVE-2023-2088: >-
     The version of Openstack Nova (3:25.1.0-0ubuntu1~cloud0) running on this
     host is impacted by security vulnerability CVE-2023-2088. There is a fix
     available in the Ubuntu archives and upgrading is recommended BUT it is

--- a/tests/unit/test_ycheck_scenarios.py
+++ b/tests/unit/test_ycheck_scenarios.py
@@ -463,6 +463,25 @@ scenarioB:
       raises:
         type: LaunchpadBug
         message: foo
+scenarioC:
+  checks:
+    property_w_error:
+      property: tests.unit.test_ycheck_scenarios.TestProperty.always_true
+  conclusions:
+    c1:
+      decision: property_no_error
+      raises:
+        type: UbuntuCVE
+        message: foo
+scenarioD:
+  checks:
+    property_w_error:
+      property: tests.unit.test_ycheck_scenarios.TestProperty.always_true
+  conclusions:
+    c1:
+      decision: property_no_error
+      raises:
+        cve-id: 123
 """  # noqa
 
 
@@ -1015,15 +1034,15 @@ class TestYamlScenarios(utils.BaseTestCase):
         scenarios.YScenarioChecker().load_and_run()
 
         # Check caught exception logs
-        args = ('caught exception when running scenario %s:', 'scenarioB')
+        args = ('caught exception when running scenario %s:', 'scenarioD')
         mock_log.exception.assert_called_with(*args)
 
         args = ('something went wrong when executing decision',)
         mock_log2.exception.assert_called_with(*args)
 
-        mock_exc.assert_called_with("both bug-id (current=1234) and bug type "
-                                    "(current=issue) required in order to "
-                                    "raise a bug")
+        mock_exc.assert_called_with("both cve-id/bug-id (current=1234) and "
+                                    "bug type (current=issue) required in "
+                                    "order to raise a bug")
         issues = list(IssuesStore().load().values())
         self.assertEqual(len(issues[0]), 1)
         i_types = [i['type'] for i in issues[0]]
@@ -1032,8 +1051,8 @@ class TestYamlScenarios(utils.BaseTestCase):
         for issue in issues[0]:
             if issue['type'] == 'HotSOSScenariosWarning':
                 msg = ("One or more scenarios failed to run (scenarioA, "
-                       "scenarioB) - run hotsos in debug mode (--debug) to "
-                       "get more detail")
+                       "scenarioB, scenarioC, scenarioD) - run hotsos in "
+                       "debug mode (--debug) to get more detail")
                 self.assertEqual(issue['message'], msg)
 
     @init_test_scenario(VARS)


### PR DESCRIPTION
Adds a new UbuntuCVE issue type for raising issues with and link to a cve. This is particularly useful when there is no Launchpad url.