### PR TITLE
pylintrc/fixup: *really* enable unspecified-encoding

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -32,4 +32,3 @@ disable=
  too-many-instance-attributes,
  too-many-lines,
  too-many-locals,
- unspecified-encoding,


### PR DESCRIPTION
previous patch (#937) somehow didn't include the pylintrc change so this is a follow-up patch to correct that.