### PR TITLE
utils/TemplatedTestGenerator/test_method_name: support dots in name

### DIFF
--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -229,8 +229,11 @@ class TemplatedTestGenerator(object):
     @property
     def test_method_name(self):
         """ Test method name uses the original name. """
-        name = self.test_sub_path.split('.')[0]
-        name = name.replace('/', '_')
+        name = os.path.splitext(self.test_sub_path)[0]
+        replace_char = '_'
+        chars_to_replace = ('/', '.')
+        for char in chars_to_replace:
+            name = name.replace(char, replace_char)
         return 'test_{}'.format(name)
 
     def _generate(self):


### PR DESCRIPTION
test_method_name now properly removes the file extension from the file name and uses the remainder even if there are multiple dots present in the name.

Fixes: #818