### PR TITLE
pylintrc: re-enable unspecified-encoding

### DIFF
--- a/hotsos/cli.py
+++ b/hotsos/cli.py
@@ -78,7 +78,7 @@ def get_repo_info():
     """
     repo_info = os.environ.get('REPO_INFO_PATH')
     if repo_info and os.path.exists(repo_info):
-        with open(repo_info) as fd:
+        with open(repo_info, encoding='utf-8') as fd:
             return fd.read().strip()
 
     # pypi
@@ -88,7 +88,7 @@ def get_repo_info():
     # pylint: disable-next=W4902
     with resources.path('hotsos', '.repo-info') as repo_info:
         if repo_info and os.path.exists(repo_info):
-            with open(repo_info) as fd:
+            with open(repo_info, encoding='utf-8') as fd:
                 return fd.read().strip()
 
     try:

--- a/hotsos/core/host_helpers/cli.py
+++ b/hotsos/core/host_helpers/cli.py
@@ -148,7 +148,7 @@ class CmdBase():
 
     @classmethod
     def safe_readlines(cls, path):
-        with open(path, 'r', errors="surrogateescape") as fd:
+        with open(path, 'r', encoding='utf-8', errors="surrogateescape") as fd:
             return fd.readlines()
 
     def register_hook(self, name, f):
@@ -265,7 +265,7 @@ class FileCmd(CmdBase):
         # NOTE: any post-exec hooks must be aware that their input will be
         # defined by the following.
         if self.json_decode:
-            with open(self.path) as fd:
+            with open(self.path, encoding='utf-8') as fd:
                 output = json.load(fd)
         else:
             output = []
@@ -582,7 +582,7 @@ class CephJSONFileCmd(FileCmd):
         if not os.path.exists(self.path):
             raise SourceNotFound(self.path)
 
-        with open(self.path) as f:
+        with open(self.path, encoding='utf-8') as f:
             lines = f.readlines()
 
         if self.first_line_filter:
@@ -707,7 +707,7 @@ class SourceRunner():
             if out.source is not None:
                 return out.source
 
-            with open(self.output_file, 'w') as fd:
+            with open(self.output_file, 'w', encoding='utf-8') as fd:
                 if isinstance(out.value, list):
                     fd.write(''.join(out.value))
                 elif isinstance(out.value, dict):

--- a/hotsos/core/host_helpers/sysctl.py
+++ b/hotsos/core/host_helpers/sysctl.py
@@ -68,7 +68,7 @@ class SYSCtlConfHelper():
 
         setters = {}
         unsetters = {}
-        with open(self.path) as fd:
+        with open(self.path, encoding='utf-8') as fd:
             for line in fd.readlines():
                 if line.startswith("#"):
                     continue

--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -167,7 +167,7 @@ class SystemdService():
             log.warning("service memory info not found at %s", cgroupv2)
             return 0
 
-        with open(cgroupv2) as fd:
+        with open(cgroupv2, encoding='utf-8') as fd:
             total = int(fd.read())
             if total == 0:
                 return total
@@ -341,7 +341,7 @@ class SystemdHelper(ServiceManagerBase):
 
                     _path = _path[0]
 
-                with open(_path) as fd:
+                with open(_path, encoding='utf-8') as fd:
                     for pid in fd:
                         for line in self._ps:
                             if re.match(rf'^\S+\s+{int(pid)}\s+', line):

--- a/hotsos/core/issues/utils.py
+++ b/hotsos/core/issues/utils.py
@@ -79,7 +79,7 @@ class KnownBugsStore(IssuesStoreBase):
         if not os.path.exists(self.store_path):
             return {}
 
-        with open(self.store_path) as fd:
+        with open(self.store_path, encoding='utf-8') as fd:
             bugs = yaml.safe_load(fd)
         if bugs and IssuesManager.SUMMARY_OUT_BUGS_ROOT in bugs:
             return bugs
@@ -94,7 +94,7 @@ class KnownBugsStore(IssuesStoreBase):
         else:
             current = {IssuesManager.SUMMARY_OUT_BUGS_ROOT: [entry.content]}
 
-        with open(self.store_path, 'w') as fd:
+        with open(self.store_path, 'w', encoding='utf-8') as fd:
             fd.write(yaml.dump(current))
 
 
@@ -112,7 +112,7 @@ class IssuesStore(IssuesStoreBase):
         if not os.path.exists(self.store_path):
             return {}
 
-        with open(self.store_path) as fd:
+        with open(self.store_path, encoding='utf-8') as fd:
             issues = yaml.safe_load(fd)
         if issues and IssuesManager.SUMMARY_OUT_ISSUES_ROOT in issues:
             return issues
@@ -131,7 +131,7 @@ class IssuesStore(IssuesStoreBase):
         else:
             current = {key: [entry.content]}
 
-        with open(self.store_path, 'w') as fd:
+        with open(self.store_path, 'w', encoding='utf-8') as fd:
             fd.write(yaml.dump(current))
 
 

--- a/hotsos/core/plugins/juju/resources.py
+++ b/hotsos/core/plugins/juju/resources.py
@@ -40,14 +40,14 @@ class JujuMachine():
         # filter out 'sanitised' lines since they will not be valid yaml
         ftmp = utils.mktemp_dump("")
         try:
-            with open(ftmp, 'w') as fdtmp:
+            with open(ftmp, 'w', encoding='utf-8') as fdtmp:
                 expr = re.compile(r"\*{9}")
-                with open(path) as fd:
+                with open(path, encoding='utf-8') as fd:
                     for line in fd:
                         if not expr.search(line):
                             fdtmp.write(line)
 
-            with open(ftmp) as fd:
+            with open(ftmp, encoding='utf-8') as fd:
                 cfg = yaml.safe_load(fd)
         finally:
             os.remove(ftmp)
@@ -157,7 +157,7 @@ class JujuUnit():
         if not os.path.exists(path):
             return info
 
-        with open(path) as fd:
+        with open(path, encoding='utf-8') as fd:
             for line in fd:
                 if line.startswith('commit-short:'):
                     sha1_short = line.partition(' ')[2]

--- a/hotsos/core/plugins/kernel/common.py
+++ b/hotsos/core/plugins/kernel/common.py
@@ -30,7 +30,7 @@ class KernelBase():
         parameters = []
         path = os.path.join(HotSOSConfig.data_root, "proc/cmdline")
         if os.path.exists(path):
-            with open(path) as fd:
+            with open(path, encoding='utf-8') as fd:
                 cmdline = fd.read().strip()
             for entry in cmdline.split():
                 if entry.startswith("BOOT_IMAGE"):

--- a/hotsos/core/plugins/kernel/config.py
+++ b/hotsos/core/plugins/kernel/config.py
@@ -29,7 +29,7 @@ class KernelConfig(host_helpers.ConfigBase):
         if not self.exists:
             return
 
-        with open(self.path) as fd:
+        with open(self.path, encoding='utf-8') as fd:
             for line in fd:
                 expr = r'.*\s+isolcpus=([0-9\-,]+)\s*.*'
                 ret = re.compile(expr).match(line)

--- a/hotsos/core/plugins/kernel/memory.py
+++ b/hotsos/core/plugins/kernel/memory.py
@@ -40,7 +40,7 @@ class _BaseProcKeyValue():
         if not os.path.exists(self.path):
             return 0
 
-        with open(self.path) as fd:
+        with open(self.path, encoding='utf-8') as fd:
             for line in fd:
                 if re.split(self.key_val_sep(), line, 1)[0] == key:
                     value = int(re.split(self.key_val_sep(), line)[1])
@@ -146,7 +146,7 @@ class SlabInfo():
         if not os.path.exists(self.path):
             return self._slab_info
 
-        with open(self.path) as fd:
+        with open(self.path, encoding='utf-8') as fd:
             for line in fd:
                 exclude = False
                 for name in self._filter_names:
@@ -220,7 +220,7 @@ class BuddyInfo():
             return self._numa_nodes
 
         nodes = set()
-        with open(self.path) as fd:
+        with open(self.path, encoding='utf-8') as fd:
             for line in fd:
                 nodes.add(int(line.split()[1].strip(',')))
 
@@ -228,7 +228,7 @@ class BuddyInfo():
         return self._numa_nodes
 
     def get_node_zones(self, zones_type, node):
-        with open(self.path) as fd:
+        with open(self.path, encoding='utf-8') as fd:
             for line in fd:
                 if line.split()[3] == zones_type and \
                         line.startswith(f"Node {node},"):

--- a/hotsos/core/plugins/kernel/net.py
+++ b/hotsos/core/plugins/kernel/net.py
@@ -42,7 +42,7 @@ class ProcNetBase(abc.ABC):
             return
 
         log.debug("start processing %s", fname)
-        with open(fname) as fd:
+        with open(fname, encoding='utf-8') as fd:
             labels = None
             values = None
             for line in fd:
@@ -331,7 +331,7 @@ class SockStat(ProcNetBase):
             return None
 
         log.debug("start processing %s", fname)
-        with open(fname) as fd:
+        with open(fname, encoding='utf-8') as fd:
             for line in fd:
                 psl = line.split(':')
                 if len(psl) != 2:

--- a/hotsos/core/plugins/kernel/sysfs.py
+++ b/hotsos/core/plugins/kernel/sysfs.py
@@ -19,7 +19,7 @@ class SYSFSBase():
         if not os.path.exists(path):
             return None
 
-        with open(path) as fd:
+        with open(path, encoding='utf-8') as fd:
             return fd.read().strip()
 
 

--- a/hotsos/core/plugins/openstack/common.py
+++ b/hotsos/core/plugins/openstack/common.py
@@ -100,7 +100,7 @@ class OpenstackBase():
                                'etc/openstack-release')
         # this exists as of Jammy/Yoga
         if os.path.exists(relpath):
-            with open(relpath) as fd:
+            with open(relpath, encoding='utf-8') as fd:
                 return fd.read().partition('=')[2].strip()
 
         relname = 'unknown'
@@ -199,7 +199,7 @@ class OpenstackBase():
         if not self.ssl_enabled:
             return certificate_paths
 
-        with open(self.apache2_ssl_config_file) as fd:
+        with open(self.apache2_ssl_config_file, encoding='utf-8') as fd:
             for line in fd:
                 ret = re.search(r'SSLCertificateFile /(\S+)', line)
                 if ret:
@@ -232,7 +232,7 @@ class OpenstackBase():
         if not self.ssl_enabled:
             return False
 
-        with open(self.apache2_ssl_config_file) as fd:
+        with open(self.apache2_ssl_config_file, encoding='utf-8') as fd:
             for line in fd:
                 if line.strip().startswith('#'):
                     continue

--- a/hotsos/core/plugins/openstack/neutron.py
+++ b/hotsos/core/plugins/openstack/neutron.py
@@ -102,14 +102,14 @@ class NeutronHAInfo():
             if not os.path.exists(state_path):
                 continue
 
-            with open(state_path) as fd:
+            with open(state_path, encoding='utf-8') as fd:
                 uuid = os.path.basename(entry)
                 state = fd.read().strip()
                 router = NeutronRouter(uuid, state)
 
             keepalived_conf_path = os.path.join(entry, 'keepalived.conf')
             if os.path.isfile(keepalived_conf_path):
-                with open(keepalived_conf_path) as fd:
+                with open(keepalived_conf_path, encoding='utf-8') as fd:
                     for line in fd:
                         expr = r'.+ virtual_router_id (\d+)'
                         ret = re.compile(expr).search(line)

--- a/hotsos/core/plugins/sosreport.py
+++ b/hotsos/core/plugins/sosreport.py
@@ -38,7 +38,7 @@ class SOSReportChecks(PluginPartBase):
         if not os.path.exists(path):
             return None
 
-        with open(path) as fd:
+        with open(path, encoding='utf-8') as fd:
             for line in fd:
                 if not line.startswith('sosreport:'):
                     continue

--- a/hotsos/core/plugins/storage/bcache.py
+++ b/hotsos/core/plugins/storage/bcache.py
@@ -27,7 +27,7 @@ class BcacheConfig(ConfigBase):
         if not os.path.exists(cfg):
             return None
 
-        with open(cfg) as fd:
+        with open(cfg, encoding='utf-8') as fd:
             return fd.read().strip()
 
 
@@ -63,7 +63,7 @@ class BDev():
     def __getattr__(self, key):
         cfg = os.path.join(self.path, key)
         if os.path.exists(cfg):
-            with open(cfg) as fd:
+            with open(cfg, encoding='utf-8') as fd:
                 return fd.read().strip()
 
         raise AttributeError(f"{key} not found in bdev config")
@@ -86,7 +86,7 @@ class Cacheset():
     def __getattr__(self, key):
         cfg = os.path.join(self.path, key)
         if os.path.exists(cfg):
-            with open(cfg) as fd:
+            with open(cfg, encoding='utf-8') as fd:
                 return fd.read().strip()
 
         raise AttributeError(f"{key} not found in cacheset config")

--- a/hotsos/core/plugins/system/system.py
+++ b/hotsos/core/plugins/system/system.py
@@ -96,7 +96,7 @@ class SystemBase():
         if not os.path.exists(data_source):
             return None
 
-        with open(data_source) as fd:
+        with open(data_source, encoding='utf-8') as fd:
             for line in fd.read().split():
                 ret = re.compile(r"^DISTRIB_CODENAME=(.+)").match(line)
                 if ret:

--- a/hotsos/core/plugintools.py
+++ b/hotsos/core/plugintools.py
@@ -119,7 +119,7 @@ class HTMLFormatter(OutputFormatterBase):
     @property
     def footer(self):
         with open(os.path.join(HotSOSConfig.templates_path,
-                               'footer.html')) as fd:
+                               'footer.html'), encoding='utf-8') as fd:
             return fd.read()
 
     def _expand_list(self, data, level):
@@ -262,7 +262,7 @@ class PartManager():
 
             part_path = newpath
 
-        with open(part_path, 'w') as fd:
+        with open(part_path, 'w', encoding='utf-8') as fd:
             fd.write(out)
 
         self.add_to_index(index, part_path)
@@ -271,7 +271,7 @@ class PartManager():
     def indexes(self):
         path = os.path.join(HotSOSConfig.plugin_tmp_dir, "index.yaml")
         if os.path.exists(path):
-            with open(path) as fd:
+            with open(path, encoding='utf-8') as fd:
                 return yaml.safe_load(fd.read()) or {}
 
         return {}
@@ -279,7 +279,7 @@ class PartManager():
     def add_to_index(self, index, part):
         indexes = self.indexes
         path = os.path.join(HotSOSConfig.plugin_tmp_dir, "index.yaml")
-        with open(path, 'w') as fd:
+        with open(path, 'w', encoding='utf-8') as fd:
             if index in indexes:
                 indexes[index].append(part)
             else:
@@ -313,7 +313,7 @@ class PartManager():
         parts = {}
         for index in sorted(self.indexes):
             for part in self.indexes[index]:
-                with open(part) as fd:
+                with open(part, encoding='utf-8') as fd:
                     part_yaml = yaml.safe_load(fd)
 
                     # Don't allow root level keys to be clobbered, instead just

--- a/hotsos/core/utils.py
+++ b/hotsos/core/utils.py
@@ -24,7 +24,7 @@ def mktemp_dump(data, prefix=None):
     else:
         ftmp = tempfile.mktemp(dir=HotSOSConfig.plugin_tmp_dir)
 
-    with open(ftmp, 'w') as fd:
+    with open(ftmp, 'w', encoding='utf-8') as fd:
         fd.write(data)
 
     return ftmp

--- a/hotsos/core/ycheck/engine/common.py
+++ b/hotsos/core/ycheck/engine/common.py
@@ -40,7 +40,7 @@ class YDefsLoader():
                     continue
 
                 if self._get_yname(abs_path) == os.path.basename(path):
-                    with open(abs_path) as fd:
+                    with open(abs_path, encoding='utf-8') as fd:
                         log.debug("applying dir globals %s", entry)
                         defs.update(yaml.safe_load(fd.read()) or {})
 
@@ -50,7 +50,7 @@ class YDefsLoader():
                     # directory.
                     continue
 
-                with open(abs_path) as fd:
+                with open(abs_path, encoding='utf-8') as fd:
                     self.stats_num_files_loaded += 1
                     _content = yaml.safe_load(fd.read()) or {}
                     defs[self._get_yname(abs_path)] = _content

--- a/tests/unit/test_host_helpers.py
+++ b/tests/unit/test_host_helpers.py
@@ -229,7 +229,7 @@ class TestCLIHelper(utils.BaseTestCase):
     @mock.patch.object(host_helpers.cli, 'subprocess')
     def test_ps(self, mock_subprocess):
         path = os.path.join(HotSOSConfig.data_root, "ps")
-        with open(path, 'r') as fd:
+        with open(path, 'r', encoding='utf-8') as fd:
             out = fd.readlines()
 
         self.assertEqual(host_helpers.cli.CLIHelper().ps(), out)

--- a/tests/unit/test_issues_utils.py
+++ b/tests/unit/test_issues_utils.py
@@ -20,7 +20,8 @@ class TestIssuesUtils(utils.BaseTestCase):
 
     def test_get_issues(self):
         raised_issues = {}
-        with open(os.path.join(self.plugin_tmp_dir, 'yaml'), 'w') as fd:
+        with open(os.path.join(self.plugin_tmp_dir, 'yaml'),
+                  'w', encoding='utf-8') as fd:
             fd.write(yaml.dump(raised_issues))
 
         mgr = IssuesManager()
@@ -81,7 +82,8 @@ class TestKnownBugsUtils(utils.BaseTestCase):
                         'message': None,
                         'origin': 'testplugin.testpart'}]}
         with open(os.path.join(self.plugin_tmp_dir,
-                               'known_bugs.yaml'), 'w') as fd:
+                               'known_bugs.yaml'),
+                  'w', encoding='utf-8') as fd:
             fd.write(yaml.dump(known_bugs))
 
         ret = IssuesManager().load_bugs()
@@ -108,7 +110,8 @@ class TestKnownBugsUtils(utils.BaseTestCase):
                         'message': None,
                         'origin': 'testplugin.testpart'}]}
         with open(os.path.join(self.plugin_tmp_dir,
-                               'known_bugs.yaml'), 'w') as fd:
+                               'known_bugs.yaml'),
+                  'w', encoding='utf-8') as fd:
             fd.write(yaml.dump(known_bugs))
 
         mgr = IssuesManager()

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -330,7 +330,7 @@ class TestOpenstackBase(utils.BaseTestCase):
         if self.ip_link_show is None:
             path = os.path.join(HotSOSConfig.data_root,
                                 "sos_commands/networking/ip_-s_-d_link")
-            with open(path) as fd:
+            with open(path, encoding='utf-8') as fd:
                 self.ip_link_show = fd.readlines()
 
 

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -179,29 +179,29 @@ class TestSYSCtlChecks(SystemTestsBase):
                                          'sos_commands/kernel'),
                             os.path.join(dtmp, 'sos_commands/kernel'))
 
-            with open(etc_sysctl_conf, 'a') as fd:
+            with open(etc_sysctl_conf, 'a', encoding='utf-8') as fd:
                 fd.write('-net.core.rmem_default\n')
 
             # create a config with an unsetter
             with open(os.path.join(dtmp, 'etc/sysctl.d/99-unit-test.conf'),
-                      'w') as fd:
+                      'w', encoding='utf-8') as fd:
                 fd.write("-net.ipv4.conf.all.rp_filter\n")
 
             # create a config that has not been applied
             with open(os.path.join(dtmp, 'etc/sysctl.d/98-unit-test.conf'),
-                      'w') as fd:
+                      'w', encoding='utf-8') as fd:
                 fd.write("kernel.pid_max = 12345678\n")
                 fd.write("net.ipv4.conf.all.rp_filter = 200\n")
 
             # inject an unset value into an invalid file
             with open(os.path.join(dtmp, 'etc/sysctl.d/97-unit-test.conf.bak'),
-                      'w') as fd:
+                      'w', encoding='utf-8') as fd:
                 fd.write("kernel.watchdog = 0\n")
 
             # create a config with an unsetter that wont be applied since it
             # has a lesser priority.
             with open(os.path.join(dtmp, 'etc/sysctl.d/96-unit-test.conf'),
-                      'w') as fd:
+                      'w', encoding='utf-8') as fd:
                 fd.write("-kernel.pid_max\n")
                 fd.write("net.core.rmem_default = 1000000000\n")
 
@@ -219,7 +219,7 @@ class TestUbuntuPro(SystemTestsBase):
                 """ fake clihelper """
                 @staticmethod
                 def pro_status():
-                    with open(ftmp.name, 'w') as fd:
+                    with open(ftmp.name, 'w', encoding='utf-8') as fd:
                         fd.write(''.join(UBUNTU_PRO_ATTACHED))
 
                     return ftmp.name
@@ -266,7 +266,7 @@ class TestUbuntuPro(SystemTestsBase):
                 """ fake clihelper """
                 @staticmethod
                 def pro_status():
-                    with open(ftmp.name, 'w') as fd:
+                    with open(ftmp.name, 'w', encoding='utf-8') as fd:
                         fd.write(''.join(UBUNTU_PRO_NOT_ATTACHED))
 
                     return ftmp.name
@@ -289,7 +289,7 @@ class TestUbuntuPro(SystemTestsBase):
                 """ fake clihelper """
                 @staticmethod
                 def pro_status():
-                    with open(ftmp.name, 'w') as fd:
+                    with open(ftmp.name, 'w', encoding='utf-8') as fd:
                         fd.write(''.join(UA_ATTACHED))
 
                     return ftmp.name
@@ -341,7 +341,7 @@ class TestUbuntuPro(SystemTestsBase):
                 """ fake clihelper """
                 @staticmethod
                 def pro_status():
-                    with open(ftmp.name, 'w') as fd:
+                    with open(ftmp.name, 'w', encoding='utf-8') as fd:
                         fd.write(''.join(UA_ATTACHED_WITH_NOTICE))
 
                     return ftmp.name
@@ -382,7 +382,7 @@ class TestUbuntuPro(SystemTestsBase):
                 """ fake clihelper """
                 @staticmethod
                 def pro_status():
-                    with open(ftmp.name, 'w') as fd:
+                    with open(ftmp.name, 'w', encoding='utf-8') as fd:
                         fd.write(''.join(UA_NOT_ATTACHED))
 
                     return ftmp.name
@@ -405,7 +405,7 @@ class TestUbuntuPro(SystemTestsBase):
                 """ fake clihelper """
                 @staticmethod
                 def pro_status():
-                    with open(ftmp.name, 'w') as fd:
+                    with open(ftmp.name, 'w', encoding='utf-8') as fd:
                         fd.write('M' + ''.join(UBUNTU_PRO_ATTACHED[1:]))
 
                     return ftmp.name

--- a/tests/unit/test_ut_scenario_loader.py
+++ b/tests/unit/test_ut_scenario_loader.py
@@ -70,7 +70,8 @@ class TestScenarioTestLoader(utils.BaseTestCase):
 
             for scenario_name_template in scenario_name_templates:
                 scenario_name = scenario_name_template.format(lvl)
-                with open(os.path.join(_path, scenario_name), 'w') as fd:
+                with open(os.path.join(_path, scenario_name),
+                          'w', encoding='utf-8') as fd:
                     fd.write(FAKE_SCENARIO)
 
     @staticmethod
@@ -92,12 +93,14 @@ class TestScenarioTestLoader(utils.BaseTestCase):
 
             for name_template in test_files_without_target:
                 file_name = name_template.format(lvl)
-                with open(os.path.join(_path, file_name), 'w') as fd:
+                with open(os.path.join(_path, file_name),
+                          'w', encoding='utf-8') as fd:
                     fd.write(FAKE_TEST)
 
             for name_template in test_files_with_target:
                 file_name = name_template.format(lvl)
-                with open(os.path.join(_path, file_name), 'w') as fd:
+                with open(os.path.join(_path, file_name),
+                          'w', encoding='utf-8') as fd:
                     fd.write(FAKE_TEST_W_TARGET)
 
     def test_check_test_names(self):
@@ -213,7 +216,7 @@ class TestScenarioTestLoader(utils.BaseTestCase):
             self.create_tests(dtmp, levels=3)
 
             with open(os.path.join(dtmp, 'test1.yaml'),
-                      'w') as fd:
+                      'w', encoding='utf-8') as fd:
                 fd.write(FAKE_SCENARIO)
             with mock.patch.object(utils, 'DEFS_TESTS_DIR', dtmp):
                 utils.TemplatedTest(

--- a/tests/unit/test_ycheck_properties.py
+++ b/tests/unit/test_ycheck_properties.py
@@ -285,7 +285,7 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
                 pkg: '@checks.c1.requires.package'
         """  # noqa
         with TempScenarioDefs() as tmpscenarios:
