### PR TITLE
scenario: check if "ldap_use_tokengroups" is enabled for ad domains

### DIFF
--- a/hotsos/core/host_helpers/config.py
+++ b/hotsos/core/host_helpers/config.py
@@ -87,6 +87,9 @@ class IniConfigBase(ConfigBase):
         self.config = None
         self._load()
 
+    def __bool__(self):
+        return self.config is not None
+
     @staticmethod
     def bool_str(val):
         if val.lower() == "true":
@@ -112,6 +115,10 @@ class IniConfigBase(ConfigBase):
         return v
 
     @property
+    def all_sections(self):
+        return self.config.sections() + ["DEFAULT"]
+
+    @property
     def all_keys(self):
         return [x for option in self.config.items()
                 for x in list(option[1].keys())]
@@ -127,7 +134,7 @@ class IniConfigBase(ConfigBase):
         # 1: Section is specified.
         if section is not None:
             # Look for section name, case-insensitive
-            for sect in self.config.sections() + ["DEFAULT"]:
+            for sect in self.all_sections:
                 if section.upper() == sect.upper():
                     return self.post_processing(
                         self.config.get(sect, key, fallback=None),
@@ -138,7 +145,7 @@ class IniConfigBase(ConfigBase):
         # 2: No section specified.
         # The default section is not included in the section
         # set so append it
-        for sec in self.config.sections() + ["DEFAULT"]:
+        for sec in self.all_sections:
             v = self.config.get(sec, key, fallback=None)
             log.debug("ini read value -> %s:%s = %s", section, key, v)
             if v:
@@ -157,3 +164,7 @@ class IniConfigBase(ConfigBase):
             log.error("cannot parse config file `%s`", self.path)
             self.config = None
             return
+
+
+class GenericIniConfig(IniConfigBase):
+    pass

--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -178,6 +178,10 @@ class VaultWarning(IssueTypeBase):
     pass
 
 
+class SSSDWarning(IssueTypeBase):
+    pass
+
+
 class UbuntuCVE(CVETypeBase):
 
     @property

--- a/hotsos/defs/scenarios/system/sssd-ad-tokengroups.yaml
+++ b/hotsos/defs/scenarios/system/sssd-ad-tokengroups.yaml
@@ -1,0 +1,25 @@
+vars:
+  ad_domains_with_tokengroups_enabled: '@hotsos.core.plugins.system.system.SSSD.tokengroups_enabled_domains'
+
+checks:
+  any_tokengroups_enabled_domains:
+    - varops: [[$ad_domains_with_tokengroups_enabled], [length_hint]]
+
+conclusions:
+  ad_domains_with_tokengroups_enabled:
+    decision: any_tokengroups_enabled_domains
+    raises:
+      type: SSSDWarning
+      message: >-
+        The following SSSD Active Directory domains have `ldap_use_tokengroups`
+        enabled which is known to be causing sssd user group membership problems:
+
+        {domains}
+
+        Consider disabling `ldap_use_tokengroups` for those domains if there are
+        intermittent user group membership problems like group permission issues,
+        system login or "sudo" failures.
+
+        https://sssd.io/troubleshooting/ad_provider.html
+      format-dict:
+        domains: $ad_domains_with_tokengroups_enabled:comma_join

--- a/hotsos/defs/tests/scenarios/system/sssd-ad-tokengroups-false.yaml
+++ b/hotsos/defs/tests/scenarios/system/sssd-ad-tokengroups-false.yaml
@@ -1,0 +1,35 @@
+target-name: sssd-ad-tokengroups.yaml
+data-root:
+  files:
+    etc/sssd/sssd.conf: |
+      [sssd]
+      domains = example.local
+      config_file_version = 2
+      services = nss, pam
+      debug_level = 9
+
+      # Uses a different id provider
+      [domain/example.local1]
+      default_shell = /bin/bash
+      id_provider = ldap
+      fallback_homedir = /home/%u@%d
+      access_provider = ldap
+      ldap_use_tokengroups = True
+
+      # id_provider absent
+      [domain/example.local2]
+      default_shell = /bin/bash
+      krb5_store_password_if_offline = True
+      cache_credentials = True
+      krb5_realm = example.local
+      realmd_tags = manages-system joined-with-adcli
+      ldap_use_tokengroups = True
+      fallback_homedir = /home/%u@%d
+      ad_domain = example.local
+      use_fully_qualified_names = False
+      ldap_id_mapping = True
+      ad_server = ms8.example.local
+
+      [nss]
+      debug_level = 0xFFF0
+raised-issues:  # none expected

--- a/hotsos/defs/tests/scenarios/system/sssd-ad-tokengroups.yaml
+++ b/hotsos/defs/tests/scenarios/system/sssd-ad-tokengroups.yaml
@@ -1,0 +1,78 @@
+data-root:
+  files:
+    etc/sssd/sssd.conf: |
+      [sssd]
+      domains = example.local
+      config_file_version = 2
+      services = nss, pam
+      debug_level = 9
+
+      # id_provider ad, ldap_use_tokengroups implicit true
+      [domain/example.local]
+      default_shell = /bin/bash
+      krb5_store_password_if_offline = True
+      cache_credentials = True
+      krb5_realm = example.local
+      realmd_tags = manages-system joined-with-adcli
+      id_provider = ad
+      fallback_homedir = /home/%u@%d
+      ad_domain = example.local
+      use_fully_qualified_names = False
+      ldap_id_mapping = True
+      access_provider = ad
+      ad_server = ms8.example.local
+
+      # id_provider ad, ldap_use_tokengroups explicit true
+      [domain/example.local2]
+      default_shell = /bin/bash
+      krb5_store_password_if_offline = True
+      cache_credentials = True
+      krb5_realm = example.local
+      realmd_tags = manages-system joined-with-adcli
+      id_provider = ad
+      ldap_use_tokengroups = True
+      fallback_homedir = /home/%u@%d
+      ad_domain = example.local
+      use_fully_qualified_names = False
+      ldap_id_mapping = True
+      access_provider = ad
+      ad_server = ms8.example.local
+
+      # Uses a different id provider
+      [domain/example.local3]
+      default_shell = /bin/bash
+      id_provider = ipa
+      fallback_homedir = /home/%u@%d
+      access_provider = ipa
+      ldap_use_tokengroups = True
+
+      # id_provider ad, ldap_use_tokengroups explicit False
+      [domain/example.local4]
+      default_shell = /bin/bash
+      krb5_store_password_if_offline = True
+      cache_credentials = True
+      krb5_realm = example.local
+      realmd_tags = manages-system joined-with-adcli
+      id_provider = ad
+      ldap_use_tokengroups = False
+      fallback_homedir = /home/%u@%d
+      ad_domain = example.local
+      use_fully_qualified_names = False
+      ldap_id_mapping = True
+      access_provider = ad
+      ad_server = ms8.example.local
+
+      [nss]
+      debug_level = 0xFFF0
+raised-issues:
+  SSSDWarning: >-
+    The following SSSD Active Directory domains have `ldap_use_tokengroups`
+    enabled which is known to be causing sssd user group membership problems:
+
+    domain/example.local, domain/example.local2
+
+    Consider disabling `ldap_use_tokengroups` for those domains if there are
+    intermittent user group membership problems like group permission issues,
+    system login or "sudo" failures.
+
+    https://sssd.io/troubleshooting/ad_provider.html

--- a/hotsos/plugin_extensions/__init__.py
+++ b/hotsos/plugin_extensions/__init__.py
@@ -13,5 +13,5 @@ from . import (  # noqa: F401
     sosreport,
     storage,
     system,
-    vault,
+    vault
 )


### PR DESCRIPTION
added a new sssd plugin to retrieve a list of domains that ldap_use_ tokengroups is enabled for. added a new scenario to issue a warning when a sssd domain is using "ad" id provider and ldap_use_tokengroups is not explicitly disabled.

Fixes #890