### PR TITLE
pylintrc: re-enable unused-private-member check

### DIFF
--- a/hotsos/plugin_extensions/juju/summary.py
+++ b/hotsos/plugin_extensions/juju/summary.py
@@ -13,6 +13,7 @@ from hotsos.core.search import (
 )
 from hotsos.core.utils import sorted_dict
 from hotsos.core.search import CommonTimestampMatcher
+from hotsos.core.plugintools import summary_entry
 
 
 class UnitLogInfo():
@@ -100,7 +101,8 @@ class JujuSummary(JujuChecks):
     """ Implementation of Juju summary. """
     summary_part_index = 0
 
-    def __0_summary_services(self):
+    @summary_entry('services', 0)
+    def summary_services(self):
         if self.systemd.services:
             return self.systemd.summary
         if self.pebble.services:
@@ -108,19 +110,22 @@ class JujuSummary(JujuChecks):
 
         return None
 
-    def __1_summary_version(self):
+    @summary_entry('version', 1)
+    def summary_version(self):
         if self.machine:
             return self.machine.version
 
         return "unknown"
 
-    def __2_summary_machine(self):
+    @summary_entry('machine', 2)
+    def summary_machine(self):
         if self.machine:
             return self.machine.id
 
         return "unknown"
 
-    def __3_summary_units(self):
+    @summary_entry('units', 3)
+    def summary_units(self):
         if not self.units:
             return None
 

--- a/hotsos/plugin_extensions/kernel/summary.py
+++ b/hotsos/plugin_extensions/kernel/summary.py
@@ -4,6 +4,7 @@ from hotsos.core.plugins.kernel.common import KernelChecks
 from hotsos.core.plugins.kernel.config import SystemdConfig
 from hotsos.core.plugins.kernel.memory import MemoryChecks
 from hotsos.core.plugins.kernel.sysfs import CPU
+from hotsos.core.plugintools import summary_entry
 
 
 class KernelSummary(KernelChecks):
@@ -44,17 +45,20 @@ class KernelSummary(KernelChecks):
         info['cpufreq-scaling-governor'] = cpu_gov_all
         return info
 
-    def __0_summary_version(self):
+    @summary_entry("version", 0)
+    def summary_version(self):
         return self.version or None
 
-    def __1_summary_boot(self):
+    @summary_entry("boot", 1)
+    def summary_boot(self):
         if self.boot_parameters:
             return ' '.join(self.boot_parameters)
 
         return None
 
     @staticmethod
-    def __2_summary_systemd():
+    @summary_entry("systemd", 2)
+    def summary_systemd():
         cfg = SystemdConfig()
         if cfg.exists:
             if cfg.get('CPUAffinity'):
@@ -62,9 +66,11 @@ class KernelSummary(KernelChecks):
 
         return None
 
-    def __3_summary_cpu(self):
+    @summary_entry("cpu", 3)
+    def summary_cpu(self):
         return self.cpu_info or None
 
     @staticmethod
-    def __4_summary_memory():
+    @summary_entry("memory", 4)
+    def summary_memory():
         return MemoryChecks().nodes_with_limited_high_order_memory_full or None

--- a/hotsos/plugin_extensions/kubernetes/summary.py
+++ b/hotsos/plugin_extensions/kubernetes/summary.py
@@ -1,11 +1,13 @@
 from hotsos.core.plugins.kubernetes import KubernetesChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class KubernetesSummary(KubernetesChecks):
     """ Implementation of Kubernetes summary. """
     summary_part_index = 0
 
-    def __1_summary_services(self):
+    @summary_entry('services', 1)
+    def summary_services(self):
         if self.systemd.services:
             return self.systemd.summary
         if self.pebble.services:
@@ -13,19 +15,24 @@ class KubernetesSummary(KubernetesChecks):
 
         return None
 
-    def __2_summary_snaps(self):
+    @summary_entry('snaps', 2)
+    def summary_snaps(self):
         return self.snaps.all_formatted or None
 
-    def __3_summary_dpkg(self):
+    @summary_entry('dpkg', 3)
+    def summary_dpkg(self):
         return self.apt.all_formatted or None
 
