### PR TITLE
pylint: bump version to 3.1.0

### DIFF
--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -63,6 +63,10 @@ def get_repo_info():
             return fd.read().strip()
 
     # pypi
+    # NOTE: The pylint warning is suppressed for W4902 because the
+    # alternative (i.e. resources.files) is not available for python
+    # 3.8, which is a supported environment for hotsos.
+    # pylint: disable-next=W4902
     with resources.path('hotsos', '.repo-info') as repo_info:
         if repo_info and os.path.exists(repo_info):
             with open(repo_info) as fd:
@@ -93,7 +97,7 @@ def get_defs_path():
     defs = os.path.join(get_hotsos_root(), 'defs')
     if not os.path.isdir(defs):
         # pypi
-        with resources.path('hotsos', 'defs') as path:
+        with resources.path('hotsos', 'defs') as path:  # pylint: disable=W4902
             defs = path
 
     if not os.path.isdir(defs):
@@ -112,6 +116,7 @@ def get_templates_path():
     templates = os.path.join(get_hotsos_root(), 'templates')
     if not os.path.isdir(templates):
         # pypi
+        # pylint: disable-next=W4902
         with resources.path('hotsos', 'templates') as path:
             templates = path
 

--- a/hotsos/core/plugins/kernel/kernlog/calltrace.py
+++ b/hotsos/core/plugins/kernel/kernlog/calltrace.py
@@ -125,8 +125,7 @@ class GenericTraceType(TraceTypeBase):
         return len(self.generics)
 
     def __iter__(self):
-        for generics in self.generics:
-            yield generics
+        yield from self.generics
 
 
 class MemFieldsBase(object):
@@ -256,8 +255,7 @@ class BcacheDeadlockType(TraceTypeBase):
         return len(self.deadlocks)
 
     def __iter__(self):
-        for deadlocks in self.deadlocks:
-            yield deadlocks
+        yield from self.deadlocks
 
 
 class FanotifyDeadlockType(TraceTypeBase):
@@ -304,8 +302,7 @@ class FanotifyDeadlockType(TraceTypeBase):
         return len(self.fanotify_hangs)
 
     def __iter__(self):
-        for fanotify_hangs in self.fanotify_hangs:
-            yield fanotify_hangs
+        yield from self.fanotify_hangs
 
 
 class OOMKillerTraceType(TraceTypeBase):
@@ -400,8 +397,7 @@ class OOMKillerTraceType(TraceTypeBase):
         return len(self.oom_traces)
 
     def __iter__(self):
-        for oom_trace in self.oom_traces:
-            yield oom_trace
+        yield from self.oom_traces
 
 
 class HungtaskTraceType(TraceTypeBase):
@@ -447,8 +443,7 @@ class HungtaskTraceType(TraceTypeBase):
         return len(self.hungtasks)
 
     def __iter__(self):
-        for hungtasks in self.hungtasks:
-            yield hungtasks
+        yield from self.hungtasks
 
 
 class CallTraceManager(KernLogBase):

--- a/hotsos/core/ycheck/engine/properties/requires/common.py
+++ b/hotsos/core/ycheck/engine/properties/requires/common.py
@@ -46,8 +46,7 @@ class CheckItemsBase(abc.ABC):
             self._items = {raw: None}
 
     def __iter__(self):
-        for item in self._items.items():
-            yield item
+        yield from self._items.items()
 
 
 class PackageCheckItemsBase(CheckItemsBase):

--- a/hotsos/plugin_extensions/storage/ceph_event_checks.py
+++ b/hotsos/plugin_extensions/storage/ceph_event_checks.py
@@ -79,8 +79,7 @@ class EventCallbackCRCErrors(CephEventCallbackBase):
 
             for osd, num_errs in osds.items():
                 if num_errs > 3:
-                    if num_errs > osd_err_max:
-                        osd_err_max = num_errs
+                    osd_err_max = max(osd_err_max, num_errs)
 
                     osds_in_err.add(osd)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ bashate
 flake8==6.0.0
 flake8-import-order==0.18.2
 stestr
-pylint==3.0.4
+pylint==3.1.0
 rpdb
 yamllint==1.35.1
 coverage

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -38,8 +38,7 @@ def find_all_templated_tests(path):
 
         defpath = os.path.join(path, testdef)
         if os.path.isdir(defpath):
-            for subpath in find_all_templated_tests(defpath):
-                yield subpath
+            yield from find_all_templated_tests(defpath)
         else:
             yield defpath
 


### PR DESCRIPTION
... to make it consistent with the `searchkit`. fixed the new warnings issued by the pylint.