### PR TITLE
pylintrc: re-enable "pointless-statement" check.

### DIFF
--- a/hotsos/core/host_helpers/packaging.py
+++ b/hotsos/core/host_helpers/packaging.py
@@ -338,7 +338,7 @@ class DockerImageHelper(PackageHelperBase):
             return {}
 
         # go fetch
-        self.all
+        _ = self.all
         return self._core_images
 
 
@@ -466,7 +466,7 @@ class APTPackageHelper(PackageHelperBase):
             return self._core_packages
 
         # go fetch
-        self.all
+        _ = self.all
         return self._core_packages
 
 
@@ -650,5 +650,5 @@ class SnapPackageHelper(PackageHelperBase):
             return {}
 
         # go fetch
-        self.all
+        _ = self.all
         return self._core_snaps

--- a/hotsos/core/ycheck/common.py
+++ b/hotsos/core/ycheck/common.py
@@ -159,7 +159,7 @@ class GlobalSearcher(contextlib.AbstractContextManager, UserDict):
                               allow_global_constraints=True)
 
     def run(self):
-        self.results
+        _ = self.results
 
 
 class GlobalSearcherPreloaderBase():

--- a/pylintrc
+++ b/pylintrc
@@ -26,7 +26,6 @@ disable=
  missing-class-docstring,
  missing-function-docstring,
  missing-module-docstring,
- pointless-statement,
  protected-access,
  too-few-public-methods,
  too-many-ancestors,

--- a/tests/unit/storage/test_ceph_osd.py
+++ b/tests/unit/storage/test_ceph_osd.py
@@ -83,14 +83,14 @@ class TestCephOSDChecksBase(StorageCephOSDTestsBase):
     def test_daemon_osd_config(self):
         config = ceph_core.CephDaemonConfigShow(osd_id=0)
         with self.assertRaises(AttributeError):
-            config.foo
+            _ = config.foo
 
         self.assertEqual(config.bluefs_buffered_io, 'true')
 
     def test_daemon_osd_config_no_exist(self):
         config = ceph_core.CephDaemonConfigShow(osd_id=100)
         with self.assertRaises(AttributeError):
-            config.bluefs_buffered_io
+            _ = config.bluefs_buffered_io
 
     def test_daemon_osd_all_config(self):
         config = ceph_core.CephDaemonAllOSDsCommand('CephDaemonConfigShow')

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -112,7 +112,7 @@ class TestHostNetworkingHelper(utils.BaseTestCase):
 
     def test_get_interfaces_cached(self):
         helper = host_helpers.HostNetworkingHelper()
-        helper.host_interfaces_all
+        _ = helper.host_interfaces_all
         ifaces = helper.cache.get('interfaces')  # pylint: disable=E1111
         expected = ['lo',
                     'ens3',
@@ -164,7 +164,7 @@ class TestHostNetworkingHelper(utils.BaseTestCase):
         addr = '10.0.0.128'
         iface = helper.get_interface_with_addr(addr)
         # do this to cache stats
-        iface.stats
+        _ = iface.stats
         helper = host_helpers.HostNetworkingHelper()
         data = helper.cache_load('interfaces')
         iface_found = False


### PR DESCRIPTION
for valid use cases in the code base (e.g. property call), assign the return value to a throwaway variable.