### PR TITLE
ycheck/requires/types/apt: decouple version range utilities from APT

### DIFF
--- a/hotsos/core/ycheck/engine/properties/requires/types/apt.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/apt.py
@@ -26,150 +26,6 @@ class APTCheckItems(PackageCheckItemsBase):
 
         return _versions
 
-    def normalize_version_criteria(self, version_criteria):
-        """Normalize all the criterions in a criteria.
-
-        Normalization does the following:
-        - removes empty criteria
-        - replaces old ops with the new ones
-        - sorts each criterion(ascending) and criteria(descending)
-        - adds upper/lower bounds to criteria, where needed
-
-        @param version_criteria: List of version ranges to normalize
-        @return: Normalized list of version ranges
-        """
-
-        # Step 0: Ensure that all version values are DPKGVersion type
-        for idx, version_criterion in enumerate(version_criteria):
-            for k, v in version_criterion.items():
-                version_criterion.update({k: DPKGVersion(v)})
-
-        # Step 1: Remove empty criteria
-        version_criteria = [x for x in version_criteria if len(x) > 0]
-
-        # Step 2: Replace legacy ops with the new ones
-        legacy_ops = {"min": "ge", "max": "le"}
-        for idx, version_criterion in enumerate(version_criteria):
-            for lop, nop in legacy_ops.items():
-                if lop in version_criterion:
-                    version_criterion[nop] = version_criterion[lop]
-                    del version_criterion[lop]
-
-        # Step 3: Sort each criterion in itself, so the smallest version
-        # appears first
-        for idx, version_criterion in enumerate(version_criteria):
-            version_criterion = dict(sorted(version_criterion.items(),
-                                     key=lambda a: a[1]))
-            version_criteria[idx] = version_criterion
-
-        # Step 4: Sort all criteria by the first element in the criterion
-        version_criteria = sorted(version_criteria,
-                                  key=lambda a: list(a.values())[0])
-
-        # Step 5: Add the implicit upper/lower bounds where needed
-        lower_bound_ops = ["gt", "ge", "eq"]  # ops that define a lower bound
-        upper_bound_ops = ["lt", "le", "eq"]  # ops that define an upper bound
-        equal_compr_ops = ["eq", "ge", "le"]  # ops that compare for equality
-        for idx, version_criterion in enumerate(version_criteria):
-            log.debug("\tchecking criterion %s", str(version_criterion))
-
-            has_lower_bound = any(x in lower_bound_ops
-                                  for x in version_criterion)
-            has_upper_bound = any(x in upper_bound_ops
-                                  for x in version_criterion)
-            is_the_last_item = idx == (len(version_criteria) - 1)
-            is_the_first_item = idx == 0
-
-            log.debug("\t\tcriterion %s has lower bound?"
-                      "%s has upper bound? %s", str(version_criterion),
-                      has_lower_bound, has_upper_bound)
-
-            if not has_upper_bound and not is_the_last_item:
-                op = "le"  # default
-                next_criterion = version_criteria[idx + 1]
-                next_op, next_val = list(next_criterion.items())[0]
-                # If the next criterion op compares for equality, then the
-                # implicit op added to this criterion should not compare for
-                # equality.
-                if next_op in equal_compr_ops:
-                    op = "lt"
-                log.debug("\t\tadding implicit upper bound %s:%s to %s", op,
-                          next_val, version_criterion)
-                version_criterion[op] = next_val
-            elif not has_lower_bound and not is_the_first_item:
-                op = "ge"  # default
-                prev_criterion = version_criteria[idx - 1]
-                prev_op, prev_val = list(prev_criterion.items())[-1]
-                # If the previous criterion op compares for equality, then the
-                # implicit op added to this criterion should not compare for
-                # equality.
-                if prev_op in equal_compr_ops:
-                    op = "gt"
-                log.debug("\t\tadding implicit lower bound %s:%s to %s", op,
-                          prev_val, version_criterion)
-                version_criterion[op] = prev_val
-
-            # Re-sort and overwrite the criterion
-            version_criteria[idx] = dict(
-                sorted(version_criterion.items(),
-                       key=lambda a: a[1]))
-
-        # Step 6: Sort by descending order so the largest version range
-        # appears first
-        version_criteria = sorted(version_criteria,
-                                  key=lambda a: list(a.values())[0],
-                                  reverse=True)
-
-        log.debug("final criteria: %s", str(version_criteria))
-        return version_criteria
-
-    def package_version_within_ranges(self, pkg, version_criteria):
-        """Check if pkg's version satisfies any criterion listed in
-        the version_criteria.
-
-        @param pkg: The name of the apt package
-        @param version_criteria: List of version ranges to normalize
-
-        @return: True if ver(pkg) satisfies any criterion, false otherwise.
-        """
-        result = True
-        pkg_version = self.packaging_helper.get_version(pkg)
-
-        # Supported operations for defining version ranges
-        ops = {
-            "eq": lambda lhs, rhs: lhs == DPKGVersion(rhs),
-            "lt": lambda lhs, rhs: lhs < DPKGVersion(rhs),
-            "le": lambda lhs, rhs: lhs <= DPKGVersion(rhs),
-            "gt": lambda lhs, rhs: lhs > DPKGVersion(rhs),
-            "ge": lambda lhs, rhs: lhs >= DPKGVersion(rhs),
-            "min": lambda lhs, rhs: ops["ge"](lhs, rhs),
-            "max": lambda lhs, rhs: ops["le"](lhs, rhs),
-        }
-
-        version_criteria = self.normalize_version_criteria(version_criteria)
-
-        for version_criterion in version_criteria:
-            # Each criterion is evaluated on its own
-            # so if any of the criteria is true, then
-            # the check is also true.
-            for op_name, op_fn in ops.items():
-                if op_name in version_criterion:
-                    version = str(version_criterion[op_name])
-                    # Check if the criterion is satisfied or not
-                    if not op_fn(str(pkg_version), version):
-                        break
-            else:
-                # Loop is not exited by a break which means
-                # all ops in the criterion are satisfied.
-                result = True
-                # Break the outer loop
-                break
-            result = False
-
-        log.debug("package %s=%s within version ranges %s (result=%s)", pkg,
-                  pkg_version, version_criteria, result)
-        return result
-
 
 class YRequirementTypeAPT(YRequirementTypeBase):
     """ Provides logic to perform checks on APT packages. """