-            with open(tmpscenarios.path, 'w') as fd:
+            with open(tmpscenarios.path, 'w', encoding='utf-8') as fd:
                 fd.write(scenario)
 
             with GlobalSearcher() as searcher:
@@ -314,7 +314,7 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
                 pkg: '@checks.c1.requires.package'
         """  # noqa
         with TempScenarioDefs() as tmpscenarios:
-            with open(tmpscenarios.path, 'w') as fd:
+            with open(tmpscenarios.path, 'w', encoding='utf-8') as fd:
                 fd.write(scenario)
 
             with GlobalSearcher() as searcher:
@@ -343,7 +343,7 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
                 pkg: '@checks.c1.requires.package'
         """  # noqa
         with TempScenarioDefs() as tmpscenarios:
-            with open(tmpscenarios.path, 'w') as fd:
+            with open(tmpscenarios.path, 'w', encoding='utf-8') as fd:
                 fd.write(scenario)
 
             with GlobalSearcher() as searcher:
@@ -371,7 +371,7 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
                 pkg: '@checks.c1.requires.package'
         """
         with TempScenarioDefs() as tmpscenarios:
-            with open(tmpscenarios.path, 'w') as fd:
+            with open(tmpscenarios.path, 'w', encoding='utf-8') as fd:
                 fd.write(scenario)
 
             with GlobalSearcher() as searcher:
@@ -402,7 +402,7 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
                 pkg: '@checks.c1.requires.package'
         """
         with TempScenarioDefs() as tmpscenarios:
-            with open(tmpscenarios.path, 'w') as fd:
+            with open(tmpscenarios.path, 'w', encoding='utf-8') as fd:
                 fd.write(scenario)
 
             with GlobalSearcher() as searcher:
@@ -434,7 +434,7 @@ class TestYamlRequiresTypeCache(utils.BaseTestCase):
                 pkg: '@checks.c1.requires.package'
         """
         with TempScenarioDefs() as tmpscenarios:
-            with open(tmpscenarios.path, 'w') as fd:
+            with open(tmpscenarios.path, 'w', encoding='utf-8') as fd:
                 fd.write(scenario)
 
             with GlobalSearcher() as searcher:

--- a/tests/unit/test_ycheck_scenarios.py
+++ b/tests/unit/test_ycheck_scenarios.py
@@ -64,7 +64,7 @@ def init_test_scenario(yaml_contents, scenario_name=None):
                 sname = scenario_name or 'test'
                 yfile = os.path.join(yroot, f'{sname}.yaml')
                 os.makedirs(os.path.dirname(yfile))
-                with open(yfile, 'w') as fd:
+                with open(yfile, 'w', encoding='utf-8') as fd:
                     fd.write(yaml_contents)
                 return f(*args, **kwargs)
 
@@ -732,7 +732,7 @@ class TestYamlScenarios(utils.BaseTestCase):  # noqa, pylint: disable=too-many-p
     @staticmethod
     def _create_search_results(path, contents=None):
         if contents:
-            with open(path, 'w') as fd:
+            with open(path, 'w', encoding='utf-8') as fd:
                 for line in contents:
                     fd.write(line)
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -220,7 +220,7 @@ class TemplatedTestGenerator():
         if not os.path.exists(test_def_path):
             raise Exception(f"{test_def_path} does not exist")
 
-        with open(test_def_path) as fd:
+        with open(test_def_path, encoding='utf-8') as fd:
             self.testdef = yaml.safe_load(fd) or {}
         if not self.testdef or not os.path.exists(test_def_path):
             raise Exception(f"invalid test template at {test_def_path}")
@@ -399,7 +399,7 @@ def create_data_root(files_to_create, copy_from_original=None):
                             [f'{path}: {line}'
                              for line in content.split("\n")]))
 
-                    with open(path, 'w') as fd:
+                    with open(path, 'w', encoding='utf-8') as fd:
                         fd.write(content)
 
                 orig_data_root = HotSOSConfig.data_root

--- a/tools/validation/hotyvalidate.py
+++ b/tools/validation/hotyvalidate.py
@@ -89,7 +89,7 @@ class HotYValidate(TestCase):
         for scenario_file in scenario_files:
             logging.debug("processing scenario file [%s]", scenario_file)
 
-            with open(scenario_file) as sfilestream:
+            with open(scenario_file, encoding='utf-8') as sfilestream:
                 sy = yaml.safe_load(sfilestream)
 
                 # If the YAML file contains "requires" section


### PR DESCRIPTION
explicitly request "utf-8" encoding for all open() calls. When unspecified, Python retrieves the platform-dependent value via locale.getencoding() call, which should evaluate to "utf-8" for Linux-y OS'es.