-    def __4_summary_pods(self):
+    @summary_entry('pods', 4)
+    def summary_pods(self):
         return self.pods or None
 
-    def __5_summary_containers(self):
+    @summary_entry('containers', 5)
+    def summary_containers(self):
         return self.containers or None
 
-    def __6_summary_flannel(self):
+    @summary_entry('flannel', 6)
+    def summary_flannel(self):
         info = {}
         for port in self.flannel_ports:
             info[port.name] = port.encap_info

--- a/hotsos/plugin_extensions/lxd/summary.py
+++ b/hotsos/plugin_extensions/lxd/summary.py
@@ -1,28 +1,33 @@
 from hotsos.core.plugins.lxd import LXD, LXDChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class LXDSummary(LXDChecks):
     """ Implementation of LXD summary. """
     summary_part_index = 0
 
-    def __0_summary_services(self):
+    @summary_entry('services', 0)
+    def summary_services(self):
         if self.systemd.services:
             return self.systemd.summary
 
         return None
 
-    def __1_summary_snaps(self):
+    @summary_entry('snaps', 1)
+    def summary_snaps(self):
         if self.snaps:
             return self.snaps.all_formatted
 
         return None
 
-    def __2_summary_dpkg(self):
+    @summary_entry('dpkg', 2)
+    def summary_dpkg(self):
         if self.apt:
             return self.apt.all_formatted
 
         return None
 
     @staticmethod
-    def __3_summary_instances():
+    @summary_entry('instances', 3)
+    def summary_instances():
         return LXD().instances or None

--- a/hotsos/plugin_extensions/maas/summary.py
+++ b/hotsos/plugin_extensions/maas/summary.py
@@ -1,23 +1,27 @@
 from hotsos.core.plugins.maas import MAASChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class MAASSummary(MAASChecks):
     """ Implementation of MAAS summary. """
     summary_part_index = 0
 
-    def __0_summary_services(self):
+    @summary_entry('services', 0)
+    def summary_services(self):
         if self.systemd.services:
             return self.systemd.summary
 
         return None
 
-    def __1_summary_dpkg(self):
+    @summary_entry('dpkg', 1)
+    def summary_dpkg(self):
         if self.apt.core:
             return self.apt.all_formatted
 
         return None
 
-    def __2_summary_snaps(self):
+    @summary_entry('snaps', 2)
+    def summary_snaps(self):
         if self.snaps.core:
             return self.snaps.all_formatted
 

--- a/hotsos/plugin_extensions/mysql/summary.py
+++ b/hotsos/plugin_extensions/mysql/summary.py
@@ -1,11 +1,13 @@
 from hotsos.core.plugins.mysql import MySQLChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class MySQLSummary(MySQLChecks):
     """ Implementation of MySQL summary. """
     summary_part_index = 0
 
-    def __0_summary_services(self):
+    @summary_entry('services', 0)
+    def summary_services(self):
         if self.systemd.services:
             return self.systemd.summary
         if self.pebble.services:
@@ -13,7 +15,8 @@ class MySQLSummary(MySQLChecks):
 
         return None
 
-    def __1_summary_dpkg(self):
+    @summary_entry('dpkg', 1)
+    def summary_dpkg(self):
         if self.apt_info.core:
             return self.apt_info.all_formatted
 