@@ -188,7 +44,9 @@ class YRequirementTypeAPT(YRequirementTypeBase):
                 log.debug("package %s installed=%s", pkg, _result)
                 if not versions:
                     continue
-                _result = items.package_version_within_ranges(pkg, versions)
+                pkg_version = items.packaging_helper.get_version(pkg)
+                _result = DPKGVersion.is_version_within_ranges(pkg_version,
+                                                               versions)
                 # bail at first failure
                 if not _result:
                     break

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -4,6 +4,10 @@ from unittest import mock
 
 from hotsos.core.config import HotSOSConfig
 from hotsos.core import host_helpers
+from hotsos.core.host_helpers.packaging import (
+    DPKGVersion,
+    DPKGBadVersionSyntax
+)
 from hotsos.core.host_helpers.config import ConfigBase
 from hotsos.core.host_helpers.filestat import FileFactory
 
@@ -678,3 +682,333 @@ class TestApparmorHelper(utils.BaseTestCase):
                           'virt-aa-helper')
         self.assertEqual(profile.name, 'virt-aa-helper')
         self.assertEqual(profile.mode, 'enforce')
+
+
+class TestDPKGVersion(utils.BaseTestCase):
+
+    def test_dpkg_normalize_string_repr(self):
+        data = [
+            {"ge": "8.9"}, {"lt": "4"}, {"ge": "6.3", "lt": "7.2"}
+        ]
+
+        self.assertEqual(repr(DPKGVersion.normalize_version_criteria(data)),
+                         "[{'ge': 8.9}, {'ge': 6.3, 'lt': 7.2}, {'lt': 4}]")
+
+    def test_dpkg_version_comparison(self):
+        data = [
+             {"gt": '1.2~1'}, {"gt": '1.2~2'}, {"gt": '1.2'}
+        ]
+
+        result = DPKGVersion.normalize_version_criteria(data)
+        expected = [
+            {'gt': '1.2'},
+            {'gt': '1.2~2', 'le': '1.2'},
+            {'gt': '1.2~1', 'le': '1.2~2'}
+        ]
+        self.assertEqual(result, expected)
+
+    def test_dpkg_version_normalize_00(self):
+        for elem in ['eq', 'ge', 'gt', 'le', 'lt', 'min', 'max']:
+            data = [
+                {
+                    elem: '1'
+                }
+            ]
+            result = DPKGVersion.normalize_version_criteria(data)
+            self.assertEqual(result, data)
+
+    def test_dpkg_version_normalize_01(self):
+        for elem_a in ['eq', 'ge', 'gt', 'le', 'lt']:
+            for elem_b in ['eq', 'ge', 'gt', 'le', 'lt']:
+                if elem_a.startswith(elem_b[0]):
+                    continue
+                data = [
+                    {
+                        elem_a: '3', elem_b: '4'
+                    },
+                    {
+                        elem_a: '1', elem_b: '2'
+                    },
+                ]
+                result = DPKGVersion.normalize_version_criteria(data)
+                self.assertEqual(result, data)
+
+    def test_dpkg_version_normalize_02(self):
+        data = [
+            {'gt': '1'}, {'gt': '2'}, {'lt': '4'}
+        ]
+        result = DPKGVersion.normalize_version_criteria(data)
+        expected = [
+            {'lt': '4', 'gt': '4'},
+            {'gt': '2', 'le': '4'},
+            {'gt': '1', 'le': '2'}
+        ]
+        self.assertEqual(result, expected)
+
+    def test_dpkg_version_normalize_03(self):
+        data = [
+            {'gt': '1', 'lt': '2'}, {'gt': '3'}, {'gt': '4'}
+        ]
+        result = DPKGVersion.normalize_version_criteria(data)
+        expected = [
+            {'gt': '4'},
+            {'gt': '3', 'le': '4'},
+            {'gt': '1', 'lt': '2'}
+        ]
+        self.assertEqual(result, expected)
+
+    def test_dpkg_version_normalize_04(self):
+        data = [
+            {'gt': '1', 'lt': '2'}, {'gt': '3', 'lt': '4'}, {'gt': '4'}
+        ]
+        result = DPKGVersion.normalize_version_criteria(data)
+        expected = [
+            {'gt': '4'},
+            {'gt': '3', 'lt': '4'},
+            {'gt': '1', 'lt': '2'}
+        ]
+        self.assertEqual(result, expected)
+
+    def test_dpkg_version_normalize_05(self):
+        data = [
+            {'gt': '1'}, {'gt': '3', 'lt': '4'}, {'gt': '4'}
+        ]
+        result = DPKGVersion.normalize_version_criteria(data)
+        expected = [
+            {'gt': '4'},
+            {'gt': '3', 'lt': '4'},
+            {'gt': '1', 'le': '3'}
+        ]
+        self.assertEqual(result, expected)
+
+    def test_dpkg_version_normalize_06(self):
+        data = [
+            {'lt': '2'}, {'lt': '3'}, {'lt': '4'}
+        ]
+        result = DPKGVersion.normalize_version_criteria(data)
+        expected = [
+            {'ge': '3', 'lt': '4'},
+            {'lt': '2'},
+            {'ge': '2', 'lt': '3'},
+        ]
+        self.assertEqual(result, expected)
+
+    def test_dpkg_version_normalize_07(self):
+        data = [
+            {'min': '2', 'max': '3'}
+        ]
+        result = DPKGVersion.normalize_version_criteria(data)
+        expected = [
+            {'ge': '2', 'le': '3'}
+        ]
+        self.assertEqual(result, expected)
+
+    def test_dpkg_version_pkgver_bad_version(self):
+        with self.assertRaises(DPKGBadVersionSyntax):
+            DPKGVersion.is_version_within_ranges(
+                '1:8.2p1-4ubuntu0.4',
+                [{'lt': 'immabadversion'}]
+            )
+
+    def test_dpkg_version_pkgver_lt_false(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'lt': '1:8.2p1-4ubuntu0.4'}]
+        )
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_lt_true(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'lt': '1:8.2p1-4ubuntu0.5'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_le_false(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'le': '1:8.2p1-4ubuntu0.3'}]
+        )
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_le_true_eq(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'le': '1:8.2p1-4ubuntu0.4'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_le_true_less(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'le': '1:8.2p1-4ubuntu0.4'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_gt_false(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'gt': '1:8.2p1-4ubuntu0.5'}]
+        )
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_gt_true(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'gt': '1:8.2p1-4ubuntu0.3'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_ge_false(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'ge': '1:8.2p1-4ubuntu0.5'}]
+        )
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_ge_true_eq(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'ge': '1:8.2p1-4ubuntu0.4'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_ge_true_greater(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'ge': '1:8.2p1-4ubuntu0.3'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_is_equal_true(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'eq': '1:8.2p1-4ubuntu0.4'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_is_equal_false(self):
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'eq': '1:8.2p1-4ubuntu0.3'}]
+        )
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_within_ranges_true(self):
+        result = DPKGVersion.is_version_within_ranges('1:8.2p1-4ubuntu0.4',
+                                                      [{'min': '1:8.2',
+                                                        'max': '1:8.3'}])
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_within_ranges_false(self):
+        result = DPKGVersion.is_version_within_ranges('1:8.2p1-4ubuntu0.4',
+                                                      [{'min': '1:8.2',
+                                                        'max': '1:8.2'}])
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_within_ranges_multi(self):
+        result = DPKGVersion.is_version_within_ranges('1:8.2p1-4ubuntu0.4',
+                                                      [{'min': '1:8.0',
+                                                        'max': '1:8.1'},
+                                                       {'min': '1:8.2',
+                                                        'max': '1:8.3'}])
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_within_ranges_no_max_true(self):
+        result = DPKGVersion.is_version_within_ranges('1:8.2p1-4ubuntu0.4',
+                                                      [{'min': '1:8.0'},
+                                                       {'min': '1:8.1'},
+                                                       {'min': '1:8.2'},
+                                                       {'min': '1:8.3'}])
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_within_ranges_no_max_false(self):
+        result = DPKGVersion.is_version_within_ranges('1:8.2p1-4ubuntu0.4',
+                                                      [{'min': '1:8.3'},
+                                                       {'min': '1:8.4'},
+                                                       {'min': '1:8.5'}])
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_within_ranges_mixed_true(self):
+        result = DPKGVersion.is_version_within_ranges('1:8.2p1-4ubuntu0.4',
+                                                      [{'min': '1:8.0'},
+                                                       {'min': '1:8.1',
+                                                        'max': '1:8.1.1'},
+                                                       {'min': '1:8.2'},
+                                                       {'min': '1:8.3'}])
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_within_ranges_mixed_false(self):
+        result = DPKGVersion.is_version_within_ranges('1:8.2p1-4ubuntu0.4',
+                                                      [{'min': '1:8.0'},
+                                                       {'min': '1:8.1',
+                                                        'max': '1:8.1.1'},
+                                                       {'min': '1:8.2',
+                                                        'max': '1:8.2'},
+                                                       {'min': '1:8.3'}])
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_within_ranges_mixed_lg_false(self):
+        # 1:8.2p1-4ubuntu0.4
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'gt': '1:8.2p1-4ubuntu0.4'},
+             {'gt': '1:8.1',
+              'lt': '1:8.1.1'},
+             {'gt': '1:8.2',
+              'lt': '1:8.2'},
+             {'gt': '1:8.3'}]
+        )
+        self.assertFalse(result)
+
+    def test_dpkg_version_pkgver_within_ranges_mixed_lg_true(self):
+        # 1:8.2p1-4ubuntu0.4
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'gt': '1:8.2p1-4ubuntu0.4'},
+             {'gt': '1:8.1',
+              'lt': '1:8.1.1'},
+             {'gt': '1:8.2p1-4ubuntu0.3',
+              'lt': '1:8.2p1-4ubuntu0.5'},
+             {'gt': '1:8.3'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_within_ranges_first_true(self):
+        # 1:8.2p1-4ubuntu0.4
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'ge': '1:8.2p1-4ubuntu0.4'},
+             {'gt': '1:8.1',
+              'lt': '1:8.1.1'},
+             {'gt': '1:8.2p1-4ubuntu0.3',
+              'lt': '1:8.2p1-4ubuntu0.5'},
+             {'gt': '1:8.3'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_within_ranges_mid_true(self):
+        # 1:8.2p1-4ubuntu0.4
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'gt': '1:8.2p1-4ubuntu0.4'},
+             {'gt': '1:8.1',
+              'le': '1:8.2p1-4ubuntu0.4'},
+             {'gt': '1:8.2p1-4ubuntu0.6',
+              'lt': '1:8.2p1-4ubuntu0.9'},
+             {'gt': '1:8.3'}]
+        )
+        self.assertTrue(result)
+
+    def test_dpkg_version_pkgver_within_ranges_last_true(self):
+        # 1:8.2p1-4ubuntu0.4
+        result = DPKGVersion.is_version_within_ranges(
+            '1:8.2p1-4ubuntu0.4',
+            [{'gt': '1:8.2p1-4ubuntu0.4'},
+             {'gt': '1:8.1',
+              'le': '1:8.2p1-4ubuntu0.4'},
+             {'gt': '1:8.2p1-4ubuntu0.6',
+              'lt': '1:8.2p1-4ubuntu0.9'},
+             {'eq': '1:8.2p1-4ubuntu0.4'}]
+        )
+        self.assertTrue(result)


### PR DESCRIPTION
The version range functions 'normalize_version_criteria' and 'is_version_within_ranges' are not exclusive to apt and could be used by other classes. This patch moves these two functions to host_helpers/packaging/DPKGVersion, along with the unit tests. Added new unit tests for requires/types/apt. Reflected the changes to requires/types/binary and its unit tests.

Added __repr__ class member fn to DPKGVersion to get a readable value when `print()` ing the DPKGVersion objects.

`package_version_within_ranges` is now called `is_version_with in_ranges` and it accepts a version instead of a package name.

BinCheckItems no longer inherits from APTCheckItems.