### PR TITLE
Use /etc/openstack-release if available

### DIFF
--- a/hotsos/core/plugins/openstack/common.py
+++ b/hotsos/core/plugins/openstack/common.py
@@ -91,8 +91,14 @@ class OpenstackBase(object):
             # scenario check.
             return relnames[0]
 
-        relname = 'unknown'
+        relpath = os.path.join(HotSOSConfig.data_root,
+                               'etc/openstack-release')
+        # this exists as of Jammy/Yoga
+        if os.path.exists(relpath):
+            with open(relpath) as fd:
+                return fd.read().partition('=')[2]
 
+        relname = 'unknown'
         # fallback to uca version if exists
         if not os.path.exists(self.apt_source_path):
             return relname

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -339,6 +339,13 @@ class TestOpenstackPluginCore(TestOpenstackBase):
         base = openstack_core.OpenstackChecksBase()
         self.assertEqual(base.release_name, 'ussuri')
 
+    @utils.create_data_root({'etc/openstack-release':
+                             'OPENSTACK_CODENAME=yoga'})
+    def test_release_name_from_file(self):
+        base = openstack_core.OpenstackChecksBase()
+        with mock.patch.object(base, 'installed_pkg_release_names', None):
+            self.assertEqual(base.release_name, 'yoga')
+
     @mock.patch('hotsos.core.host_helpers.cli.DateFileCmd.format_date')
     def test_get_release_eol(self, mock_date):
         # 2030-04-30


### PR DESCRIPTION
Ubuntu Jammy/Yoga and above has /etc/openstack-release containing the installed release name so use that as a fallback before trying UCA.