### PR TITLE
tests/storage/ceph-rgw: add missing ceph-rgw templated test loader

### DIFF
--- a/hotsos/defs/tests/scenarios/openstack/neutron/bugs/lp1980211_log_error_pkg_no_bug_neutron_ovn_meta.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/neutron/bugs/lp1980211_log_error_pkg_no_bug_neutron_ovn_meta.yaml
@@ -20,4 +20,3 @@ raised-issues:
     python3-openvswitch version 2.17.2 which contains a fix for the bug.
     Please ensure that the agent has been restarted since the package was
     upgraded.
-

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-rgw/rgw_frontend_conf.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-rgw/rgw_frontend_conf.yaml
@@ -1,4 +1,4 @@
-target-name: rgw_frontend.yaml
+target-name: rgw_frontend_rgw.yaml
 data-root:
   files:
     sos_commands/dpkg/dpkg_-l: |

--- a/tests/unit/storage/test_ceph_rgw.py
+++ b/tests/unit/storage/test_ceph_rgw.py
@@ -1,0 +1,21 @@
+
+from hotsos.core.config import HotSOSConfig
+
+from .. import utils
+
+
+class StorageCephRGWTestsBase(utils.BaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        HotSOSConfig.plugin_name = 'storage'
+
+
+@utils.load_templated_tests('scenarios/storage/ceph/ceph-rgw')
+class TestCephRGWScenarios(StorageCephRGWTestsBase):
+    """
+    Scenario tests can be written using YAML templates that are auto-loaded
+    into this test runner. This is the recommended way to write tests for
+    scenarios. It is however still possible to write the tests in Python if
+    required. See defs/tests/README.md for more info.
+    """


### PR DESCRIPTION
the YAML test scenarios under tests/scenarios/storage/ceph/ceph-rgw were not being load due to missing test file and test loader directive. added `test_ceph_rgw.py` to correct that.

fixed incorrect target-name for `rgw_frontend_conf.yaml`.

removed a redundant line from `lp1980211_log_error_pkg_no_bug_neutron_ovn_meta.yaml`