### PR TITLE
Re-enables pylint useless-object-inheritance check

### DIFF
--- a/hotsos/client.py
+++ b/hotsos/client.py
@@ -38,7 +38,7 @@ class HotSOSSummary(plugintools.PluginPartBase):
         return out
 
 
-class OutputManager(object):
+class OutputManager():
     FILTER_SCHEMA = [IssuesManager.SUMMARY_OUT_ISSUES_ROOT,
                      IssuesManager.SUMMARY_OUT_BUGS_ROOT]
     SUMMARY_FORMATS = ['yaml', 'json', 'markdown', 'html']
@@ -205,7 +205,7 @@ class OutputManager(object):
         self._summary[plugin] = content
 
 
-class HotSOSClient(object):
+class HotSOSClient():
 
     def __init__(self, plugins=None):
         """

--- a/hotsos/core/analytics.py
+++ b/hotsos/core/analytics.py
@@ -2,7 +2,7 @@ import statistics
 from datetime import datetime
 
 
-class EventCollection(object):
+class EventCollection():
     """Used to collect events found in logfiles. Events are defined as having
     identifiable start and end points containing timestamp information such
     that we can calculate their duration.
@@ -150,7 +150,7 @@ class EventCollection(object):
                 start_item["end"] = end_ts
 
 
-class SearchResultIndices(object):
+class SearchResultIndices():
     def __init__(self, day_idx=1, secs_idx=2, event_id_idx=3,
                  metadata_idx=None, metadata_key=None):
         """
@@ -168,7 +168,7 @@ class SearchResultIndices(object):
         self.metadata_key = metadata_key
 
 
-class LogEventStats(object):
+class LogEventStats():
     """Used to identify events within logs whereby a event has a start and end
     point. It can thenbe implemented by other classes to perform further
     analysis on event data.

--- a/hotsos/core/config.py
+++ b/hotsos/core/config.py
@@ -7,7 +7,7 @@ class ConfigException(Exception):
     pass
 
 
-class ConfigOpt(object):
+class ConfigOpt():
 
     def __init__(self, name, description, default_value, value_type):
         self.name = name
@@ -205,7 +205,7 @@ class ConfigMeta(abc.ABCMeta):
         super().__setattr__(key, val)
 
 
-class HotSOSConfig(object, metaclass=ConfigMeta):
+class HotSOSConfig(metaclass=ConfigMeta):
 
     @classmethod
     def reset(cls):

--- a/hotsos/core/host_helpers/apparmor.py
+++ b/hotsos/core/host_helpers/apparmor.py
@@ -11,14 +11,14 @@ from hotsos.core.factory import FactoryBase
 from hotsos.core.host_helpers.cli import CLIHelperFile
 
 
-class AAProfile(object):
+class AAProfile():
 
     def __init__(self, name):
         self.name = name
         self.mode = ApparmorHelper().get_profile_mode(name)
 
 
-class ApparmorHelper(object):
+class ApparmorHelper():
 
     @cached_property
     def profiles(self):

--- a/hotsos/core/host_helpers/cli.py
+++ b/hotsos/core/host_helpers/cli.py
@@ -67,7 +67,7 @@ class CommandNotFound(Exception):
         return self.msg
 
 
-class NullSource(object):
+class NullSource():
     def __call__(self, *args, **kwargs):
         return CmdOutput([])
 
@@ -117,13 +117,13 @@ def reset_command(f):
     return reset_command_inner
 
 
-class CmdOutput(object):
+class CmdOutput():
     def __init__(self, value, source=None):
         self.value = value
         self.source = source
 
 
-class CmdBase(object):
+class CmdBase():
     """ Base class for all command source types. """
 
     def __init__(self):
@@ -323,7 +323,7 @@ class BinFileCmd(FileCmd):
         return CmdOutput(output.splitlines(keepends=True))
 
 
-class JournalctlBase(object):
+class JournalctlBase():
 
     @property
     def since_date(self):
@@ -414,7 +414,7 @@ class OVSAppCtlFileCmd(FileCmd):
         return out
 
 
-class OVSOFCtlCmdBase(object):
+class OVSOFCtlCmdBase():
     OFPROTOCOL_VERSIONS = ['OpenFlow15', 'OpenFlow14', 'OpenFlow13',
                            'OpenFlow12', 'OpenFlow11', 'OpenFlow10']
 
@@ -595,7 +595,7 @@ class CephJSONFileCmd(FileCmd):
         return output
 
 
