### PR TITLE
Enhancement/detect missing scenario tests

### DIFF
--- a/tests/unit/test_ut_scenario_loader.py
+++ b/tests/unit/test_ut_scenario_loader.py
@@ -1,8 +1,11 @@
 import os
 import tempfile
 import uuid
+import glob
+import json
 from unittest import mock
 
+import yaml
 from hotsos.core.config import HotSOSConfig
 
 from . import utils
@@ -117,10 +120,12 @@ class TestScenarioTestLoader(ScenarioTestsBase):
                 tests = [x for x in dir(a) if x.startswith("test_")]
                 self.assertEqual(len(tests), 4)
 
-                self.assertTrue("test_1_myscenario_with_many_dots_1" in tests)
-                self.assertTrue("test_1_myscenario1" in tests)
-                self.assertTrue("test_1_myscenario1alt" in tests)
-                self.assertTrue("test_1_myscenario_noextension1" in tests)
+                self.assertTrue("test_yscenario_1_myscenario_with_many_dots_1"
+                                in tests)
+                self.assertTrue("test_yscenario_1_myscenario1" in tests)
+                self.assertTrue("test_yscenario_1_myscenario1alt" in tests)
+                self.assertTrue("test_yscenario_1_myscenario_noextension1"
+                                in tests)
 
     def test_find_all_templated_tests(self):
         with tempfile.TemporaryDirectory() as dtmp:
@@ -235,16 +240,16 @@ class TestScenarioTestLoader(ScenarioTestsBase):
                 class MyTests(ScenarioTestsBase):
                     pass
 
-                MyTests().test_1_myscenario1()  # pylint: disable=E1101
-                MyTests().test_1_myscenario1alt()  # pylint: disable=E1101
-                MyTests().test_1_2_myscenario2()  # pylint: disable=E1101
-                MyTests().test_1_2_myscenario2alt()  # noqa pylint: disable=E1101
-                MyTests().test_1_2_3_myscenario3()  # noqa pylint: disable=E1101
-                MyTests().test_1_2_3_myscenario3alt()  # noqa pylint: disable=E1101
-                MyTests().test_1_2_3_4_myscenario4()  # noqa pylint: disable=E1101
-                MyTests().test_1_2_3_4_myscenario4alt()  # noqa pylint: disable=E1101
-                MyTests().test_1_2_3_4_5_myscenario5()  # noqa pylint: disable=E1101
-                MyTests().test_1_2_3_4_5_myscenario5alt()  # noqa pylint: disable=E1101
+                MyTests().test_yscenario_1_myscenario1()
+                MyTests().test_yscenario_1_myscenario1alt()
+                MyTests().test_yscenario_1_2_myscenario2()
+                MyTests().test_yscenario_1_2_myscenario2alt()
+                MyTests().test_yscenario_1_2_3_myscenario3()
+                MyTests().test_yscenario_1_2_3_myscenario3alt()
+                MyTests().test_yscenario_1_2_3_4_myscenario4()
+                MyTests().test_yscenario_1_2_3_4_myscenario4alt()
+                MyTests().test_yscenario_1_2_3_4_5_myscenario5()
+                MyTests().test_yscenario_1_2_3_4_5_myscenario5alt()
 
                 raised = False
                 try:
@@ -273,8 +278,8 @@ class TestScenarioTestLoader(ScenarioTestsBase):
                 class MyTests(ScenarioTestsBase):
                     pass
 
-                MyTests().test_myscenario5()  # pylint: disable=E1101
-                MyTests().test_myscenario5alt()  # pylint: disable=E1101
+                MyTests().test_yscenario_myscenario5()
+                MyTests().test_yscenario_myscenario5alt()
 
                 raised = False
                 try:
@@ -298,3 +303,130 @@ class TestScenarioTestLoader(ScenarioTestsBase):
                 class MyTests(ScenarioTestsBase):
                     pass
                 MyTests()
