### PR TITLE
Fix Openstack EOL check

### DIFF
--- a/hotsos/core/plugins/openstack/common.py
+++ b/hotsos/core/plugins/openstack/common.py
@@ -132,8 +132,9 @@ class OpenstackBase(object):
                 delta = (eol - today).days
                 return delta
 
-            log.warning("unable to determine eol info for unknown release "
-                        "name '%s'", self.release_name)
+        log.warning("unable to determine eol info for release "
+                    "name '%s' - assuming 0 days left", self.release_name)
+        return 0
 
     @property
     def bind_interfaces(self):

--- a/hotsos/defs/tests/scenarios/openstack/eol_rel_eol.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/eol_rel_eol.yaml
@@ -1,3 +1,4 @@
+target-name: eol.yaml
 data-root:
   files:
     sos_commands/date/date: 'Thu Apr 30 16:19:17 UTC 2030'

--- a/hotsos/defs/tests/scenarios/openstack/eol_rel_not_eol.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/eol_rel_not_eol.yaml
@@ -1,0 +1,8 @@
+target-name: eol.yaml
+data-root:
+  copy-from-original:
+    - sos_commands/dpkg/dpkg_-l
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+raised-issues:
+

--- a/hotsos/defs/tests/scenarios/openstack/eol_rel_not_known.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/eol_rel_not_known.yaml
@@ -1,0 +1,19 @@
+target-name: eol.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |-
+      ii  nova-api-metadata                    2:16.1.7-0ubuntu1~cloud3                                    all          OpenStack Compute - metadata API frontend
+      ii  nova-common                          2:16.1.7-0ubuntu1~cloud3                                    all          OpenStack Compute - common files
+      ii  nova-compute                         2:16.1.7-0ubuntu1~cloud3                                    all          OpenStack Compute - compute node base
+      ii  nova-compute-kvm                     2:16.1.7-0ubuntu1~cloud3                                    all          OpenStack Compute - compute node (KVM)
+      ii  nova-compute-libvirt                 2:16.1.7-0ubuntu1~cloud3                                    all          OpenStack Compute - compute node libvirt support
+      ii  python3-nova                         2:16.1.7-0ubuntu1~cloud3                                    all          OpenStack Compute Python 3 libraries
+  copy-from-original:
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+raised-issues:
+  OpenstackWarning: >-
+    This node is running a version of Openstack that is End of Life
+    (release=pike) which means it has limited support and is
+    likely not receiving updates anymore. Please consider upgrading
+    to a newer release.


### PR DESCRIPTION
If a release has no EOL info we assume it is
no longer supported. Adds more tests for the
eol scenario.

Resolves: #881