### PR TITLE
config/SectionalConfigBase: replace DIY ini parser with configparser

### DIFF
--- a/doc/source/contrib/language_ref/property_ref/requirement_types.rst
+++ b/doc/source/contrib/language_ref/property_ref/requirement_types.rst
@@ -254,7 +254,7 @@ Perform config checks by applying assertion rules to the contents of config
 file. Assertions are defined as a list that is grouped as a
 :ref:`LogicalGroupings` with AND as the default grouping. The final result
 evaluates to True/False. Makes use of config "handlers" i.e. implementations of
-*core.host_helpers.config.SectionalConfigBase* that support querying the
+*core.host_helpers.config.IniConfigBase* that support querying the
 contents of config files in a common way.
 
 Usage:

--- a/hotsos/core/host_helpers/__init__.py
+++ b/hotsos/core/host_helpers/__init__.py
@@ -4,7 +4,7 @@ from .cli import (  # noqa: F403,F401
 )
 from .config import (  # noqa: F403,F401
     ConfigBase,
-    SectionalConfigBase,
+    IniConfigBase,
 )
 from .network import (  # noqa: F403,F401
     NetworkPort,

--- a/hotsos/core/plugins/kernel/config.py
+++ b/hotsos/core/plugins/kernel/config.py
@@ -39,7 +39,7 @@ class KernelConfig(host_helpers.ConfigBase):
                     break
 
 
-class SystemdConfig(host_helpers.SectionalConfigBase):
+class SystemdConfig(host_helpers.IniConfigBase):
     """Systemd configuration."""
 
     def __init__(self, *args, **kwargs):

--- a/hotsos/core/plugins/mysql.py
+++ b/hotsos/core/plugins/mysql.py
@@ -32,14 +32,14 @@ class MySQLChecksBase(plugintools.PluginPartBase):
         return self.apt_info.core is not None
 
 
-class MySQLConfig(host_helpers.SectionalConfigBase):
+class MySQLConfig(host_helpers.IniConfigBase):
     def __init__(self, *args, **kwargs):
         path = os.path.join(HotSOSConfig.data_root,
                             'etc/mysql/mysql.conf.d/mysqld.cnf')
         super().__init__(*args, path=path, **kwargs)
 
 
-class MySQLRouterConfig(host_helpers.SectionalConfigBase):
+class MySQLRouterConfig(host_helpers.IniConfigBase):
     def __init__(self, *args, **kwargs):
         path = os.path.join(HotSOSConfig.data_root,
                             'var/lib/mysql/*mysql-router/mysqlrouter.conf')

--- a/hotsos/core/plugins/openstack/openstack.py
+++ b/hotsos/core/plugins/openstack/openstack.py
@@ -270,7 +270,7 @@ OST_EXCEPTIONS = {'barbican': BARBICAN_EXCEPTIONS + CASTELLAN_EXCEPTIONS,
                   }
 
 
-class OpenstackConfig(host_helpers.SectionalConfigBase):
+class OpenstackConfig(host_helpers.IniConfigBase):
 
     def __getattr__(self, key):
         return self.get(key)

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -17,7 +17,7 @@ from hotsos.core.host_helpers import (
     PebbleHelper,
     SnapPackageHelper,
     SystemdHelper,
-    SectionalConfigBase,
+    IniConfigBase,
 )
 from hotsos.core.log import log
 from hotsos.core.plugins.kernel.net import Lsof
@@ -92,7 +92,7 @@ def csv_to_set(f):
     return csv_to_set_inner
 
 
-class CephConfig(SectionalConfigBase):
+class CephConfig(IniConfigBase):
     def __init__(self, *args, **kwargs):
         path = os.path.join(HotSOSConfig.data_root, 'etc/ceph/ceph.conf')
         super().__init__(*args, path=path, **kwargs)
@@ -1082,7 +1082,7 @@ class CephChecksBase(StorageBase):
         bs_keys = ['bluestore block wal size', 'bluestore block db size',
                    r'bluestore compression .+']
 
-        for keys in self.ceph_config.all.values():
+        for keys in self.ceph_config.all_keys:
             for conf_key in keys:
                 if conf_key in bs_keys:
                     return True

--- a/hotsos/plugin_extensions/openstack/service_features.py
+++ b/hotsos/plugin_extensions/openstack/service_features.py
@@ -70,7 +70,6 @@ class ServiceFeatureChecks(OpenstackChecksBase):
 
                         if key in module_features:
                             continue
-
                         if service in DEFAULTS:
                             if module in DEFAULTS[service]:
                                 if key in DEFAULTS[service][module]:

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -623,9 +623,9 @@ class TestSnapPackageHelper(utils.BaseTestCase):
 class TestConfigHelper(utils.BaseTestCase):
 
     @utils.create_data_root({'test.conf': DUMMY_CONFIG})
-    def test_sectionalconfig_base(self):
+    def test_iniconfig_base(self):
         conf = os.path.join(HotSOSConfig.data_root, 'test.conf')
-        cfg = host_helpers.SectionalConfigBase(conf)
+        cfg = host_helpers.IniConfigBase(conf)
         self.assertTrue(cfg.exists)
         self.assertEqual(cfg.get('a-key'), '1023')
         self.assertEqual(cfg.get('a-key', section='a-section'), '1023')

--- a/tests/unit/test_ycheck_properties.py
+++ b/tests/unit/test_ycheck_properties.py
@@ -10,7 +10,7 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers import (
     DPKGVersion
 )
-from hotsos.core.host_helpers.config import SectionalConfigBase
+from hotsos.core.host_helpers.config import IniConfigBase
 from hotsos.core.issues.utils import IssuesStore
 from hotsos.core.ycheck import scenarios
 from hotsos.core.ycheck.engine import (
@@ -52,7 +52,7 @@ class TestProperty(YPropertyBase):
         return False
 
 
-class TestConfig(SectionalConfigBase):
+class TestConfig(IniConfigBase):
     pass
 
 

--- a/tests/unit/test_ycheck_scenarios.py
+++ b/tests/unit/test_ycheck_scenarios.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from propertree.propertree2 import OverrideRegistry
 from hotsos.core.config import HotSOSConfig
-from hotsos.core.host_helpers.config import SectionalConfigBase
+from hotsos.core.host_helpers.config import IniConfigBase
 from hotsos.core.issues import IssuesManager
 from hotsos.core.issues.utils import IssuesStore
 from hotsos.core.search import FileSearcher, SearchDef
@@ -45,7 +45,7 @@ def global_search_context(f):
     return global_search_context_inner
 
 
-class TestConfig(SectionalConfigBase):
+class TestConfig(IniConfigBase):
     pass
 
 


### PR DESCRIPTION
SectionalConfigBase is a MacGyver'd INI parser in disguise. Python has a reliable way of reading ini files, which is the `configparser` standard module. This patch replaces the regex-based custom ini parsing algorithm with configparser. Renamed the SectionalConfigBase class to IniConfigBase to better reflect what it *really* is.

Removed "all" function and added "all_keys" function instead.