### PR TITLE
[unittest] Define addDuration method to support 3.12

### DIFF
--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -450,6 +450,13 @@ class BaseTestCase(unittest.TestCase):
         else:
             LoggingManager().start(level=logging.WARNING)
 
+    def _addDuration(self, *args, **kwargs):  # For Python >= 3.12
+        """ Python 3.12 needs subclasses of unittest.TestCase to implement
+        this in order to record times and execute any cleanup actions once
+        a test completes regardless of success. Otherwise it emits a warning.
+        This generic implementation helps suppress it and possibly others in
+        the future. """
+
     def tearDown(self):
         LoggingManager().stop()
         HotSOSConfig.reset()


### PR DESCRIPTION
Change:
https://github.com/python/cpython/pull/12271/commits/d88087ea57f116d754b92c5189d75777f717f4ef

This essentially suppresses the warnings:
RuntimeWarning: TestResult has no addDuration method\n  warnings.warn("TestResult has no addDuration method")