-class SourceRunner(object):
+class SourceRunner():
 
     def __init__(self, cmdkey, sources, cache, output_file=None):
         """
@@ -700,7 +700,7 @@ class SourceRunner(object):
         return out.value
 
 
-class CLICacheWrapper(object):
+class CLICacheWrapper():
 
     def __init__(self, cache_load_f, cache_save_f):
         self.load_f = cache_load_f

--- a/hotsos/core/host_helpers/common.py
+++ b/hotsos/core/host_helpers/common.py
@@ -7,7 +7,7 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core.log import log
 
 
-class NullCache(object):
+class NullCache():
     """ A cache that does nothing but maintains the MPCache abi. """
 
     def get(self, *args, **kwargs):

--- a/hotsos/core/host_helpers/filestat.py
+++ b/hotsos/core/host_helpers/filestat.py
@@ -5,7 +5,7 @@ from hotsos.core.factory import FactoryBase
 from hotsos.core.log import log
 
 
-class FileObj(object):
+class FileObj():
 
     def __init__(self, filename):
         self.filename = os.path.join(HotSOSConfig.data_root, filename)

--- a/hotsos/core/host_helpers/packaging.py
+++ b/hotsos/core/host_helpers/packaging.py
@@ -12,7 +12,7 @@ class DPKGBadVersionSyntax(Exception):
     pass
 
 
-class DPKGVersion(object):
+class DPKGVersion():
 
     def __init__(self, a):
         self.a = str(a)
@@ -468,7 +468,7 @@ class APTPackageHelper(PackageHelperBase):
         return self._core_packages
 
 
-class AptPackage(object):
+class AptPackage():
 
     def __init__(self, name, version):
         self.name = name

--- a/hotsos/core/host_helpers/pebble.py
+++ b/hotsos/core/host_helpers/pebble.py
@@ -8,7 +8,7 @@ from hotsos.core.host_helpers.common import ServiceManagerBase
 from hotsos.core.utils import sorted_dict
 
 
-class PebbleService(object):
+class PebbleService():
 
     def __init__(self, name, state):
         self.name = name

--- a/hotsos/core/host_helpers/ssl.py
+++ b/hotsos/core/host_helpers/ssl.py
@@ -9,7 +9,7 @@ from hotsos.core.host_helpers.cli import CLIHelper
 from hotsos.core.log import log
 
 
-class SSLCertificate(object):
+class SSLCertificate():
 
     def __init__(self, certificate_path):
         self.path = os.path.join(HotSOSConfig.data_root, certificate_path)
@@ -46,7 +46,7 @@ class SSLCertificate(object):
         return int(days.days)
 
 
-class SSLCertificatesHelper(object):
+class SSLCertificatesHelper():
 
     def __init__(self, certificate, expire_days):
         """

--- a/hotsos/core/host_helpers/sysctl.py
+++ b/hotsos/core/host_helpers/sysctl.py
@@ -35,7 +35,7 @@ class SYSCtlFactory(FactoryBase):
         return self.get(name)
 
 
-class SYSCtlConfHelper(object):
+class SYSCtlConfHelper():
 
     def __init__(self, path):
         self.path = path

--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -22,7 +22,7 @@ from hotsos.core.log import log
 from hotsos.core.utils import sorted_dict
 
 
-class SystemdService(object):
+class SystemdService():
 
     def __init__(self, name, state, has_instances=False):
         self.name = name

--- a/hotsos/core/host_helpers/uptime.py
+++ b/hotsos/core/host_helpers/uptime.py
@@ -5,7 +5,7 @@ from hotsos.core.host_helpers import CLIHelper
 from hotsos.core.log import log
 
 
