### PR TITLE
Remove dup ms from logging format

### DIFF
--- a/hotsos/core/log.py
+++ b/hotsos/core/log.py
@@ -26,7 +26,7 @@ class LoggingManager(object):
 
     @property
     def _format(self):
-        return ("%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s "
+        return ("%(asctime)s %(process)d %(levelname)s %(name)s "
                 "[-] %(message)s")
 
     @cached_property


### PR DESCRIPTION
asctime already contains milliseconds so we were
printing it twice.