### PR TITLE
Fix some pylint warnings

### DIFF
--- a/hotsos/core/analytics.py
+++ b/hotsos/core/analytics.py
@@ -57,7 +57,7 @@ class EventCollection(object):
         """
         For a given event end marker, find the most recent start marker.
         """
-        last = None
+        last = {}
         for item in self._events[event_id].get("heads", []):
             start_ts = item["start"]
             if start_ts <= end_ts:

--- a/pylintrc
+++ b/pylintrc
@@ -39,7 +39,6 @@ disable=
  super-init-not-called,
  useless-object-inheritance,
  unidiomatic-typecheck,
- unsubscriptable-object,
  inconsistent-return-statements,
  attribute-defined-outside-init,
  too-few-public-methods,
@@ -51,7 +50,6 @@ disable=
  broad-exception-raised,
  unspecified-encoding,
  consider-using-f-string,
- consider-using-with,
  consider-using-dict-items,
  unused-private-member,
  no-member


### PR DESCRIPTION
find_most_recent_start() was using None as a default value, changed to use {} as it was confusing pylint, unsubscriptable-object warning.

consider-using-with is now enforced as there are no longer any occurences of code triggering it.