### PR TITLE
Move coverage to its own tox section

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,9 @@ jobs:
     - name: Run pep8
       run: tox -e pep8
       if: matrix.python-version == '3.10'
+    - name: Run coverage
+      run: tox -e coverage
+      if: matrix.python-version == '3.10'
     - name: Run bashate
       run: tox -e bashate
       if: matrix.python-version == '3.10'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py3,pep8,pylint,bashate,yamllint,functional
+envlist = py3,coverage,pep8,pylint,bashate,yamllint,functional
 sitepackages = False
 minversion = 3.18.0
 
@@ -24,10 +24,6 @@ deps =
 commands =
     coverage erase
     stestr run --serial --test-path {[testenv]unit_tests} {posargs}
-    coverage combine
-    coverage report
-    coverage html -d cover
-    coverage xml -o cover/coverage.xml
 
 [testenv:pep8]
 allowlist_externals = flake8
@@ -69,3 +65,12 @@ commands = bash {toxinidir}/tools/test/functest.sh
 
 [testenv:docs]
 commands = sphinx-build -j auto -d {toxinidir}/doc/build/doctrees -b html {toxinidir}/doc/source doc/build/html
+
+[testenv:coverage]
+depends = py3
+commands =
+    coverage combine
+    coverage report
+    coverage html -d cover
+    coverage xml -o cover/coverage.xml
+


### PR DESCRIPTION
Running coverage every time stestr runs gives
unexpected results and errors especially when
running a single unit test. This moves coverage
to its own section in tox.ini and adds it to the
default list of commands to be run.