### PR TITLE
Remove need for module level global searcher

### DIFF
--- a/examples/hotsos-example-openstack.summary.yaml
+++ b/examples/hotsos-example-openstack.summary.yaml
@@ -201,11 +201,6 @@ openstack:
         live_migration_permit_post_copy: false
     api-ssl: false
   agent-checks:
-    neutron-l3ha:
-      keepalived:
-        transitions:
-          984c22fd-64b3-4fa1-8ddd-87090f401ce5:
-            '2022-02-10': 1
     neutron-l3-agent:
       router-updates:
         top:
@@ -281,6 +276,11 @@ openstack:
           stdev: 0.0
           avg: 0.0
           samples: 2500
+    neutron-l3ha:
+      keepalived:
+        transitions:
+          984c22fd-64b3-4fa1-8ddd-87090f401ce5:
+            '2022-02-10': 1
   bugs-detected:
     https://bugs.launchpad.net/bugs/2029952: This host is running neutron agents that
       use python3-oslo.privsep and the installed version (2.1.1-0ubuntu1) is impacted

--- a/hotsos/core/ycheck/engine/common.py
+++ b/hotsos/core/ycheck/engine/common.py
@@ -99,6 +99,10 @@ class YDefsLoader(object):
 
 class YHandlerBase(object):
 
+    def __init__(self, global_searcher, *args, **kwargs):
+        self.global_searcher = global_searcher
+        super().__init__(*args, **kwargs)
+
     @abc.abstractmethod
     def run(self):
         """ Process operations. """

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -6,6 +6,7 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core.plugins.storage import (
     ceph as ceph_core,
 )
+from hotsos.core.ycheck.common import GlobalSearcher
 from hotsos.plugin_extensions.storage import ceph_summary, ceph_event_checks
 
 from .. import utils
@@ -406,9 +407,10 @@ class TestCephMonEvents(CephMonTestsBase):
                   'long-heartbeat-pings': {'2022-02-09': 4},
                   'heartbeat-no-reply': {'2022-02-09': {'osd.0': 1,
                                                         'osd.1': 2}}}
-        inst = ceph_event_checks.CephEventHandler()
-        actual = self.part_output_to_actual(inst.output)
-        self.assertEqual(actual, result)
+        with GlobalSearcher() as searcher:
+            inst = ceph_event_checks.CephEventHandler(global_searcher=searcher)
+            actual = self.part_output_to_actual(inst.output)
+            self.assertEqual(actual, result)
 
 
 @utils.load_templated_tests('scenarios/storage/ceph/ceph-mon')

--- a/tests/unit/storage/test_ceph_osd.py
+++ b/tests/unit/storage/test_ceph_osd.py
@@ -5,7 +5,7 @@ from hotsos.core import host_helpers
 from hotsos.core.plugins.storage import (
     ceph as ceph_core,
 )
-from hotsos.core.ycheck.common import GLOBAL_SEARCH_REGISTRY
+from hotsos.core.ycheck.common import GlobalSearcher
 from hotsos.plugin_extensions.storage import (
     ceph_summary,
     ceph_event_checks,
@@ -214,13 +214,10 @@ class TestCephOSDEvents(StorageCephOSDTestsBase):
         result = {'crc-err-bluestore': {'2021-02-12': 5, '2021-02-13': 1},
                   'crc-err-rocksdb': {'2021-02-12': 7}}
 
-        # This is done in setUp but we have to repeat here otherwise the
-        # date() mock will not be used in the search constraints.
-        GLOBAL_SEARCH_REGISTRY.reset()
-
-        inst = ceph_event_checks.CephEventHandler()
-        actual = self.part_output_to_actual(inst.output)
-        self.assertEqual(actual, result)
+        with GlobalSearcher() as searcher:
+            inst = ceph_event_checks.CephEventHandler(global_searcher=searcher)
+            actual = self.part_output_to_actual(inst.output)
+            self.assertEqual(actual, result)
 
 
 @utils.load_templated_tests('scenarios/storage/ceph/ceph-osd')

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -7,6 +7,7 @@ from hotsos.core.host_helpers.systemd import SystemdService
 from hotsos.core.issues.utils import IssuesStore
 from hotsos.core.plugins.openvswitch import OpenvSwitchBase, OVSDB
 from hotsos.core.ycheck.scenarios import YScenarioChecker
+from hotsos.core.ycheck.common import GlobalSearcher
 from hotsos.plugin_extensions.openvswitch import (
     event_checks,
     summary,
@@ -269,8 +270,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                     {'2022-02-10': 3},
                 'bridge-no-such-device': {
                     '2022-02-10': {'tap6a0486f9-82': 1}}}}
