### PR TITLE
Support scenarios using jsondecode commands

### DIFF
--- a/hotsos/core/host_helpers/cli.py
+++ b/hotsos/core/host_helpers/cli.py
@@ -690,6 +690,8 @@ class SourceRunner(object):
             with open(self.output_file, 'w') as fd:
                 if isinstance(out.value, list):
                     fd.write(''.join(out.value))
+                elif isinstance(out.value, dict):
+                    fd.write(json.dumps(out.value))
                 else:
                     fd.write(out.value)
 


### PR DESCRIPTION
Some scenarios use jsondecode commands which writes the output to a file. This was failing if the
decoded value was a dict so now we re-encode the
dict to json if we need to write it to a file. Also ensures that if the search preloaders raise an exception we catch it, log it and move on to.