### PR TITLE
Fix the way coverage is run

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 source = hotsos
+parallel = True
 omit = tests/*
 
 [report]

--- a/tox.ini
+++ b/tox.ini
@@ -17,12 +17,10 @@ setenv =
     PYTHONHASHSEED=0
     TESTS_DIR={[testenv]unit_tests}
     non-utc-tz: TZ=EST+5
-    PYTHON=coverage run --source hotsos --parallel-mode
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands =
-    coverage erase
     stestr run --serial --test-path {[testenv]unit_tests} {posargs}
 
 [testenv:pep8]
@@ -61,11 +59,16 @@ commands = sphinx-build -j auto -d {toxinidir}/doc/build/doctrees -b html {toxin
 
 [testenv:coverage]
 depends = py3
+setenv =
+    {[testenv]setenv}
+    PYTHON=coverage run
 commands =
+    stestr run --serial --test-path {[testenv]unit_tests} {posargs}
     coverage combine
     coverage report
     coverage html -d cover
     coverage xml -o cover/coverage.xml
+    coverage erase
 
 [testenv:hotyvalidate]
 setenv = PYTHONPATH={toxinidir}


### PR DESCRIPTION
Move all coverage commands into the 'coverage' section of tox.ini, else it will be run for every unit test run, for example, 'tox -e py3'.