-        inst = event_checks.OVSEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVSEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ovs-vswitchd.yaml',
@@ -284,8 +286,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
             'ovs-vswitchd': {
                 'assertion-failures':
                     {'2023-06-08': 2}}}
-        inst = event_checks.OVSEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVSEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('errors-and-warnings.yaml',
@@ -303,8 +306,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                         '2022-02-04': 6,
                         '2022-02-09': 2,
                         '2022-02-10': 4}}}}
-        inst = event_checks.OVSEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVSEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('errors-and-warnings.yaml',
@@ -319,8 +323,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                 'ovs-vswitchd': {
                     'EMER': {
                         '2023-06-08': 2}}}}
-        inst = event_checks.OVSEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVSEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('datapath-checks.yaml',
@@ -336,8 +341,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                             'RX': {
                                 'dropped': 1394875,
                                 'packets': 309}}}}
-        inst = event_checks.OVSEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVSEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ovn-central.yaml',
@@ -363,9 +369,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                             '2022-02-16': 2,
                             '2022-02-17': 1}
                     }}
-
-        inst = event_checks.OVNEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVNEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ovn-controller.yaml',
@@ -382,8 +388,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                         '2022-02-16':
                             {'provnet-aa3a4fec-a788-42e6-a773-bf3a0cdb52c2':
                              1}}}}
-        inst = event_checks.OVNEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVNEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('errors-and-warnings.yaml',
@@ -402,9 +409,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                         'ovsdb-server-sb': {
                             'ERR': {'2022-02-16': 2, '2022-02-17': 2},
                             'WARN': {'2022-02-16': 23, '2022-02-17': 23}}}}
-
-        inst = event_checks.OVNEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVNEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('bfd.yaml',
@@ -422,8 +429,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                                 '2022-07-27': {'ovn-abc-xb-0': 1,
                                                'ovn-abc-xa-2': 1,
                                                'ovn-abc-xa-15': 3}}}}}}
-        inst = event_checks.OVSEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVSEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ovn/ovn-central.yaml',
@@ -438,8 +446,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                                             '2022-07-27': 2}},
                     'ovsdb-server-sb': {'leadership-transfers': {
                                             '2022-07-27': 2}}}
-        inst = event_checks.OVNEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVNEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ovn/ovn-central.yaml',
@@ -450,8 +459,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
     def test_ovn_northd_leadership_changes(self):
         expected = {'ovn-northd': {'leadership-acquired': {
                                             '2023-12-13': 2}}}
-        inst = event_checks.OVNEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVNEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ovn/ovn-central.yaml',
@@ -466,8 +476,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                                             '2022-07-13': 3}},
                     'ovsdb-server-sb': {'compactions': {
                                             '2022-07-14': 3}}}
-        inst = event_checks.OVNEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVNEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
     @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
                 new=utils.is_def_filter('ovs/datapath-checks.yaml',
@@ -479,8 +490,9 @@ class TestOpenvswitchEvents(TestOpenvswitchBase):
                 'deferred-action-limit-reached': {
                     'ovs-system':
                         {'Mar 3': 7}}}}
-        inst = event_checks.OVSEventChecks()
-        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+        with GlobalSearcher() as searcher:
+            inst = event_checks.OVSEventChecks(searcher)
+            self.assertEqual(self.part_output_to_actual(inst.output), expected)
 
 
 @utils.load_templated_tests('scenarios/openvswitch')