-class UptimeHelper(object):
+class UptimeHelper():
     def __init__(self):
         """
         uptime is either expressed in different combinations of days, hours

--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -1,7 +1,7 @@
 import abc
 
 
-class IssueTypeBase(object):
+class IssueTypeBase():
     ISSUE_TYPE = 'issue'
 
     def __init__(self, msg):

--- a/hotsos/core/issues/utils.py
+++ b/hotsos/core/issues/utils.py
@@ -7,7 +7,7 @@ from hotsos.core.log import log
 from hotsos.core.utils import sorted_dict
 
 
-class IssueContext(object):
+class IssueContext():
     def __init__(self, **kwargs):
         self.context = {}
         self.set(**kwargs)
@@ -142,7 +142,7 @@ class IssuesStore(IssuesStoreBase):
             fd.write(yaml.dump(current))
 
 
-class IssuesManager(object):
+class IssuesManager():
     SUMMARY_OUT_ISSUES_ROOT = 'potential-issues'
     SUMMARY_OUT_BUGS_ROOT = 'bugs-detected'
 

--- a/hotsos/core/log.py
+++ b/hotsos/core/log.py
@@ -9,7 +9,7 @@ from hotsos.core.config import HotSOSConfig
 log = logging.getLogger('hotsos')
 
 
-class LoggingManager(object):
+class LoggingManager():
 
     def __init__(self):
         self.delete_temp_file = True

--- a/hotsos/core/plugins/juju/resources.py
+++ b/hotsos/core/plugins/juju/resources.py
@@ -11,7 +11,7 @@ from hotsos.core.log import log
 from hotsos.core import utils
 
 
-class JujuMachine(object):
+class JujuMachine():
 
     def __init__(self, juju_lib_path):
         self.juju_lib_path = juju_lib_path
@@ -111,7 +111,7 @@ class JujuMachine(object):
         return units
 
 
-class JujuUnit(object):
+class JujuUnit():
 
     def __init__(self, unit_id, application, juju_lib_path, path=None):
         self.id = unit_id
@@ -157,14 +157,14 @@ class JujuUnit(object):
         return info
 
 
-class JujuCharm(object):
+class JujuCharm():
 
     def __init__(self, name, version):
         self.name = name
         self.version = int(version)
 
 
-class JujuBase(object):
+class JujuBase():
     CHARM_MANIFEST_GLOB = "agents/unit-*/state/deployer/manifests"
 
     @property

--- a/hotsos/core/plugins/kernel/common.py
+++ b/hotsos/core/plugins/kernel/common.py
@@ -7,7 +7,7 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core.plugins.kernel.config import KernelConfig
 
 
-class KernelBase(object):
+class KernelBase():
 
     @cached_property
     def version(self):

--- a/hotsos/core/plugins/kernel/kernlog/calltrace.py
+++ b/hotsos/core/plugins/kernel/kernlog/calltrace.py
@@ -128,7 +128,7 @@ class GenericTraceType(TraceTypeBase):
         yield from self.generics
 
 
-class MemFieldsBase(object):
+class MemFieldsBase():
     """
     Provides a common way to identify fields in an oom kill trace and extract
     their values.

--- a/hotsos/core/plugins/kernel/kernlog/common.py
+++ b/hotsos/core/plugins/kernel/kernlog/common.py
@@ -14,7 +14,7 @@ KERNLOG_PREFIX = (r'(?:\S+\s+\d+\s+[\d:]+\s+\S+\s+\S+:\s+)?{}'.
                   format(KERNLOG_TS))
 
 
-class CallTraceHeuristicBase(object):
+class CallTraceHeuristicBase():
     """ Defines a common interface for heuristics implementations. """
 
     @abc.abstractmethod
@@ -22,7 +22,7 @@ class CallTraceHeuristicBase(object):
         """ Ensure callable to get results. """
 
 
-class CallTraceStateBase(object):
+class CallTraceStateBase():
     """
     A state capture object that allows getting and setting arbitrary state.
     """
@@ -83,7 +83,7 @@ class TraceTypeBase(abc.ABC):
         """ Iterate over each call trace found. """
 
 
-class KernLogBase(object):
+class KernLogBase():
 
     def __init__(self):
         c = SearchConstraintSearchSince(ts_matcher_cls=CommonTimestampMatcher)

--- a/hotsos/core/plugins/kernel/kernlog/events.py
+++ b/hotsos/core/plugins/kernel/kernlog/events.py
@@ -3,7 +3,7 @@ from hotsos.core.plugins.kernel.kernlog.common import KernLogBase
 from hotsos.core.search import SearchDef
 
 
-class OverMTUDroppedPacketEvent(object):
+class OverMTUDroppedPacketEvent():
 
     @property
     def searchdef(self):

--- a/hotsos/core/plugins/kernel/memory.py
+++ b/hotsos/core/plugins/kernel/memory.py
@@ -5,7 +5,7 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core.utils import sorted_dict
 
 
-class _BaseProcKeyValue(object):
+class _BaseProcKeyValue():
     # Set to list of keys we expect to find in the file. If these keys are not
     # found their value will be returned as DEFAULT_RETURN_VALUE instead of
     # raising an AttributeError.
@@ -109,7 +109,7 @@ class MemInfo(_BaseProcKeyValue):
         return round(100 - (self.HugePages_Free * 100) / self.HugePages_Total)
 
 
-class SlabInfo(object):
+class SlabInfo():
 
     def __init__(self, filter_names=None):
         self._filter_names = filter_names or []
@@ -193,7 +193,7 @@ class SlabInfo(object):
         return top5
 
 
-class BuddyInfo(object):
+class BuddyInfo():
 
     def __init__(self):
         self._numa_nodes = []
@@ -228,7 +228,7 @@ class BuddyInfo(object):
         return None
 
 
-class MallocInfo(object):
+class MallocInfo():
 
     def __init__(self, node, zone):
         self.node = node
@@ -280,7 +280,7 @@ class MallocInfo(object):
         return count
 
 
-class MemoryChecks(object):
+class MemoryChecks():
 
     @property
     def max_unavailable_block_sizes(self):

