### PR TITLE
Add generic binary requirements checker

### DIFF
--- a/doc/source/contrib/language_ref/property_ref/requirement_types.rst
+++ b/doc/source/contrib/language_ref/property_ref/requirement_types.rst
@@ -98,6 +98,39 @@ Cache keys:
   * package - name of each installed package
   * version - version of each installed package
 
+Binary
+---
+
+Takes a binary name and optional list of version ranges. Returns True if
+the binary exists and if provided, version is within ranges.
+
+Usage:
+
+.. code-block:: yaml
+
+    binary:
+      name: mybin
+      handler: path.to.handler
+
+Or with version ranges as follows:
+
+.. code-block:: yaml
+
+    binary:
+      handler: path.to.bininterfacehandler
+      mybin:
+        - min: 0.0
+          max: 1.0
+        - min: 4.0
+          max: 5.0
+
+NOTE: the version checking logic is currently the same as for the :ref:`Apt` type.
+
+Cache keys:
+
+  * binary - name of each installed binary
+  * version - version of each installed binary
+
 Snap
 ----
 

--- a/hotsos/core/plugins/juju/__init__.py
+++ b/hotsos/core/plugins/juju/__init__.py
@@ -1,1 +1,2 @@
 from .common import JujuChecksBase  # noqa: F403,F401
+from .resources import JujuBinaryInterface  # noqa: F403,F401

--- a/hotsos/core/ycheck/engine/properties/requires/requires.py
+++ b/hotsos/core/ycheck/engine/properties/requires/requires.py
@@ -5,6 +5,7 @@ from hotsos.core.ycheck.engine.properties.common import (
 )
 from hotsos.core.ycheck.engine.properties.requires.types import (
     apt,
+    binary,
     snap,
     config,
     pebble,
@@ -70,6 +71,7 @@ class RequiresLogicalGrouping(PTreeLogicalGrouping):
 class YPropertyRequires(YPropertyMappedOverrideBase):
     _override_keys = ['requires']
     _override_members = [apt.YRequirementTypeAPT,
+                         binary.YRequirementTypeBinary,
                          snap.YRequirementTypeSnap,
                          config.YRequirementTypeConfig,
                          pebble.YRequirementTypePebble,

--- a/hotsos/core/ycheck/engine/properties/requires/types/binary.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/binary.py
@@ -1,0 +1,68 @@
+from functools import cached_property
+
+from hotsos.core.log import log
+from hotsos.core.ycheck.engine.properties.requires import (
+    intercept_exception,
+    YRequirementTypeBase,
+)
+from hotsos.core.ycheck.engine.properties.requires.types.apt import \
+    APTCheckItems
+
+
+class BinCheckItems(APTCheckItems):
+    """
+    By default we use the APT version checks logic for binary versions. At some
+    point in the future we may want to support overriding this.
+    """
+
+    def __init__(self, *args, bin_handler=None, **kwargs):
+        self.bin_handler = bin_handler
+        super().__init__(*args, **kwargs)
+
+    @cached_property
+    def packaging_helper(self):
+        return self.bin_handler()
+
+
+class YRequirementTypeBinary(YRequirementTypeBase):
+    _override_keys = ['binary']
+    _overrride_autoregister = True
+
+    @property
+    def _bin_info(self):
+        if hasattr(self, 'name'):
+            return {self.name: None}
+
+        return {k: v for k, v in self.content.items() if k not in ['handler']}
+
+    @property
+    @intercept_exception
+    def _result(self):
+        items = BinCheckItems(self._bin_info,
+                              bin_handler=self.get_cls(self.handler))
+
+        _result = True
+        # bail on first fail i.e. if any not installed
+        if not items.not_installed:
+            for binary, versions in items:
+                log.debug("binary %s installed=%s", binary, _result)
+                if not versions:
+                    continue
+
+                _result = items.package_version_within_ranges(binary, versions)
+                # bail at first failure
+                if not _result:
+                    break
+        else:
+            log.debug("one or more binary not installed so returning False "
+                      "- %s", ', '.join(items.not_installed))
+            # bail on first fail i.e. if any not installed
+            _result = False
+
+        self.cache.set('binary', ', '.join(items.installed))
+        self.cache.set('version', ', '.join([
+            str(x) for x in items.installed_versions]))
+        log.debug('requirement check: %s %s (result=%s)',
+                  self.__class__.__name__,
+                  ', '.join(items.packages_to_check), _result)
+        return _result


### PR DESCRIPTION
We have requirement types for packages like apt, snap etc but do not have a way to get information from a binary. Some applications are not installed by packages but may still have e.g. a version so having a way to query this is useful. This tries to provide a common way to do do this and uses the Juju plugin/binary as an initial use-case.

Resolves: #815