@@ -511,7 +523,9 @@ class TestOpenvswitchScenarios(TestOpenvswitchBase):
                         self.processes[svc] = 1
 
         mock_systemd.side_effect = FakeSystemdHelper
-        YScenarioChecker().run()
+        with GlobalSearcher() as searcher:
+            YScenarioChecker(searcher).run()
+
         msg = ('The ovn-northd service on this ovn-central host is not '
                'active/running which means that changes made to the '
                'northbound database are not being ported to the southbound '
@@ -544,7 +558,9 @@ class TestOpenvswitchScenarios(TestOpenvswitchBase):
 
         with mock.patch(('hotsos.core.host_helpers.systemd.SystemdHelper.'
                          'services'), services):
-            YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                YScenarioChecker(searcher).run()
+
             issues = list(IssuesStore().load().values())
             self.assertEqual(len(issues), 0)
 
@@ -573,7 +589,9 @@ class TestOpenvswitchScenarios(TestOpenvswitchBase):
 
         with mock.patch(('hotsos.core.host_helpers.systemd.SystemdHelper.'
                          'services'), services):
-            YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                YScenarioChecker(searcher).run()
+
             msg = ("One or more of services ovn-northd, ovn-ovsdb-server-nb "
                    "and ovn-ovsdb-server-sb has not been restarted since ssl "
                    "certs were updated and this may breaking their ability to "
@@ -601,7 +619,9 @@ class TestOpenvswitchScenarios(TestOpenvswitchBase):
                     FakeSystemdService('ovn-controller', 'enabled')}
         with mock.patch(('hotsos.core.host_helpers.systemd.SystemdHelper.'
                          'services'), services):
-            YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                YScenarioChecker(searcher).run()
+
             issues = list(IssuesStore().load().values())
             self.assertEqual(len(issues), 0)
 
@@ -625,7 +645,9 @@ class TestOpenvswitchScenarios(TestOpenvswitchBase):
                     FakeSystemdService('ovn-controller', 'enabled')}
         with mock.patch(('hotsos.core.host_helpers.systemd.SystemdHelper.'
                          'services'), services):
-            YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                YScenarioChecker(searcher).run()
+
             msg = ("ovn-controller has not been restarted since ssl certs "
                    "were updated so may be using old certs. Please check.")
             issues = list(IssuesStore().load().values())[0]

