### PR TITLE
requires/types/snap: add 'version' requirement type

### DIFF
--- a/doc/source/contrib/language_ref/property_ref/requirement_types.rst
+++ b/doc/source/contrib/language_ref/property_ref/requirement_types.rst
@@ -134,8 +134,9 @@ Cache keys:
 Snap
 ----
 
-Takes a snap package name and optional list of revision ranges. Returns True if
-the package exists and if provided, revision is within ranges.
+Takes a snap package name and optional list of revision, version and channel.
+The check returns True if the package is installed and at least one of the r/v/c
+combination evaluates to True.
 
 Usage:
 
@@ -143,27 +144,33 @@ Usage:
 
     snap: mypackage
 
-Or with revision ranges as follows:
+Or with optional conditions as follows:
 
 .. code-block:: yaml
 
     snap:
       mypackage:
-        - min: 1234
-          max: 2345
+        - revision:
+            min: 1234
+            max: 2345
           channel: 2.0/stable
-        - min: 3456
-          max: 4567
+        - version:
+            eq: 1.17
+        - channel: 3.0/beta
 
-In the above example *mypackage* must have a revision between *1234* and *2345*
-or 3456 and 4567 inclusive. If *mypackage* revision is between *1234* and
-*2345* it must also be from channel *2.0/stable*
+In the above example in order for snap requirement to be True, *mypackage* snap must be
+installed in the system and either one of the following conditions must be true:
+
+ * revision number is between *1234*-*2345* and the channel name is *2.0/stable*
+ * version number is *1.17*
+ * channel name is "3.0/beta"
 
 Cache keys:
 
   * channel - channel of each installed package
   * package - name of each installed package
   * revision - revision of each installed package
+  * version - version of each installed package
 
 Pebble
 ------

--- a/hotsos/core/host_helpers/packaging.py
+++ b/hotsos/core/host_helpers/packaging.py
@@ -156,8 +156,8 @@ class DPKGVersion(object):
         """Check if pkg's version satisfies any criterion listed in
         the version_criteria.
 
-        @param pkg: The name of the apt package
-        @param version_criteria: List of version ranges to normalize
+        @param version: Version
+        @param version_criteria: Criteria to check version against
 
         @return: True if ver(pkg) satisfies any criterion, false otherwise.
         """
@@ -178,6 +178,9 @@ class DPKGVersion(object):
             version_criteria)
 
         for version_criterion in version_criteria:
+            if not version_criterion.keys() <= ops.keys():
+                raise Exception("Unrecognized comparison operator name(s):"
+                                f"{version_criterion.keys()-ops.keys()}")
             # Each criterion is evaluated on its own
             # so if any of the criteria is true, then
             # the check is also true.

--- a/hotsos/core/ycheck/engine/properties/requires/common.py
+++ b/hotsos/core/ycheck/engine/properties/requires/common.py
@@ -65,12 +65,8 @@ class PackageCheckItemsBase(CheckItemsBase):
 
     @cached_property
     def installed(self):
-        _installed = []
-        for p in self.packages_to_check:
-            if self.packaging_helper.is_installed(p):
-                _installed.append(p)
-
-        return _installed
+        return [p for p in self.packages_to_check
+                if self.packaging_helper.is_installed(p)]
 
     @cached_property
     def not_installed(self):

--- a/hotsos/core/ycheck/engine/properties/requires/types/apt.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/apt.py
@@ -20,11 +20,7 @@ class APTCheckItems(PackageCheckItemsBase):
 
     @cached_property
     def installed_versions(self):
-        _versions = []
-        for p in self.installed:
-            _versions.append(self.packaging_helper.get_version(p))
-
-        return _versions
+        return [self.packaging_helper.get_version(p) for p in self.installed]
 
 
 class YRequirementTypeAPT(YRequirementTypeBase):

--- a/hotsos/defs/scenarios/juju/juju_pebble_cve.yaml
+++ b/hotsos/defs/scenarios/juju/juju_pebble_cve.yaml
@@ -2,8 +2,8 @@ checks:
   has_affected_pebble_snap:
     snap:
       pebble:
-        - min: 646
-          max: 646
+        - revision:
+            eq: 646
 conclusions:
   pebble_cve:
     decision: has_affected_pebble_snap

--- a/hotsos/defs/scenarios/lxd/lxcfs_deadlock.yaml
+++ b/hotsos/defs/scenarios/lxd/lxcfs_deadlock.yaml
@@ -10,8 +10,9 @@ checks:
   has_lxd_version_5_9:
     snap:
       lxd:
-        - min: 24096
-          max: 24180
+        - revision:
+            min: 24096
+            max: 24180
   fuse_out_of_threads_error:
     input:
       command: journalctl

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -1012,3 +1012,11 @@ class TestDPKGVersion(utils.BaseTestCase):
              {'eq': '1:8.2p1-4ubuntu0.4'}]
         )
         self.assertTrue(result)
+
+    def test_dpkg_version_invalid_op_name(self):
+        with self.assertRaises(Exception):
+            # 1:8.2p1-4ubuntu0.4
+            DPKGVersion.is_version_within_ranges(
+                '1:8.2p1-4ubuntu0.4',
+                [{'foo': '1:8.2p1-4ubuntu0.4'}]
+            )

