### PR TITLE
project: add code coverage report to tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = hotsos
+omit = tests/*
+
+[report]
+ignore_errors = True
+skip_empty = True
+precision = 2
+fail_under = 84

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist
 *.egg-info
 .repo-info
 doc/build
+cover/
+.coverage

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ stestr
 pylint==3.0.4
 rpdb
 yamllint==1.35.1
+coverage

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,17 @@ setenv = VIRTUAL_ENV={envdir}
          TESTS_DIR={[testenv]unit_tests}
          PYFILES={toxinidir}/setup.py {toxinidir}/hotsos/ {[testenv]unit_tests}
          non-utc-tz: TZ=EST+5
+         PYTHON=coverage run --source hotsos --parallel-mode
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-commands = stestr run --serial --test-path {[testenv]unit_tests} {posargs}
+commands =
+    coverage erase
+    stestr run --serial --test-path {[testenv]unit_tests} {posargs}
+    coverage combine
+    coverage report
+    coverage html -d cover
+    coverage xml -o cover/coverage.xml
 
 [testenv:pep8]
 allowlist_externals = flake8


### PR DESCRIPTION
This patch introduces `coverage`[1] to generate code coverage reports from hotsos's test runs. This includes the code and YAML scenario tests as the coverage captures everything in the test run.



<details>
<summary>Click here to see example tabular text output</summary>

```
Name                                                              Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------------------------------
hotsos/__init__.py                                                    0      0      0      0   100%
hotsos/cli.py                                                       189    117    135     10    32%
hotsos/client.py                                                    167     75     86     12    53%
hotsos/core/__init__.py                                               0      0      0      0   100%
hotsos/core/analytics.py                                            130      5     72      7    94%
hotsos/core/config.py                                                98      5     34      3    94%
hotsos/core/exceptions.py                                             2      0      0      0   100%
hotsos/core/factory.py                                                4      0      2      0   100%
hotsos/core/host_helpers/__init__.py                                 10      0      0      0   100%
hotsos/core/host_helpers/apparmor.py                                 50      2     28      4    92%
hotsos/core/host_helpers/cli.py                                     477     38    186     14    91%
hotsos/core/host_helpers/common.py                                   54      5     44      2    93%
hotsos/core/host_helpers/config.py                                  108      5     70      2    95%
hotsos/core/host_helpers/filestat.py                                 31      0     12      0   100%
hotsos/core/host_helpers/network.py                                 235     11    126      6    94%
hotsos/core/host_helpers/packaging.py                               281     51    134     18    78%
hotsos/core/host_helpers/pebble.py                                   56      2     28      2    95%
hotsos/core/host_helpers/ssl.py                                      40      4     10      1    90%
hotsos/core/host_helpers/sysctl.py                                   53      0     26      0   100%
hotsos/core/host_helpers/systemd.py                                 218     13    135     12    93%
hotsos/core/host_helpers/uptime.py                                   64      8     30      5    82%
hotsos/core/issues/__init__.py                                        2      0      0      0   100%
hotsos/core/issues/issue_types.py                                   128      2     34      0    99%
hotsos/core/issues/utils.py                                         121     10     62      5    91%
hotsos/core/log.py                                                   45      7     16      2    85%
hotsos/core/plugins/__init__.py                                       0      0      0      0   100%
hotsos/core/plugins/juju/__init__.py                                  2      0      0      0   100%
hotsos/core/plugins/juju/common.py                                   17      0      2      0   100%
hotsos/core/plugins/juju/resources.py                               158     17     90     15    85%
hotsos/core/plugins/kernel/__init__.py                                3      0      0      0   100%
hotsos/core/plugins/kernel/common.py                                 38      2     22      3    92%
hotsos/core/plugins/kernel/config.py                                 34      4     14      3    85%
hotsos/core/plugins/kernel/kernlog/__init__.py                        2      0      0      0   100%
hotsos/core/plugins/kernel/kernlog/calltrace.py                     272     26    140      2    89%
hotsos/core/plugins/kernel/kernlog/common.py                         46      1     30      1    97%
hotsos/core/plugins/kernel/kernlog/events.py                         36      0     23      1    98%
hotsos/core/plugins/kernel/memory.py                                206     15    136     11    91%
hotsos/core/plugins/kernel/net.py                                   286     15    166     12    94%
hotsos/core/plugins/kernel/sysfs.py                                  52      5     34      7    86%
hotsos/core/plugins/kubernetes.py                                    54      6     24      2    85%
hotsos/core/plugins/lxd/__init__.py                                   1      0      0      0   100%
hotsos/core/plugins/lxd/common.py                                    35      3     16      0    90%
hotsos/core/plugins/maas.py                                          23      4      6      0    79%
hotsos/core/plugins/mysql.py                                         29      1      4      0    97%
hotsos/core/plugins/openstack/__init__.py                             2      0      0      0   100%
hotsos/core/plugins/openstack/common.py                             171     25    103     13    84%
hotsos/core/plugins/openstack/exceptions.py                          24      0      0      0   100%
hotsos/core/plugins/openstack/neutron.py                             87      2     44      7    93%
hotsos/core/plugins/openstack/nova.py                               238     13    122     19    91%
hotsos/core/plugins/openstack/octavia.py                             35     19     20      1    42%
hotsos/core/plugins/openstack/openstack.py                          129      4     46      1    96%
hotsos/core/plugins/openvswitch/__init__.py                           2      0      0      0   100%
hotsos/core/plugins/openvswitch/common.py                            34      1      8      2    93%
hotsos/core/plugins/openvswitch/ovn.py                              128     70     82      4    46%
hotsos/core/plugins/openvswitch/ovs.py                              146      2     78      8    96%
hotsos/core/plugins/pacemaker.py                                     37      3     16      2    91%
hotsos/core/plugins/rabbitmq/__init__.py                              2      0      0      0   100%
hotsos/core/plugins/rabbitmq/common.py                               22      1      4      1    92%
hotsos/core/plugins/rabbitmq/report.py                              152      5     98     10    93%
hotsos/core/plugins/sosreport.py                                     46      3     24      5    89%
hotsos/core/plugins/storage/__init__.py                               4      0      0      0   100%
hotsos/core/plugins/storage/bcache.py                               158     10     96     16    90%
hotsos/core/plugins/storage/ceph.py                                 734    105    486     56    83%
hotsos/core/plugins/system/__init__.py                                1      0      0      0   100%
hotsos/core/plugins/system/common.py                                  8      1      2      0    90%
hotsos/core/plugins/system/system.py                                124      8     76     11    90%
hotsos/core/plugins/vault.py                                         21      4      6      0    78%
hotsos/core/plugintools.py                                          251    104    118      4    56%
hotsos/core/root_manager.py                                          77     13     36      5    84%
hotsos/core/search.py                                                34      6     12      3    80%
hotsos/core/utils.py                                                 61      5     26      0    94%
hotsos/core/ycheck/__init__.py                                        1      0      0      0   100%
hotsos/core/ycheck/engine/__init__.py                                 2      0      0      0   100%
hotsos/core/ycheck/engine/common.py                                  57      1     34      2    97%
hotsos/core/ycheck/engine/properties/__init__.py                      4      0      0      0   100%
hotsos/core/ycheck/engine/properties/checks.py                      126      3     60      6    95%
hotsos/core/ycheck/engine/properties/common.py                      272     32    109     17    87%
hotsos/core/ycheck/engine/properties/conclusions.py                 151      1     64      3    98%
hotsos/core/ycheck/engine/properties/inputdef.py                     60      3     32      2    95%
hotsos/core/ycheck/engine/properties/requires/__init__.py             1      0      0      0   100%
hotsos/core/ycheck/engine/properties/requires/common.py             134      4     80      1    98%
hotsos/core/ycheck/engine/properties/requires/requires.py            51      2     20      3    93%
hotsos/core/ycheck/engine/properties/requires/types/__init__.py       0      0      0      0   100%
hotsos/core/ycheck/engine/properties/requires/types/apt.py           97      0     64      0   100%
hotsos/core/ycheck/engine/properties/requires/types/binary.py        38      2     20      1    95%
hotsos/core/ycheck/engine/properties/requires/types/config.py       149      8     70      5    94%
hotsos/core/ycheck/engine/properties/requires/types/path.py          26      0     12      0   100%
hotsos/core/ycheck/engine/properties/requires/types/pebble.py        47     23     24      1    46%
hotsos/core/ycheck/engine/properties/requires/types/property.py      18      0      8      0   100%
hotsos/core/ycheck/engine/properties/requires/types/snap.py          72      1     50      2    98%
hotsos/core/ycheck/engine/properties/requires/types/systemd.py       71      3     34      2    95%
hotsos/core/ycheck/engine/properties/requires/types/varops.py        23      0     10      0   100%
hotsos/core/ycheck/engine/properties/search.py                      259     19    137     11    91%
hotsos/core/ycheck/engine/properties/vardef.py                       24      7      8      2    66%
hotsos/core/ycheck/events.py                                        207     12    124     12    92%
hotsos/core/ycheck/scenarios.py                                      99      5     41      3    94%
hotsos/plugin_extensions/__init__.py                                  1      0      0      0   100%
hotsos/plugin_extensions/juju/__init__.py                             1      0      0      0   100%
hotsos/plugin_extensions/juju/summary.py                            101      8     48     11    86%
hotsos/plugin_extensions/kernel/__init__.py                           1      0      0      0   100%
hotsos/plugin_extensions/kernel/summary.py                           51      6     30     13    74%
hotsos/plugin_extensions/kubernetes/__init__.py                       1      0      0      0   100%
hotsos/plugin_extensions/kubernetes/summary.py                       30      4     18      5    77%
hotsos/plugin_extensions/lxd/__init__.py                              1      0      0      0   100%
hotsos/plugin_extensions/lxd/summary.py                              16      0      8      4    83%
hotsos/plugin_extensions/maas/__init__.py                             1      0      0      0   100%
hotsos/plugin_extensions/maas/summary.py                             12      1      6      1    89%
hotsos/plugin_extensions/mysql/__init__.py                            1      0      0      0   100%
hotsos/plugin_extensions/mysql/summary.py                            11      2      6      2    65%
hotsos/plugin_extensions/openstack/__init__.py                        2      0      0      0   100%
hotsos/plugin_extensions/openstack/agent/__init__.py                  0      0      0      0   100%
hotsos/plugin_extensions/openstack/agent/events.py                  246     48    100     15    74%
hotsos/plugin_extensions/openstack/agent/exceptions.py              149      6     83      8    94%
hotsos/plugin_extensions/openstack/nova_external_events.py           54      1     21      4    93%
hotsos/plugin_extensions/openstack/service_features.py               41      0     30      3    96%
hotsos/plugin_extensions/openstack/service_network_checks.py        121     17     86     14    82%
hotsos/plugin_extensions/openstack/summary.py                        27      3     14      3    85%
hotsos/plugin_extensions/openstack/vm_info.py                       103      6     52     16    86%
hotsos/plugin_extensions/openvswitch/__init__.py                      1      0      0      0   100%
hotsos/plugin_extensions/openvswitch/event_checks.py                174     23     88     17    82%
hotsos/plugin_extensions/openvswitch/summary.py                      66     13     36      8    77%
hotsos/plugin_extensions/pacemaker/__init__.py                        1      0      0      0   100%
hotsos/plugin_extensions/pacemaker/summary.py                        18      0     10      5    82%
hotsos/plugin_extensions/rabbitmq/__init__.py                         1      0      0      0   100%
hotsos/plugin_extensions/rabbitmq/summary.py                         46      3     28      3    89%
hotsos/plugin_extensions/sosreport/__init__.py                        1      0      0      0   100%
hotsos/plugin_extensions/sosreport/summary.py                        12      0      6      0   100%
hotsos/plugin_extensions/storage/__init__.py                          1      0      0      0   100%
hotsos/plugin_extensions/storage/bcache_summary.py                   13      0      6      1    95%
hotsos/plugin_extensions/storage/ceph_event_checks.py                74     20     29      5    65%
hotsos/plugin_extensions/storage/ceph_summary.py                     51      2     30      2    95%
hotsos/plugin_extensions/system/__init__.py                           1      0      0      0   100%
hotsos/plugin_extensions/system/checks.py                            90      2     38      3    96%
hotsos/plugin_extensions/system/summary.py                           36      1     16      7    85%
hotsos/plugin_extensions/vault/__init__.py                            1      0      0      0   100%
hotsos/plugin_extensions/vault/summary.py                            11      2      6      2    65%
---------------------------------------------------------------------------------------------------
TOTAL                                                             10143   1157   5276    555    86%
```
</details>

The HTML and XML outputs are available at the moment. Here is a snapshot that illustrates how HTML output looks like:

![image](https://github.com/canonical/hotsos/assets/4488312/e974e3f0-f9d8-43df-9976-d0c746a879d6)


How to view code coverage reports:

```bash
cd <hotsos-project-root-dir>
<your-browser-of-choice> cover/index.html
```




[1]: https://coverage.readthedocs.io/