+
+    def test_scenarios_check_mappings(self):
+        """Check for all YAML tests and scenarios to determine whether
+        every scenario has at least one test.
+        """
+
+        tests_root_path = os.path.join(utils.DEFS_TESTS_DIR, 'scenarios')
+        scenarios_root_path = os.path.join(utils.DEFS_DIR, 'scenarios')
+
+        # This list contains the full paths to all scenario test cases.
+        # This information is used for reporting the number of avaliable
+        # test cases.
+        all_tests = []
+
+        # A collection of all tests and their respective scenarios. Scenario
+        # name is used as a key, where the value is list of tests associated
+        # with the scenario.
+        test_scenario_mappings = {}
+
+        # Iterate over all subdirectories of `hotsos/defs/tests` and try to
+        # discover all the available test cases.
+        for subdir in os.listdir(tests_root_path):
+            tests = utils.find_all_templated_tests(
+                os.path.join(tests_root_path, subdir))
+
+            # Load the scenario tests one by one
+            for testdef in tests:
+                # Add the discovered test to list of
+                # all tests
+                all_tests.append(testdef)
+
+                # Load the test. The code needs to access some attributes
+                # stored in the templated test class in order to be able to
+                # determine the associated scenario.
+                tg = utils.TemplatedTestGenerator(
+                    f'scenarios/{subdir}', testdef)
+
+                # Determine the test's target scenario path.
+                target_scenario_path = os.path.join(utils.DEFS_DIR,
+                    tg.test_defs_root, tg.target_path)
+
+                # Add the test case's name to tests associated with the
+                # scenario.
+                if target_scenario_path in test_scenario_mappings:
+                    test_scenario_mappings[target_scenario_path].append(
+                        testdef)
+                else:
+                    test_scenario_mappings[target_scenario_path] = [testdef]
+
+        # At this point, we have all the names of the scenarios which actually
+        # have at least one test for it. Now, we're going to grab a list of all
+        # scenario YAML files to compare them. We'll also check for a few
+        # essential things we require in scenarios (e.g. having `checks` and
+        # `conclusions` sections) as well.
+        scenario_files = glob.glob(scenarios_root_path + '/**/*.yaml',
+            recursive=True)
+
+        # This list will contain the names of the scenarios which does not have
+        # a test case.
+        scenarios_without_test = []
+
+        # List of plugin requirement files
+        scenarios_with_requires = []
+
+        # The list of scenarios which does not have a `checks` section in it
+        scenarios_without_checks_section = []
+
+        # The list of scenarios which does not have a
+        # `conclusions` section in it
+        scenarios_without_conclusions_section = []
+
+        # Try to load each scenario to determine its purpose.
+        for scenario_file in scenario_files:
+
+            with open(scenario_file) as sfilestream:
+                sy = yaml.safe_load(sfilestream)
+
+                # If the YAML file contains "requires" section
+                # then it means the yaml is defining pre-conditions
+                # for all the scenarios under the directory, so the
+                # file itself is not a scenario.
+                if "requires" in sy:
+                    scenarios_with_requires.append(scenario_file)
+                    # Skip the file.
+                    continue
+
+                # The rest, we can treat as scenarios and we should expect
+                # them to have "checks" and "conditions" sections in each of
+                # them. It does not make sense for a scenario to lack either
+                # one of them. List if any, and report them altogether for
+                # convenience.
+                if "checks" not in sy:
+                    scenarios_without_checks_section.append(scenario_file)
+
+                if "conclusions" not in sy:
+                    scenarios_without_conclusions_section.append(scenario_file)
+
+            # We expect every single scenario to have at least one test
+            # file. If there's none, store the scenario name for further
+            # reporting.
+            if scenario_file not in test_scenario_mappings:
+                scenarios_without_test.append(scenario_file)
+
+        # Report the scenarios without `checks` section, if any.
+        self.assertEqual(
+            len(scenarios_without_checks_section), 0,
+            msg=f"The following scenario files does not have a `checks`"
+            "section!:"
+            f"{json.dumps(scenarios_without_checks_section, indent=4)}"
+        )
+
+        # Report the scenarios without `conclusions` section, if any.
+        self.assertEqual(
+            len(scenarios_without_conclusions_section), 0,
+            msg=f"The following scenario files does not have a `conclusions`"
+            "section!:"
+            f"{json.dumps(scenarios_without_conclusions_section, indent=4)}"
+        )
+
+        # Finally, report the scenarios without a test.
+        self.assertEqual(
+            len(scenarios_without_test), 0,
+            msg=f"Discovered {len(all_tests)} test(s), scenario count"
+            f" is {len(scenario_files) - len(scenarios_with_requires)}, "
+            f"scenario-test mapping count is {len(test_scenario_mappings)}."
+            "The following scenario(s) does not have a test file:"
+            f" {json.dumps(scenarios_without_test, indent=4)}")

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -76,15 +76,19 @@ class TemplatedTest(object):
                  expected_issues, sub_root):
         self.sub_root = sub_root
         self.target_path = target_path
-        if not os.path.exists(os.path.join(DEFS_DIR,
-                                           self.sub_root,
-                                           self.target_path)):
-            raise FileNotFoundError(f"Scenario file {self.target_path}"
+
+        if not os.path.exists(self.target_scenario_path):
+            raise FileNotFoundError("Scenario file "
+                                    f"{self.target_scenario_path}"
                                     " not found!")
         self.data_root = data_root
         self.mocks = mocks
         self.expected_bugs = expected_bugs
         self.expected_issues = expected_issues
+
+    @property
+    def target_scenario_path(self):
+        return os.path.join(DEFS_DIR, self.sub_root, self.target_path)
 
     def check_raised_bugs(self, test_inst, expected, actual):
         """
@@ -226,6 +230,7 @@ class TemplatedTestGenerator(object):
     @property
     def target_path(self):
         """ Target path with filename replaced with target-name if provided."""
+
         if self.testdef.get('target-name'):
             return os.path.join(os.path.dirname(self.test_sub_path),
                                 self.testdef.get('target-name'))
@@ -240,7 +245,7 @@ class TemplatedTestGenerator(object):
         chars_to_replace = ('/', '.')
         for char in chars_to_replace:
             name = name.replace(char, replace_char)
-        return 'test_{}'.format(name)
+        return 'test_yscenario_{}'.format(name)
 
     def _generate(self):
         """ Generate a test from a template. """


### PR DESCRIPTION
Each scenario should have at least one test file, but we had no way
of checking that. This patch introduces a new test case named
`test_scenarios_check_mapping` that discovers all scenario tests and
the scenarios, then finds out which scenarios doesn't have a test case.
The test case also verifies that every scenario has the `checks` and
`conclusions` sections as well.
  
Added `test_yscenario_` to the test cases generated from YAML files to
be able to distinguish them in a test run._