--- a/tests/unit/test_ycheck_properties.py
+++ b/tests/unit/test_ycheck_properties.py
@@ -643,50 +643,116 @@ class TestYamlRequiresTypeSnap(utils.BaseTestCase):
 
     def test_snap_revision_within_ranges_no_channel_true(self):
         ci = snap.SnapCheckItems('core20')
-        result = ci.package_info_matches('core20', [{'min': '1327',
-                                                     'max': '1328'}])
+        result = ci.package_info_matches('core20', [
+          {
+            'revision': {'min': '1327',
+                         'max': '1328'}
+          }
+        ])
         self.assertTrue(result)
 
     def test_snap_revision_within_ranges_no_channel_false(self):
         ci = snap.SnapCheckItems('core20')
-        result = ci.package_info_matches('core20', [{'min': '1326',
-                                                     'max': '1327'}])
+        result = ci.package_info_matches('core20', [
+          {
+            'revision': {'min': '1326',
+                         'max': '1327'}
+          }
+        ])
         self.assertFalse(result)
 
     def test_snap_revision_within_ranges_channel_true(self):
         ci = snap.SnapCheckItems('core20')
-        result = ci.package_info_matches('core20',
-                                         [{'min': '1327',
-                                           'max': '1328',
-                                           'channel': 'latest/stable'}])
+        result = ci.package_info_matches('core20', [
+          {
+            'revision': {'min': '1327',
+                         'max': '1328'},
+            'channel': 'latest/stable'
+          }
+        ])
         self.assertTrue(result)
 
     def test_snap_revision_within_ranges_channel_false(self):
         ci = snap.SnapCheckItems('core20')
-        result = ci.package_info_matches('core20', [{'min': '1327',
-                                                     'max': '1328',
-                                                     'channel': 'foo'}])
+        result = ci.package_info_matches('core20', [
+          {
+            'revision': {'min': '1327',
+                         'max': '1328'},
+            'channel': 'foo'
+          }
+        ])
         self.assertFalse(result)
 
     def test_snap_revision_within_multi_ranges_channel_true(self):
         ci = snap.SnapCheckItems('core20')
-        result = ci.package_info_matches('core20', [{'min': '1326',
-                                                     'max': '1327',
-                                                     'channel': 'foo'},
-                                                    {'min': '1327',
-                                                     'max': '1328',
-                                                     'channel':
-                                                     'latest/stable'},
-                                                    {'min': '1329',
-                                                     'max': '1330',
-                                                     'channel': 'bar'}])
+        result = ci.package_info_matches('core20', [
+          {
+            'revision': {'min': '1326',
+                         'max': '1327'},
+            'channel': 'foo'
+          },
+          {
+            'revision': {'min': '1327',
+                         'max': '1328'},
+            'channel': 'latest/stable'
+          },
+          {
+            'revision': {'min': '1329',
+                         'max': '1330'},
+            'channel': 'bar'
+          }
+        ])
         self.assertTrue(result)
 
-    def test_snap_revision_with_incomplete_range(self):
+    def test_snap_revision_with_invalid_range(self):
         with self.assertRaises(Exception):
-            snap.SnapCheckItems('core20').package_info_matches('core20',
-                                                               [{'min':
-                                                                 '1327'}])
+            snap.SnapCheckItems('core20').package_info_matches('core20', [
+              {
+                'revision': {'mix': '1327'}
+              }
+            ])
+
+    def test_snap_version_check_min_max(self):
+        ci = snap.SnapCheckItems('core20')
+        result = ci.package_info_matches('core20', [
+            {
+              'version': {'min': '20220114',
+                          'max': '20220114'}
+            }
+          ])
+        self.assertTrue(result)
+
+    def test_snap_version_check_lt(self):
+        ci = snap.SnapCheckItems('core20')
+        result = ci.package_info_matches('core20', [
+            {
+              'version': {'lt': '20220115'}
+            }
+          ])
+        self.assertTrue(result)
+
+    def test_snap_version_check_gt_lt(self):
+        ci = snap.SnapCheckItems('core20')
+        result = ci.package_info_matches('core20', [
+            {
+              'version': {'gt': '20220113',
+                          'lt': '20220115'}
+            }
+          ])
+        self.assertTrue(result)
+
+    def test_snap_version_check_everything(self):
+        ci = snap.SnapCheckItems('core20')
+        print(ci.installed_revisions)
+        result = ci.package_info_matches('core20', [
+            {
+              'version': {'gt': '20220113',
+                          'lt': '20220115'},
+              'channel': 'latest/stable',
+              'revision': {'eq': '1328'}
+            }
+          ])
+        self.assertTrue(result)
 
 
 class TestYamlProperties(utils.BaseTestCase):


### PR DESCRIPTION
some of the scenarios may need "version" conditions instead of revisions. this patch does the following:

- adds a new "version" criterion to snap requirement
- both "revision" and "version" now uses DPKGVersion helper to perform the check
- "revision" now has an explicit name instead of being inferred from "min"/"max" being present
- simplified the package_info_matches() function
- updated existing scenarios to make them comply with the new syntax
- added unit tests for the new snap "version" criterion
- updated requirement_types.rst to reflect the changes to the docs
- added op name validation to DPKGVersion.is_version_within_ranges()