--- a/hotsos/plugin_extensions/openstack/agent/events.py
+++ b/hotsos/plugin_extensions/openstack/agent/events.py
@@ -18,6 +18,7 @@ from hotsos.core.plugins.openstack.common import (
 from hotsos.core.plugins.openstack.neutron import NeutronHAInfo
 from hotsos.core import utils
 from hotsos.core.utils import sorted_dict
+from hotsos.core.plugintools import summary_entry
 
 VRRP_TRANSITION_WARN_THRESHOLD = 8
 
@@ -77,7 +78,8 @@ class ApacheEventChecks(OpenstackEventHandlerBase):
     summary_part_index = 8
     event_group = 'apache'
 
-    def __101_summary_agent_checks(self):
+    @summary_entry('agent-checks', 101)
+    def summary_agent_checks(self):
         out = self.run()
         if out:
             return {self.event_group: out}
@@ -105,7 +107,8 @@ class APIEvents(OpenstackEventHandlerBase):
     summary_part_index = 9
     event_group = 'http-requests'
 
-    def __100_summary_api_info(self):
+    @summary_entry('api-info', 100)
+    def summary_api_info(self):
         out = self.run()
         if out:
             return {self.event_group: out}
@@ -212,7 +215,8 @@ class NeutronAgentEventChecks(OpenstackEventHandlerBase):
     summary_part_index = 7
     event_group = 'neutron.agents'
 
-    def __101_summary_agent_checks(self):
+    @summary_entry('agent-checks', 101)
+    def summary_agent_checks(self):
         # NOTE: order is important here
         agents = ['neutron-server', 'neutron-l3-agent', 'neutron-ovs-agent']
         out = self.run() or {}
@@ -265,7 +269,8 @@ class OctaviaAgentEventChecks(OpenstackEventHandlerBase):
     summary_part_index = 10
     event_group = 'octavia'
 
-    def __101_summary_agent_checks(self):
+    @summary_entry('agent-checks', 101)
+    def summary_agent_checks(self):
         out = self.run()
         if out:
             return {self.event_group: out}
@@ -291,7 +296,8 @@ class NovaComputeEventChecks(OpenstackEventHandlerBase):
     summary_part_index = 11
     event_group = 'nova.nova-compute'
 
-    def __101_summary_agent_checks(self):
+    @summary_entry('agent-checks', 101)
+    def summary_agent_checks(self):
         out = self.run()
         if out:
             return {'nova': out}
@@ -323,7 +329,8 @@ class AgentApparmorChecks(OpenstackEventHandlerBase):
     summary_part_index = 12
     event_group = 'apparmor'
 
-    def __101_summary_agent_checks(self):
+    @summary_entry('agent-checks', 101)
+    def summary_agent_checks(self):
         out = self.run()
         if out:
             return {self.event_group: out}
@@ -401,7 +408,8 @@ class NeutronL3HAEventChecks(OpenstackEventHandlerBase):
     summary_part_index = 13
     event_group = 'neutron.ml2-routers'
 
-    def __101_summary_agent_checks(self):
+    @summary_entry('agent-checks', 101)
+    def summary_agent_checks(self):
         out = self.run()
         if out:
             return {'neutron-l3ha': out}

--- a/hotsos/plugin_extensions/openstack/agent/exceptions.py
+++ b/hotsos/plugin_extensions/openstack/agent/exceptions.py
@@ -11,6 +11,7 @@ from hotsos.core.search import (
     SearchConstraintSearchSince,
 )
 from hotsos.core.search import CommonTimestampMatcher
+from hotsos.core.plugintools import summary_entry
 
 
 class AgentExceptionCheckResults(UserDict):
@@ -275,7 +276,8 @@ class AgentExceptionChecks(OpenStackChecks):
         self._agent_results = self._run(self.searchobj.run())
         return self._agent_results
 
-    def __200_summary_agent_exceptions(self):
+    @summary_entry('agent-exceptions', 200)
+    def summary_agent_exceptions(self):
         """
         Only ERROR level exceptions
         """
@@ -288,7 +290,8 @@ class AgentExceptionChecks(OpenStackChecks):
 
         return None
 
-    def __201_summary_agent_warnings(self):
+    @summary_entry('agent-warnings', 201)
+    def summary_agent_warnings(self):
         """
         Only WARNING level exceptions
         """

--- a/hotsos/plugin_extensions/openstack/nova_external_events.py
+++ b/hotsos/plugin_extensions/openstack/nova_external_events.py
@@ -8,6 +8,7 @@ from hotsos.core.search import (
     SearchConstraintSearchSince,
 )
 from hotsos.core.search import CommonTimestampMatcher
+from hotsos.core.plugintools import summary_entry
 
 EXT_EVENT_META = {'network-vif-plugged': {'stages_keys':
                                           ['Preparing', 'Received',
@@ -86,5 +87,6 @@ class NovaExternalEventChecks(OpenstackEventHandlerBase):
     event_group = 'nova.external-events'
     summary_part_index = 1
 
-    def __8_summary_os_server_external_events(self):
+    @summary_entry('os-server-external-events', 8)
+    def summary_os_server_external_events(self):
         return self.run()

--- a/hotsos/plugin_extensions/openstack/service_features.py
+++ b/hotsos/plugin_extensions/openstack/service_features.py
@@ -1,5 +1,6 @@
 from hotsos.core.log import log
 from hotsos.core.plugins.openstack.common import OpenStackChecks
+from hotsos.core.plugintools import summary_entry
 
 FEATURES = {'neutron': {
                 'main': {
@@ -71,7 +72,8 @@ class ServiceFeatureChecks(OpenStackChecks):
 
         return module_features
 
-    def __7_summary_features(self):
+    @summary_entry('features', 7)
+    def summary_features(self):
         """
         This is used to display whether or not specific features are enabled.
         """

--- a/hotsos/plugin_extensions/openstack/service_network_checks.py
+++ b/hotsos/plugin_extensions/openstack/service_network_checks.py
@@ -12,6 +12,7 @@ from hotsos.core.issues import (
     IssuesManager,
     OpenstackWarning,
 )
+from hotsos.core.plugintools import summary_entry
 
 
 class OpenstackNetworkChecks(OpenStackChecks):
@@ -82,21 +83,24 @@ class OpenstackNetworkChecks(OpenStackChecks):
 
         return port_health_info
 
-    def __9_summary_config(self):
+    @summary_entry('config', 9)
+    def summary_config(self):
         config_info = self.get_config_info()
         if config_info:
             return config_info
 
         return None
 
-    def __10_summary_phy_port_health(self):
+    @summary_entry('phy-port-health', 10)
+    def summary_phy_port_health(self):
         port_health_info = self.get_phy_port_health_info()
         if port_health_info:
             return port_health_info
 
         return None
 
-    def __11_summary_namespaces(self):
+    @summary_entry('namespaces', 11)
+    def summary_namespaces(self):
         """Populate namespace information dict."""
         ns_info = {}
         for line in self.cli.ip_netns():
@@ -139,7 +143,8 @@ class OpenstackNetworkChecks(OpenStackChecks):
 
         return {prefix: list(mtus) for prefix, mtus in router_mtus.items()}
 
-    def __12_summary_router_port_mtus(self):
+    @summary_entry('router-port-mtus', 12)
+    def summary_router_port_mtus(self):
         """ Provide a summary of ml2-ovs router port mtus. """
         phy_mtus = set()
         project = getattr(self, 'neutron')
@@ -174,7 +179,8 @@ class OpenstackNetworkChecks(OpenStackChecks):
 
         return router_mtus
 
-    def __13_summary_vm_port_health(self):
+    @summary_entry('vm-port-health', 13)
+    def summary_vm_port_health(self):
         """ For each instance get its ports and check port health, reporting on
         any outliers. """
         if not self.nova.instances:

--- a/hotsos/plugin_extensions/openstack/summary.py
+++ b/hotsos/plugin_extensions/openstack/summary.py
@@ -1,16 +1,19 @@
 from hotsos.core.plugins.openstack.common import OpenStackChecks
 from hotsos.core.plugins.openstack.neutron import NeutronHAInfo
+from hotsos.core.plugintools import summary_entry
 
 
 class OpenStackSummary(OpenStackChecks):
     """ Implementation of OpenStack summary. """
     summary_part_index = 0
 
-    def __0_summary_release(self):
+    @summary_entry('release', 0)
+    def summary_release(self):
         return {'name': self.release_name,
                 'days-to-eol': self.days_to_eol}
 
-    def __1_summary_services(self):
+    @summary_entry('services', 1)
+    def summary_services(self):
         """Get string info for running services."""
         if self.systemd.services:
             return self.systemd.summary
@@ -19,7 +22,8 @@ class OpenStackSummary(OpenStackChecks):
 
         return None
 
-    def __2_summary_dpkg(self):
+    @summary_entry('dpkg', 2)
+    def summary_dpkg(self):
         # require at least one core package to be installed to include
         # this in the report.
         if self.apt.core:
@@ -27,7 +31,8 @@ class OpenStackSummary(OpenStackChecks):
 
         return None
 
-    def __3_summary_docker_images(self):
+    @summary_entry('docker-images', 3)
+    def summary_docker_images(self):
         # require at least one core image to be in-use to include
         # this in the report.
         if self.docker.core:
@@ -36,7 +41,8 @@ class OpenStackSummary(OpenStackChecks):
         return None
 
     @staticmethod
-    def __4_summary_neutron_l3ha():
+    @summary_entry('neutron-l3ha', 4)
+    def summary_neutron_l3ha():
         routers = {}
         ha_info = NeutronHAInfo()
         for router in ha_info.ha_routers:

--- a/hotsos/plugin_extensions/openstack/vm_info.py
+++ b/hotsos/plugin_extensions/openstack/vm_info.py
@@ -8,13 +8,15 @@ from hotsos.core.plugins.openstack.common import (
 )
 from hotsos.core.plugins.openstack.nova import NovaLibvirt
 from hotsos.core import utils
+from hotsos.core.plugintools import summary_entry
 
 
 class OpenstackInstanceChecks(OpenStackChecks):
     """ Implements Openstack Nova instance checks. """
     summary_part_index = 2
 
-    def __5_summary_vm_info(self):
+    @summary_entry('vm-info', 5)
+    def summary_vm_info(self):
         _info = {}
 
         instances = self.nova.instances.values()
@@ -192,5 +194,6 @@ class NovaServerMigrationAnalysis(OpenstackEventHandlerBase):
     event_group = 'nova.migrations'
     summary_part_index = 3
 
-    def __6_summary_nova_migrations(self):
+    @summary_entry('nova-migrations', 6)
+    def summary_nova_migrations(self):
         return self.run()

--- a/hotsos/plugin_extensions/openvswitch/summary.py
+++ b/hotsos/plugin_extensions/openvswitch/summary.py
@@ -2,6 +2,7 @@ from hotsos.core.host_helpers import NetworkPort
 from hotsos.core.plugins.openvswitch import OpenvSwitchChecks
 from hotsos.core.plugins.openvswitch.ovn import OVNBase
 from hotsos.core.plugins.openvswitch.ovs import OpenvSwitchBase
+from hotsos.core.plugintools import summary_entry
 
 
 class OpenvSwitchSummary(OpenvSwitchChecks):
@@ -13,7 +14,8 @@ class OpenvSwitchSummary(OpenvSwitchChecks):
         self.ovs = OpenvSwitchBase()
         self.ovn = OVNBase()
 
-    def __0_summary_services(self):
+    @summary_entry('services', 0)
+    def summary_services(self):
         """Get string info for running daemons."""
         if self.systemd.services:
             return self.systemd.summary
@@ -22,10 +24,12 @@ class OpenvSwitchSummary(OpenvSwitchChecks):
 
         return None
 
-    def __1_summary_dpkg(self):
+    @summary_entry('dpkg', 1)
+    def summary_dpkg(self):
         return self.apt.all_formatted
 
-    def __2_summary_config(self):
+    @summary_entry('config', 2)
+    def summary_config(self):
         _config = {}
         if self.ovs.offload_enabled:
             _config['offload'] = 'enabled'
@@ -40,7 +44,8 @@ class OpenvSwitchSummary(OpenvSwitchChecks):
 
         return _config or None
 
-    def __3_summary_bridges(self):
+    @summary_entry('bridges', 3)
+    def summary_bridges(self):
         bridges = {}
         for bridge in self.ovs.bridges:
             # filter patch/phy ports since they are not generally interesting
@@ -70,10 +75,12 @@ class OpenvSwitchSummary(OpenvSwitchChecks):
 
         return bridges or None
 
-    def __4_summary_tunnels(self):
+    @summary_entry('tunnels', 4)
+    def summary_tunnels(self):
         return self.ovs.tunnels or None
 
-    def __5_summary_ovn(self):
+    @summary_entry('ovn', 5)
+    def summary_ovn(self):
         info = {}
         if self.ovn.nbdb:
             routers = self.ovn.nbdb.routers

--- a/hotsos/plugin_extensions/pacemaker/summary.py
+++ b/hotsos/plugin_extensions/pacemaker/summary.py
@@ -1,20 +1,24 @@
 from hotsos.core.plugins.pacemaker import PacemakerChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class PacemakerSummary(PacemakerChecks):
     """ Implementation of Pacemaker summary. """
     summary_part_index = 0
 
-    def __0_summary_services(self):
+    @summary_entry('services', 0)
+    def summary_services(self):
         if self.systemd.services:
             return self.systemd.summary
 
         return None
 
-    def __1_summary_dpkg(self):
+    @summary_entry('dpkg', 1)
+    def summary_dpkg(self):
         return self.apt.all_formatted or None
 
-    def __2_summary_nodes(self):
+    @summary_entry('nodes', 2)
+    def summary_nodes(self):
         nodes = {}
         if self.online_nodes:
             nodes["online"] = self.online_nodes

--- a/hotsos/plugin_extensions/rabbitmq/summary.py
+++ b/hotsos/plugin_extensions/rabbitmq/summary.py
@@ -1,11 +1,13 @@
 from hotsos.core.plugins.rabbitmq import RabbitMQChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class RabbitMQSummary(RabbitMQChecks):
     """ Implementation of RabbitMQ summary. """
     summary_part_index = 0
 
-    def __0_summary_services(self):
+    @summary_entry('services', 0)
+    def summary_services(self):
         if self.systemd.services:
             return self.systemd.summary
         if self.pebble.services:
@@ -13,7 +15,8 @@ class RabbitMQSummary(RabbitMQChecks):
 
         return None
 
-    def __1_summary_dpkg(self):
+    @summary_entry('dpkg', 1)
+    def summary_dpkg(self):
         return self.apt.all_formatted or None
 
     @property
@@ -46,11 +49,13 @@ class RabbitMQSummary(RabbitMQChecks):
 
         return None
 
-    def __2_summary_config(self):
+    @summary_entry('config', 2)
+    def summary_config(self):
         setting = self.report.partition_handling or 'unknown'
         return {'cluster-partition-handling': setting}
 
-    def __3_summary_resources(self):
+    @summary_entry('resources', 3)
+    def summary_resources(self):
         resources = {}
         _queue_info = self.queue_info
         if _queue_info:

--- a/hotsos/plugin_extensions/sosreport/summary.py
+++ b/hotsos/plugin_extensions/sosreport/summary.py
@@ -1,23 +1,27 @@
 from hotsos.core.plugins.sosreport import SOSReportChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class SOSReportSummary(SOSReportChecks):
     """ Implementation of SOSReport summary. """
     summary_part_index = 0
 
-    def __0_summary_version(self):
+    @summary_entry('version', 0)
+    def summary_version(self):
         if self.version is not None:
             return self.version
 
         return None
 
-    def __1_summary_dpkg(self):
+    @summary_entry('dpkg', 1)
+    def summary_dpkg(self):
         if self.apt.core:
             return self.apt.all_formatted
 
         return None
 
-    def __2_summary_plugin_timeouts(self):
+    @summary_entry('plugin-timeouts', 2)
+    def summary_plugin_timeouts(self):
         if self.timed_out_plugins:
             return self.timed_out_plugins
 

--- a/hotsos/plugin_extensions/storage/bcache_summary.py
+++ b/hotsos/plugin_extensions/storage/bcache_summary.py
@@ -1,11 +1,13 @@
 from hotsos.core.plugins.storage.bcache import BcacheChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class BcacheSummary(BcacheChecks):
     """ Implementation of Bcache summary. """
     summary_part_index = 2
 
-    def __0_summary_cachesets(self):
+    @summary_entry('cachesets', 0)
+    def summary_cachesets(self):
         _state = {}
         for cset in self.cachesets:
             _cset = {'cache_available_percent':

--- a/hotsos/plugin_extensions/storage/ceph_summary.py
+++ b/hotsos/plugin_extensions/storage/ceph_summary.py
@@ -1,16 +1,19 @@
 from hotsos.core.plugins.storage.ceph import CephChecks
 from hotsos.core.utils import sorted_dict
+from hotsos.core.plugintools import summary_entry
 
 
 class CephSummary(CephChecks):
     """ Implementation of Ceph summary. """
     summary_part_index = 0
 
-    def __0_summary_release(self):
+    @summary_entry('release', 0)
+    def summary_release(self):
         return {'name': self.release_name,
                 'days-to-eol': self.days_to_eol}
 
-    def __1_summary_services(self):
+    @summary_entry('services', 1)
+    def summary_services(self):
         """Get string info for running services."""
         if self.systemd.services:
             return self.systemd.summary
@@ -20,7 +23,8 @@ class CephSummary(CephChecks):
 
         return None
 
-    def __2_summary_dpkg(self):
+    @summary_entry('dpkg', 2)
+    def summary_dpkg(self):
         # require at least one core package to be installed to include
         # this in the report.
         if self.apt.core:
@@ -28,16 +32,19 @@ class CephSummary(CephChecks):
 
         return None
 
-    def __2_summary_snaps(self):
+    @summary_entry('snaps', 2)
+    def summary_snaps(self):
         if self.snaps.core:
             return self.snaps.all_formatted
 
         return None
 
-    def __3_summary_status(self):
+    @summary_entry('status', 3)
+    def summary_status(self):
         return self.cluster.health_status or None
 
-    def __4_summary_network(self):
+    @summary_entry('network', 4)
+    def summary_network(self):
         """ Identify ports used by Ceph daemons, include them in output
         for informational purposes.
         """
@@ -50,26 +57,31 @@ class CephSummary(CephChecks):
 
         return None
 
-    def __5_summary_osd_pgs_near_limit(self):
+    @summary_entry('osd-pgs-near-limit', 5)
+    def summary_osd_pgs_near_limit(self):
         if self.cluster.osds_pgs_above_max:
             return self.cluster.osds_pgs_above_max
 
         return None
 
-    def __6_summary_osd_pgs_suboptimal(self):
+    @summary_entry('osd-pgs-suboptimal', 6)
+    def summary_osd_pgs_suboptimal(self):
         if self.cluster.osds_pgs_suboptimal:
             return self.cluster.osds_pgs_suboptimal
 
         return None
 
-    def __7_summary_versions(self):
+    @summary_entry('versions', 7)
+    def summary_versions(self):
         versions = self.cluster.ceph_daemon_versions_unique()
         return versions or None
 
-    def __8_summary_mgr_modules(self):
+    @summary_entry('mgr-modules', 8)
+    def summary_mgr_modules(self):
         return self.cluster.mgr_modules or None
 
-    def __9_summary_local_osds(self):
+    @summary_entry('local-osds', 9)
+    def summary_local_osds(self):
         if self.local_osds:
             osds = {}
             for osd in self.local_osds:
@@ -79,8 +91,10 @@ class CephSummary(CephChecks):
 
         return None
 
-    def __10_summary_crush_rules(self):
+    @summary_entry('crush-rules', 10)
+    def summary_crush_rules(self):
         return self.cluster.crush_map.rules or None
 
-    def __11_summary_large_omap_pgs(self):
+    @summary_entry('large-omap-pgs', 11)
+    def summary_large_omap_pgs(self):
         return self.cluster.large_omap_pgs or None

--- a/hotsos/plugin_extensions/system/checks.py
+++ b/hotsos/plugin_extensions/system/checks.py
@@ -3,6 +3,7 @@ import os
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers import SYSCtlConfHelper
 from hotsos.core.plugins.system import SystemChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class SYSCtlChecks(SystemChecks):
@@ -131,7 +132,8 @@ class SYSCtlChecks(SystemChecks):
         self._cached_fs_sysctl = sysctl
         return self._cached_fs_sysctl
 
-    def __10_summary_sysctl_mismatch(self):
+    @summary_entry('sysctl-mismatch', 10)
+    def summary_sysctl_mismatch(self):
         """ Compare the values for any key set under sysctl.d and report
         an issue if any mismatches detected.
         """
@@ -155,7 +157,8 @@ class SYSCtlChecks(SystemChecks):
 
         return mismatch or None
 
-    def __11_summary_juju_charm_sysctl_mismatch(self):
+    @summary_entry('juju-charm-sysctl-mismatch', 11)
+    def summary_juju_charm_sysctl_mismatch(self):
         """ Compare the values for any key set under sysctl.d and report
         an issue if any mismatches detected.
         """

--- a/hotsos/plugin_extensions/system/summary.py
+++ b/hotsos/plugin_extensions/system/summary.py
@@ -2,30 +2,37 @@ import re
 
 from hotsos.core.host_helpers import CLIHelper, UptimeHelper
 from hotsos.core.plugins.system import SystemChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class SystemSummary(SystemChecks):
     """ Implementation of System summary. """
     summary_part_index = 0
 
-    def __0_summary_hostname(self):
+    @summary_entry('hostname', 0)
+    def summary_hostname(self):
         return self.hostname
 
-    def __1_summary_os(self):
+    @summary_entry('os', 1)
+    def summary_os(self):
         return self.os_release_name or None
 
-    def __2_summary_num_cpus(self):
+    @summary_entry('num-cpus', 2)
+    def summary_num_cpus(self):
         return self.num_cpus or None
 
     @staticmethod
-    def __3_summary_load():
+    @summary_entry('load', 3)
+    def summary_load():
         return UptimeHelper().loadavg or None
 
-    def __4_summary_virtualisation(self):
+    @summary_entry('virtualisation', 4)
+    def summary_virtualisation(self):
         return self.virtualisation_type or None
 
     @staticmethod
-    def __5_summary_rootfs():
+    @summary_entry('rootfs', 5)
+    def summary_rootfs():
         df_output = CLIHelper().df()
         if df_output:
             for line in df_output:
@@ -35,16 +42,20 @@ class SystemSummary(SystemChecks):
 
         return None
 
-    def __6_summary_unattended_upgrades(self):
+    @summary_entry('unattended-upgrades', 6)
+    def summary_unattended_upgrades(self):
         if self.unattended_upgrades_enabled:
             return "ENABLED"
         return "disabled"
 
-    def __7_summary_date(self):
+    @summary_entry('date', 7)
+    def summary_date(self):
         return self.date
 
-    def __8_summary_ubuntu_pro(self):
+    @summary_entry('ubuntu-pro', 8)
+    def summary_ubuntu_pro(self):
         return self.ubuntu_pro_status
 
-    def __9_summary_uptime(self):
+    @summary_entry('uptime', 9)
+    def summary_uptime(self):
         return self.uptime

--- a/hotsos/plugin_extensions/vault/summary.py
+++ b/hotsos/plugin_extensions/vault/summary.py
@@ -1,11 +1,13 @@
 from hotsos.core.plugins.vault import VaultChecks
+from hotsos.core.plugintools import summary_entry
 
 
 class VaultSummary(VaultChecks):
     """ Implementation of Vault summary. """
     summary_part_index = 0
 
-    def __0_summary_services(self):
+    @summary_entry('services', 0)
+    def summary_services(self):
         if self.systemd.services:
             return self.systemd.summary
         if self.pebble.services:
@@ -13,7 +15,8 @@ class VaultSummary(VaultChecks):
 
         return None
 
-    def __1_summary_snaps(self):
+    @summary_entry('snaps', 1)
+    def summary_snaps(self):
         if self.snaps.core:
             return self.snaps.all_formatted
 

--- a/pylintrc
+++ b/pylintrc
@@ -33,4 +33,3 @@ disable=
  too-many-lines,
  too-many-locals,
  unspecified-encoding,
- unused-private-member,


### PR DESCRIPTION
the only offender of this check was the plugin summary functions that are named in "__[d]+_summary" format. Added the new summary_function decorator that stores the summary function metadata (name, index) into the decorated function (i.e. summary function). Decorated functions in such manner get automatically picked up by the PluginPartBase class.