### PR TITLE
Bump `pylint` dependency

### DIFF
--- a/hotsos/core/host_helpers/__init__.py
+++ b/hotsos/core/host_helpers/__init__.py
@@ -16,17 +16,17 @@ from .packaging import (  # noqa: F403,F401
     DockerImageHelper,
     SnapPackageHelper,
 )
-from .pebble import (  # noqa: F403,F401
+from .pebble import (  # noqa: F403,F401 pylint: disable=cyclic-import
     PebbleHelper,
 )
 from .ssl import (  # noqa: F403,F401
     SSLCertificate,
     SSLCertificatesHelper,
 )
-from .systemd import (  # noqa: F403,F401
+from .systemd import (  # noqa: F403,F401 pylint: disable=cyclic-import
     SystemdHelper,
 )
-from .uptime import (  # noqa: F403,F401
+from .uptime import (  # noqa: F403,F401 pylint: disable=cyclic-import
     UptimeHelper,
 )
 from .sysctl import (  # noqa: F403,F401

--- a/pylintrc
+++ b/pylintrc
@@ -50,4 +50,5 @@ disable=
  unspecified-encoding,
  consider-using-f-string,
  unused-private-member,
- no-member
+ no-member,
+ duplicate-code,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,5 +2,5 @@ bashate
 flake8==6.0.0
 flake8-import-order==0.18.2
 stestr
-pylint==2.17.4
+pylint==3.0.4
 rpdb


### PR DESCRIPTION
Closes: https://github.com/canonical/hotsos/issues/830
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