--- a/hotsos/core/plugins/kernel/net.py
+++ b/hotsos/core/plugins/kernel/net.py
@@ -438,7 +438,7 @@ class STOVParserBase(UserList):
         """
 
 
-class FieldTranslator(object):
+class FieldTranslator():
 
     def __init__(self, result, translations):
         self.result = result

--- a/hotsos/core/plugins/kernel/sysfs.py
+++ b/hotsos/core/plugins/kernel/sysfs.py
@@ -6,7 +6,7 @@ from hotsos.core import host_helpers
 from hotsos.core.plugins.system.system import SystemBase
 
 
-class SYSFSBase(object):
+class SYSFSBase():
 
     def get(self, relpath):
         """

--- a/hotsos/core/plugins/kubernetes.py
+++ b/hotsos/core/plugins/kubernetes.py
@@ -44,7 +44,7 @@ K8S_PACKAGE_DEPS = [r'charm[\S]+',
 K8S_PACKAGE_DEPS_SNAP = [r'core[0-9]*']
 
 
-class KubernetesBase(object):
+class KubernetesBase():
 
     @cached_property
     def flannel_ports(self):

--- a/hotsos/core/plugins/lxd/common.py
+++ b/hotsos/core/plugins/lxd/common.py
@@ -18,7 +18,7 @@ CORE_SNAPS = [r"(?:snap\.)?{}".format(p) for p in CORE_APT]
 SERVICE_EXPRS = [r"{}\S*".format(s) for s in CORE_SNAPS]
 
 
-class LXD(object):
+class LXD():
 
     @cached_property
     def instances(self):

--- a/hotsos/core/plugins/openstack/common.py
+++ b/hotsos/core/plugins/openstack/common.py
@@ -27,7 +27,7 @@ from hotsos.core import plugintools
 from hotsos.core.ycheck.events import EventHandlerBase, EventCallbackBase
 
 
-class OpenstackBase(object):
+class OpenstackBase():
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/hotsos/core/plugins/openstack/neutron.py
+++ b/hotsos/core/plugins/openstack/neutron.py
@@ -44,7 +44,7 @@ class NeutronBase(OSTServiceBase):
         return interfaces
 
 
-class ServiceChecks(object):
+class ServiceChecks():
 
     @cached_property
     def ovs_cleanup_run_manually(self):
@@ -67,7 +67,7 @@ class ServiceChecks(object):
         return run_manually
 
 
-class NeutronRouter(object):
+class NeutronRouter():
 
     def __init__(self, uuid, ha_state):
         self.uuid = uuid
@@ -75,7 +75,7 @@ class NeutronRouter(object):
         self.vr_id = None
 
 
-class NeutronHAInfo(object):
+class NeutronHAInfo():
 
     def __init__(self):
         self.vr_id = None

--- a/hotsos/core/plugins/openstack/nova.py
+++ b/hotsos/core/plugins/openstack/nova.py
@@ -351,7 +351,7 @@ class CPUPinning(NovaBase):
         return node_count > 1
 
 
-class NovaInstance(object):
+class NovaInstance():
     def __init__(self, uuid, name):
         self.uuid = uuid
         self.name = name

--- a/hotsos/core/plugins/openstack/openstack.py
+++ b/hotsos/core/plugins/openstack/openstack.py
@@ -276,7 +276,7 @@ class OpenstackConfig(host_helpers.IniConfigBase):
         return self.get(key)
 
 
-class OSTProject(object):
+class OSTProject():
     SVC_VALID_SUFFIX = r'[0-9a-zA-Z-_]*'
     PY_CLIENT_PREFIX = r"python3?-{}\S*"
 
@@ -369,7 +369,7 @@ class OSTProject(object):
             yield svc, self.log_path_overrides.get(svc, [path])
 
 
-class OSTProjectCatalog(object):
+class OSTProjectCatalog():
     # Services that are not actually openstack projects but are used by them
     OST_SERVICES_DEPS = ['dnsmasq',
                          r'(?:nfs-)?ganesha\S*',
@@ -533,7 +533,7 @@ class OSTProjectCatalog(object):
         return list(deps)
 
 
-class OSTServiceBase(object):
+class OSTServiceBase():
 
     def __init__(self, name, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/hotsos/core/plugins/openvswitch/ovn.py
+++ b/hotsos/core/plugins/openvswitch/ovn.py
@@ -14,14 +14,14 @@ from hotsos.core.host_helpers import SystemdHelper
 from hotsos.core.plugins.openvswitch.common import OVS_SERVICES_EXPRS
 
 
-class OVNSBDBPort(object):
+class OVNSBDBPort():
 
     def __init__(self, name, port_type):
         self.name = name
         self.type = port_type
 
 
-class OVNSBDBChassis(object):
+class OVNSBDBChassis():
 
     def __init__(self, name, content):
         self.name = name
@@ -50,7 +50,7 @@ class OVNSBDBChassis(object):
         return [p for p in self._ports if p.type == 'cr-lrp']
 
 
-class OVNDBBase(object):
+class OVNDBBase():
 
     def __init__(self):
         contents = mktemp_dump(''.join(self.db_show))
@@ -140,7 +140,7 @@ class OVNSBDB(OVNDBBase):
         return _chassis
 
 
-class OVNBase(object):
+class OVNBase():
     """
     Base class for all OVN components.
     """

--- a/hotsos/core/plugins/openvswitch/ovs.py
+++ b/hotsos/core/plugins/openvswitch/ovs.py
@@ -20,7 +20,7 @@ from hotsos.core.search import (
 from hotsos.core.plugins.openvswitch.common import OpenvSwitchGlobalSearch
 
 
-class OVSDBTable(object):
+class OVSDBTable():
     """
     Provides an interface to an OVSDB table. Records can be extracted from
     either 'get' or 'list' command outputs. We try 'get' first and of not found
@@ -87,7 +87,7 @@ class OVSDB(FactoryBase):
         return OVSDBTable(table)
 
 
-class OVSDPLookups(object):
+class OVSDPLookups():
 
     def __init__(self):
         cli = CLIHelper()
@@ -107,7 +107,7 @@ class OVSDPLookups(object):
             return self.fields[key]
 
 
-class OVSBridge(object):
+class OVSBridge():
 
     def __init__(self, name, nethelper):
         self.name = name
@@ -130,7 +130,7 @@ class OVSBridge(object):
         return ports
 
 
-class OpenvSwitchBase(object):
+class OpenvSwitchBase():
 
     def __init__(self, *args, global_searcher=None, **kwargs):
         self.global_searcher = global_searcher

--- a/hotsos/core/plugins/pacemaker.py
+++ b/hotsos/core/plugins/pacemaker.py
@@ -13,7 +13,7 @@ PACEMAKER_SVC_EXPR = ['pacemaker[a-zA-Z-]*',
                       'corosync']
 
 
-class PacemakerBase(object):
+class PacemakerBase():
 
     @cached_property
     def crm_status(self):

--- a/hotsos/core/plugins/rabbitmq/common.py
+++ b/hotsos/core/plugins/rabbitmq/common.py
@@ -16,7 +16,7 @@ RMQ_PACKAGES = [
 ]
 
 
-class RabbitMQBase(object):
+class RabbitMQBase():
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/hotsos/core/plugins/rabbitmq/report.py
+++ b/hotsos/core/plugins/rabbitmq/report.py
@@ -10,7 +10,7 @@ from hotsos.core.search import (
 from hotsos.core.host_helpers import CLIHelperFile
 
 
-class RabbitMQReport(object):
+class RabbitMQReport():
     """
     Class providing easy access to the contents of a rabbitmqctl report.
 
@@ -203,7 +203,7 @@ class RabbitMQReport(object):
         return results[0].get(1)
 
 
-class RabbitMQVhost(object):
+class RabbitMQVhost():
     def __init__(self, name):
         self.name = name
         self._node_queues = {}

--- a/hotsos/core/plugins/storage/bcache.py
+++ b/hotsos/core/plugins/storage/bcache.py
@@ -24,7 +24,7 @@ class BcacheConfig(ConfigBase):
                 return fd.read().strip()
 
 
-class BDev(object):
+class BDev():
 
     def __init__(self, path, cache):
         self.cache = cache
@@ -60,7 +60,7 @@ class BDev(object):
         raise AttributeError("{} not found in bdev config".format(key))
 
 
-class Cacheset(object):
+class Cacheset():
 
     def __init__(self, path):
         self.path = path

--- a/hotsos/core/plugins/storage/ceph.py
+++ b/hotsos/core/plugins/storage/ceph.py
@@ -133,7 +133,7 @@ class CephConfig(IniConfigBase):
         return self.get('public network')
 
 
-class CephCrushMap(object):
+class CephCrushMap():
 
     def _filter_pools_by_rule(self, pools, crush_rule):
         res_pool = []
@@ -332,7 +332,7 @@ class CephCrushMap(object):
         return False
 
 
-class CephCluster(object):
+class CephCluster():
     OSD_META_LIMIT_PERCENT = 5
     OSD_PG_MAX_LIMIT = 500
     OSD_PG_OPTIMAL_NUM_MAX = 200
@@ -775,7 +775,7 @@ class CephCluster(object):
         return sorted(_bad_osds)
 
 
-class CephDaemonBase(object):
+class CephDaemonBase():
 
     def __init__(self, daemon_type):
         self.daemon_type = daemon_type
@@ -1131,7 +1131,7 @@ class CephChecksBase(StorageBase):
         return len(osds) == tcmalloc_osds
 
 
-class CephDaemonCommand(object):
+class CephDaemonCommand():
     """
     This class is used to run a ceph daemon command that must be supported by
     CLIHelper. Attributes of the output can then be retrieved by calling them
@@ -1150,7 +1150,7 @@ class CephDaemonCommand(object):
                              format(name, self.command))
 
 
-class CephDaemonConfigShow(object):
+class CephDaemonConfigShow():
 
     def __init__(self, osd_id):
         self.cmd = CephDaemonCommand('ceph_daemon_osd_config_show',
@@ -1160,7 +1160,7 @@ class CephDaemonConfigShow(object):
         return getattr(self.cmd, name)
 
 
-class CephDaemonDumpMemPools(object):
+class CephDaemonDumpMemPools():
 
     def __init__(self, osd_id):
         self.cmd = CephDaemonCommand('ceph_daemon_osd_dump_mempools',
@@ -1172,7 +1172,7 @@ class CephDaemonDumpMemPools(object):
             return val.get('by_pool', {}).get(name, {}).get('items')
 
 
-class CephDaemonAllOSDsCommand(object):
+class CephDaemonAllOSDsCommand():
     """
     This class is used to CephDaemonCommand for all local OSDs.
     """

--- a/hotsos/core/plugins/system/system.py
+++ b/hotsos/core/plugins/system/system.py
@@ -15,7 +15,7 @@ from hotsos.core.search import (
 )
 
 
-class NUMAInfo(object):
+class NUMAInfo():
     numactl = ""
 
     def __init__(self):
@@ -75,7 +75,7 @@ class NUMAInfo(object):
         return self.nodes.get(node)
 
 
-class SystemBase(object):
+class SystemBase():
 
     @cached_property
     def date(self):

--- a/hotsos/core/plugintools.py
+++ b/hotsos/core/plugintools.py
@@ -80,7 +80,7 @@ def yaml_dump(data):
                      default_flow_style=False).rstrip("\n")
 
 
-class OutputFormatterBase(object):
+class OutputFormatterBase():
 
     def render(self, context, template):
         # jinja 2.10.x really needs this to be a str and e.g. not a PosixPath
@@ -203,7 +203,7 @@ class MarkdownFormatter(OutputFormatterBase):
         return markdown.rstrip('\n')
 
 
-class ApplicationBase(object, metaclass=PluginRegistryMeta):
+class ApplicationBase(metaclass=PluginRegistryMeta):
 
     @property
     def bind_interfaces(self):
@@ -213,14 +213,14 @@ class ApplicationBase(object, metaclass=PluginRegistryMeta):
         raise NotImplementedError
 
 
-class SummaryEntry(object):
+class SummaryEntry():
 
     def __init__(self, data, index):
         self.data = data
         self.index = index
 
 
-class PartManager(object):
+class PartManager():
 
     def save(self, data, index):
         """
@@ -400,7 +400,7 @@ class PluginPartBase(ApplicationBase):
             return {key: entry.data for key, entry in out.items()}
 
 
-class PluginRunner(object):
+class PluginRunner():
 
     def __init__(self, plugin):
         self.parts = PLUGINS[plugin]

--- a/hotsos/core/root_manager.py
+++ b/hotsos/core/root_manager.py
@@ -10,7 +10,7 @@ from hotsos.core.host_helpers import CLIHelper
 from hotsos.core.log import log
 
 
-class DataRootManager(object):
+class DataRootManager():
     TYPE_HOST = 0
     TYPE_SOSREPORT = 1
 

--- a/hotsos/core/search.py
+++ b/hotsos/core/search.py
@@ -133,7 +133,7 @@ class CommonTimestampMatcher(TimestampMatcherBase):
         return [openstack, ceph, kernlog]
 
 
-class ExtraSearchConstraints(object):
+class ExtraSearchConstraints():
     """
     Provides a way to apply constraints to search results that are not yet
     natively supported by searchkit.

--- a/hotsos/core/ycheck/common.py
+++ b/hotsos/core/ycheck/common.py
@@ -157,7 +157,7 @@ class GlobalSearcher(contextlib.AbstractContextManager, UserDict):
         self.results
 
 
-class GlobalSearcherPreloaderBase(object):
+class GlobalSearcherPreloaderBase():
     """ Used by plugin components to preload the global searcher. """
 
     @staticmethod
@@ -231,8 +231,7 @@ class GlobalSearcherAutoRegisterMeta(type):
         SEARCHES_TO_BE_REGISTERED.append(cls)
 
 
-class GlobalSearcherAutoRegisterBase(object,
-                                     metaclass=GlobalSearcherAutoRegisterMeta):
+class GlobalSearcherAutoRegisterBase(metaclass=GlobalSearcherAutoRegisterMeta):
     """
     Generic interface for loading search definitions into the global searcher.
     The attributes of this class are intentionally similar to those of

--- a/hotsos/core/ycheck/engine/common.py
+++ b/hotsos/core/ycheck/engine/common.py
@@ -6,7 +6,7 @@ from hotsos.core.config import HotSOSConfig
 from hotsos.core.log import log
 
 
-class YDefsLoader(object):
+class YDefsLoader():
     """ Load yaml definitions. """
 
     def __init__(self, ytype, filter_path=None):
@@ -97,7 +97,7 @@ class YDefsLoader(object):
                 return loaded
 
 
-class YHandlerBase(object):
+class YHandlerBase():
 
     def __init__(self, global_searcher, *args, **kwargs):
         self.global_searcher = global_searcher

--- a/hotsos/core/ycheck/engine/properties/checks.py
+++ b/hotsos/core/ycheck/engine/properties/checks.py
@@ -17,7 +17,7 @@ from hotsos.core.ycheck.engine.properties.search import (
 from hotsos.core.ycheck.engine.properties.inputdef import YPropertyInput
 
 
-class CheckBase(object):
+class CheckBase():
 
     def fetch_item_result(self, item):
         log.debug("%s: fetch_item_result() %s", self.__class__.__name__,

--- a/hotsos/core/ycheck/engine/properties/common.py
+++ b/hotsos/core/ycheck/engine/properties/common.py
@@ -56,7 +56,7 @@ class YDefsContext(UserDict):
         return self.data.get(key)
 
 
-class PropertyCacheRefResolver(object):
+class PropertyCacheRefResolver():
     """
     This class is used to resolve string references to property cache entries.
     """

--- a/hotsos/core/ycheck/engine/properties/conclusions.py
+++ b/hotsos/core/ycheck/engine/properties/conclusions.py
@@ -108,7 +108,7 @@ class YPropertyRaises(YPropertyOverrideBase):
         return self.get_cls(_type)
 
 
-class DecisionBase(object):
+class DecisionBase():
 
     def get_check_item(self, name):
         checks = self.context.checks  # pylint: disable=E1101

--- a/hotsos/core/ycheck/engine/properties/inputdef.py
+++ b/hotsos/core/ycheck/engine/properties/inputdef.py
@@ -9,7 +9,7 @@ from hotsos.core.ycheck.engine.properties.common import (
 )
 
 
-class YPropertyInputBase(object):
+class YPropertyInputBase():
 
     @property
     def options(self):

--- a/hotsos/core/ycheck/engine/properties/requires/common.py
+++ b/hotsos/core/ycheck/engine/properties/requires/common.py
@@ -73,7 +73,7 @@ class PackageCheckItemsBase(CheckItemsBase):
         return set(self.packages_to_check).difference(self.installed)
 
 
-class OpsUtils(object):
+class OpsUtils():
 
     def ops_to_str(self, ops):
         """

--- a/hotsos/core/ycheck/engine/properties/search.py
+++ b/hotsos/core/ycheck/engine/properties/search.py
@@ -287,7 +287,7 @@ class YPropertySearchOpt(YPropertyOverrideBase):
         return self.content
 
 
-class SeqPartSearchOptsBase(object):
+class SeqPartSearchOptsBase():
 
     @property
     def expr(self):

--- a/hotsos/core/ycheck/events.py
+++ b/hotsos/core/ycheck/events.py
@@ -39,7 +39,7 @@ class EventCallbackMeta(type):
             CALLBACKS[event] = cls
 
 
-class EventCheckResult(object):
+class EventCheckResult():
     """ This is passed to an event check callback when matches are found """
 
     def __init__(self, defs_section, defs_event, search_results, search_tag,
@@ -63,7 +63,7 @@ class EventCheckResult(object):
         self.sequence_def = sequence_def
 
 
-class EventProcessingUtils(object):
+class EventProcessingUtils():
 
     @classmethod
     def _get_event_results(cls, event):

--- a/hotsos/core/ycheck/scenarios.py
+++ b/hotsos/core/ycheck/scenarios.py
@@ -86,7 +86,7 @@ class ScenariosSearchPreloader(YHandlerBase, GlobalSearcherPreloaderBase):
         self.preload_searches(self.global_searcher)
 
 
-class Scenario(object):
+class Scenario():
 
     def __init__(self, name, _checks, conclusions):
         log.debug("scenario: %s", name)

--- a/hotsos/plugin_extensions/juju/summary.py
+++ b/hotsos/plugin_extensions/juju/summary.py
@@ -15,7 +15,7 @@ from hotsos.core.utils import sorted_dict
 from hotsos.core.search import CommonTimestampMatcher
 
 
-class UnitLogInfo(object):
+class UnitLogInfo():
     """
     Create a tally of log errors and warnings for each unit.
     """

--- a/hotsos/plugin_extensions/openstack/agent/events.py
+++ b/hotsos/plugin_extensions/openstack/agent/events.py
@@ -347,7 +347,7 @@ class L3HACallback(OpenstackEventCallbackBase):
             return {'transitions': transitions}, 'keepalived'
 
 
-class NeutronL3HAEventCheckJournalCtl(object):
+class NeutronL3HAEventCheckJournalCtl():
 
     def args(self):
         """ Args callback for event cli command """

--- a/pylintrc
+++ b/pylintrc
@@ -51,4 +51,3 @@ disable=
  unnecessary-lambda,
  unspecified-encoding,
  unused-private-member,
- useless-object-inheritance,

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -512,7 +512,7 @@ class TestOpenvswitchScenarios(TestOpenvswitchBase):
                                         'scenarios/openvswitch'))
     def test_ovn_northd_running(self, mock_systemd):
 
-        class FakeSystemdHelper(object):
+        class FakeSystemdHelper():
 
             def __init__(self, svcs):
                 self.processes = {}

--- a/tests/unit/test_ut_scenario_loader.py
+++ b/tests/unit/test_ut_scenario_loader.py
@@ -12,7 +12,7 @@ class ScenarioTestsBase(utils.BaseTestCase):
     pass
 
 
-class FakeTemplatedTestGenerator(object):
+class FakeTemplatedTestGenerator():
 
     @property
     def test_method_name(self):
@@ -159,7 +159,7 @@ class TestScenarioTestLoader(ScenarioTestsBase):
             self.create_tests(dtmp)
             with mock.patch.object(utils, 'DEFS_TESTS_DIR',
                                    os.path.join(dtmp, 'tests')):
-                class FakeTests(object):
+                class FakeTests():
 
                     @utils.load_templated_tests('scenarios/testplugin/1')
                     def faketest(self):
@@ -178,7 +178,7 @@ class TestScenarioTestLoader(ScenarioTestsBase):
             self.create_tests(dtmp, levels=3)
             with mock.patch.object(utils, 'DEFS_TESTS_DIR', dtmp + '/tests'):
                 @utils.load_templated_tests('scenarios/testplugin/1')
-                class FakeTests(object):  # pylint: disable=W0612
+                class FakeTests():  # pylint: disable=W0612
                     pass
 
                 plugin_path = 'tests/scenarios/testplugin'

--- a/tests/unit/test_ycheck_properties.py
+++ b/tests/unit/test_ycheck_properties.py
@@ -56,7 +56,7 @@ class TestConfig(IniConfigBase):
     pass
 
 
-class FakeServiceObjectManager(object):
+class FakeServiceObjectManager():
 
     def __init__(self, start_times):
         self._start_times = start_times
@@ -66,7 +66,7 @@ class FakeServiceObjectManager(object):
                                  start_time=self._start_times[name])
 
 
-class FakeServiceObject(object):
+class FakeServiceObject():
 
     def __init__(self, name, state, has_instances, start_time):
         self.name = name
@@ -229,7 +229,7 @@ ii  openssh-server                       1:8.2p1-4ubuntu0.4                     
 """  # noqa
 
 
-class TempScenarioDefs(object):
+class TempScenarioDefs():
 
     def __init__(self):
         self.root = None

--- a/tests/unit/test_ycheck_scenarios.py
+++ b/tests/unit/test_ycheck_scenarios.py
@@ -17,7 +17,7 @@ from hotsos.core.ycheck.engine.properties.conclusions import (
 from . import utils
 
 
-class TestProperty(object):
+class TestProperty():
 
     @property
     def myattr(self):
@@ -48,7 +48,7 @@ class TestConfig(IniConfigBase):
     pass
 
 
-class FakeServiceObjectManager(object):
+class FakeServiceObjectManager():
 
     def __init__(self, start_times):
         self._start_times = start_times
@@ -58,7 +58,7 @@ class FakeServiceObjectManager(object):
                                  start_time=self._start_times[name])
 
 
-class FakeServiceObject(object):
+class FakeServiceObject():
 
     def __init__(self, name, state, has_instances, start_time):
         self.name = name

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -70,7 +70,7 @@ def load_templated_tests(path):
     return _inner
 
 
-class TemplatedTest(object):
+class TemplatedTest():
 
     def __init__(self, target_path, data_root, mocks, expected_bugs,
                  expected_issues, sub_root):
@@ -197,7 +197,7 @@ class TemplatedTest(object):
         return inner
 
 
-class TemplatedTestGenerator(object):
+class TemplatedTestGenerator():
 
     def __init__(self, test_defs_root, test_def_path):
         """
@@ -404,7 +404,7 @@ def create_data_root(files_to_create, copy_from_original=None):
     return create_files_inner1
 
 
-class ContextManagerBase(object):
+class ContextManagerBase():
 
     def __enter__(self):
         return self


### PR DESCRIPTION
The requires removing all cases where classes inherit from object which is not a requirement in python3.