--- a/tests/unit/test_ycheck_events.py
+++ b/tests/unit/test_ycheck_events.py
@@ -3,6 +3,7 @@ import os
 import yaml
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.ycheck.engine import YDefsSection
+from hotsos.core.ycheck.common import GlobalSearcher
 from hotsos.core.ycheck.events import (
     EventHandlerBase,
     EventCallbackBase,
@@ -183,7 +184,9 @@ class TestYamlEvents(utils.BaseTestCase):
             def event_group(self):
                 return 'mygroup'
 
-        MyEventHandler().run()
+        with GlobalSearcher() as searcher:
+            MyEventHandler(global_searcher=searcher).run()
+
         self.assertEqual(match_count['count'], 3)
         self.assertEqual(list(callbacks_called.keys()),
                          ['my-sequence-search',
@@ -204,7 +207,8 @@ class TestYamlEvents(utils.BaseTestCase):
                 return 'mygroup'
 
         with self.assertRaises(EventCallbackNotFound):
-            MyEventHandler().run()
+            with GlobalSearcher() as searcher:
+                MyEventHandler(global_searcher=searcher).run()
 
     @utils.create_data_root({'events/myplugin/mygroup.yaml': EVENT_DEF_SIMPLE,
                              'a/path': 'content'})
@@ -224,7 +228,9 @@ class TestYamlEvents(utils.BaseTestCase):
                     'event2': ('myplugin.mygroup.myeventgroup.myeventsubgroup.'
                                'event2')}}
 
-        handler = MyEventHandler()
+        with GlobalSearcher() as searcher:
+            handler = MyEventHandler(global_searcher=searcher)
+
         self.assertEqual(handler.events, defs)
         self.assertEqual(len(handler.searcher.catalog), 1)
 
@@ -245,7 +251,9 @@ class TestYamlEvents(utils.BaseTestCase):
         defs = {'myeventsubgroup': {
                     'event2': ('myplugin.mygroup.myeventgroup.myeventsubgroup.'
                                'event2')}}
-        handler = MyEventHandler()
+        with GlobalSearcher() as searcher:
+            handler = MyEventHandler(global_searcher=searcher)
+
         self.assertEqual(handler.events, defs)
         self.assertEqual(len(handler.searcher.catalog), 1)
 
@@ -263,7 +271,9 @@ class TestYamlEvents(utils.BaseTestCase):
                 return 'mygroup'
 
         defs = {}
-        handler = MyEventHandler()
+        with GlobalSearcher() as searcher:
+            handler = MyEventHandler(global_searcher=searcher)
+
         self.assertEqual(handler.events, defs)
         self.assertEqual(len(handler.searcher.catalog), 0)
 

--- a/tests/unit/test_ycheck_properties.py
+++ b/tests/unit/test_ycheck_properties.py
@@ -19,6 +19,7 @@ from hotsos.core.ycheck.engine.properties.common import (
     YPropertyBase,
     PropertyCacheRefResolver,
 )
+from hotsos.core.ycheck.common import GlobalSearcher
 from hotsos.core.ycheck.engine.properties.search import YPropertySearch
 from hotsos.core.ycheck.engine.properties.requires.types import (
     apt,
@@ -282,7 +283,9 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
             with open(tmpscenarios.path, 'w') as fd:
                 fd.write(scenario)
 
-            scenarios.YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                scenarios.YScenarioChecker(searcher).run()
+
             issues = list(IssuesStore().load().values())[0]
             self.assertEqual(issues[0]['message'], 'foo')
 
@@ -309,7 +312,9 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
             with open(tmpscenarios.path, 'w') as fd:
                 fd.write(scenario)
 
-            scenarios.YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                scenarios.YScenarioChecker(searcher).run()
+
             issues = list(IssuesStore().load().values())[0]
             self.assertEqual(issues[0]['message'], 'bar')
 
@@ -336,7 +341,9 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
             with open(tmpscenarios.path, 'w') as fd:
                 fd.write(scenario)
 
-            scenarios.YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                scenarios.YScenarioChecker(searcher).run()
+
             issues = list(IssuesStore().load().values())[0]
             self.assertEqual(issues[0]['message'], 'foo')
 
@@ -362,7 +369,9 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
             with open(tmpscenarios.path, 'w') as fd:
                 fd.write(scenario)
 
-            scenarios.YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                scenarios.YScenarioChecker(searcher).run()
+
             self.assertEqual(len(IssuesStore().load()), 0)
 
     @utils.create_data_root({'sos_commands/dpkg/dpkg_-l':
@@ -391,7 +400,9 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
             with open(tmpscenarios.path, 'w') as fd:
                 fd.write(scenario)
 
-            scenarios.YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                scenarios.YScenarioChecker(searcher).run()
+
             issues = list(IssuesStore().load().values())[0]
             self.assertEqual(issues[0]['message'], 'foo')
 
@@ -421,7 +432,9 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
             with open(tmpscenarios.path, 'w') as fd:
                 fd.write(scenario)
 
-            scenarios.YScenarioChecker().run()
+            with GlobalSearcher() as searcher:
+                scenarios.YScenarioChecker(searcher).run()
+
             issues = list(IssuesStore().load().values())[0]
             self.assertEqual(issues[0]['message'], 'snapd')
 


### PR DESCRIPTION
By allowing the event handlers in
plugin_extensions.openstack.agent.events we remove the final constraint that now allows using a context manager to manage a global searcher object that is shared across all parts in a plugin. This is now shared with all implementations of YHanlderBase i.e. events and scenarios. A future patch will enable pre-loading scenario searches into the global searcher.