### PR TITLE
[tox/coverage] cleanup tmp directories from coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ sitepackages = False
 minversion = 3.18.0
 
 [testenv]
+allowlist_externals = rm
 basepython = {env:TOX_PYTHON:python3}
 unit_tests = {toxinidir}/tests/unit/
 passenv =
@@ -18,10 +19,12 @@ setenv = VIRTUAL_ENV={envdir}
          PYFILES={toxinidir}/setup.py {toxinidir}/hotsos/ {[testenv]unit_tests}
          non-utc-tz: TZ=EST+5
          PYTHON=coverage run --source hotsos --parallel-mode
+         HOSTNAME=hostname
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands =
+    rm -rf {toxinidir}/.coverage.{env:HOSTNAME}.*
     coverage erase
     stestr run --serial --test-path {[testenv]unit_tests} {posargs}
 


### PR DESCRIPTION
Coverage leaves the tp dirs behind if tox run is interruped.