### PR TITLE
hotsos/cli: replace deprecated importlib.resources.path with files()

### DIFF
--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -63,10 +63,9 @@ def get_repo_info():
             return fd.read().strip()
 
     # pypi
-    with resources.path('hotsos', '.repo-info') as repo_info:
-        if repo_info and os.path.exists(repo_info):
-            with open(repo_info) as fd:
-                return fd.read().strip()
+    repo_info = resources.files("hotsos").joinpath(".repo_info")
+    if repo_info.exists():
+        return repo_info.read_text().strip()
 
     try:
         out = subprocess.check_output(['git', '-C', get_hotsos_root(),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -86,13 +86,10 @@ class TestCLI(utils.BaseTestCase):
         self.assertEqual(repo_info, 'some version')
 
     def test_get_repo_info_pypi(self):
-        with tempfile.TemporaryDirectory() as workdir:
-            f_repo_info = os.path.join(workdir, 'repo-info')
-            with open(f_repo_info, 'w', encoding='utf-8') as fd:
-                fd.write('some version\n')
-
-            with mock.patch('importlib.resources.path') as path:
-                path.return_value.__enter__.return_value = f_repo_info
-                repo_info = hotsos.cli.get_repo_info()
+        with mock.patch("importlib.resources.files") as mock_files:
+            joinpath = mock_files.return_value.joinpath
+            joinpath_rv = joinpath.return_value
+            joinpath_rv.read_text.return_value = "some version"
+            repo_info = hotsos.cli.get_repo_info()
 
         self.assertEqual(repo_info, 'some version')


### PR DESCRIPTION
the said function is deprecated in python 3.12 and will be removed. the new equivalent function is files(). replaced resources.path() in hotsos/cli/get_repo_info with files() and also updated the unit test.