### PR TITLE
pylintrc: re-enable too-many-arguments

### DIFF
--- a/hotsos/core/analytics.py
+++ b/hotsos/core/analytics.py
@@ -1,5 +1,6 @@
 import statistics
 from datetime import datetime
+from dataclasses import dataclass
 
 
 class EventCollection():
@@ -151,24 +152,23 @@ class EventCollection():
                 start_item["end"] = end_ts
 
 
+@dataclass(frozen=True)
 class SearchResultIndices():
     """
     Used to know where to find required information within a SearchResult.
-    """
-    def __init__(self, day_idx=1, secs_idx=2, event_id_idx=3,
-                 metadata_idx=None, metadata_key=None):
-        """
-        The indexes refer to python.re groups.
 
-        The minimum required information that a result must contain is day,
-        secs and event_id. Results will be referred to using whatever event_id
-        is set to.
-        """
-        self.day = day_idx
-        self.secs = secs_idx
-        self.event_id = event_id_idx
-        self.metadata = metadata_idx
-        self.metadata_key = metadata_key
+    The indexes refer to python.re groups.
+
+    The minimum required information that a result must contain is day,
+    secs and event_id. Results will be referred to using whatever event_id
+    is set to.
+    """
+
+    day: int = 1
+    secs: int = 2
+    event_id: int = 3
+    metadata: int = None
+    metadata_key: str = None
 
 
 class LogEventStats():

--- a/hotsos/core/host_helpers/network.py
+++ b/hotsos/core/host_helpers/network.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import re
+from dataclasses import dataclass
 
 # NOTE: we import direct from searchkit rather than hotsos.core.search to
 #       avoid circular dependency issues.
@@ -27,17 +28,20 @@ IP_IFACE_VXLAN_INFO = r"\s+(vxlan) id (\d+) local (\S+) dev (\S+) .+"
 IP_EOF = r"^$"
 
 
+@dataclass()
 class NetworkPort(HostHelpersBase):
     """ Representation of a network port. """
-    def __init__(self, name, addresses, hwaddr, state, encap_info,
-                 mtu, namespace=None):
-        self.name = name
-        self.addresses = addresses
-        self.hwaddr = hwaddr
-        self.state = state
-        self.encap_info = encap_info
-        self.mtu = mtu
-        self.namespace = namespace
+
+    name: str
+    addresses: list
+    hwaddr: str
+    state: str
+    encap_info: str
+    mtu: str
+    namespace: str = None
+
+    def __post_init__(self):
+        # Required for initializing the self.cache
         super().__init__()
 
     @property

--- a/hotsos/plugin_extensions/openstack/vm_info.py
+++ b/hotsos/plugin_extensions/openstack/vm_info.py
@@ -153,7 +153,7 @@ class SrcMigrationCallback(OpenstackEventCallbackBase):
                     migration_info[vm_uuid] = [info]
 
         # section name expected to be live-migration
-        return migration_info, event.section
+        return migration_info, event.section_name
 
 
 class PrePostLiveMigrationCallback(OpenstackEventCallbackBase):
@@ -186,7 +186,7 @@ class PrePostLiveMigrationCallback(OpenstackEventCallbackBase):
 
     def __call__(self, event):
         # section name expected to be live-migration
-        return self._migration_stats_info(event), event.section
+        return self._migration_stats_info(event), event.section_name
 
 
 class NovaServerMigrationAnalysis(OpenstackEventHandlerBase):

--- a/hotsos/plugin_extensions/storage/ceph_event_checks.py
+++ b/hotsos/plugin_extensions/storage/ceph_event_checks.py
@@ -25,8 +25,10 @@ class EventCallbackMisc(CephEventCallbackBase):
             IssuesManager().add(CephOSDError(msg))
             return None
 
-        key_by_date = event.name == 'heartbeat-no-reply'
-        return self.categorise_events(event, key_by_date=key_by_date)
+        options = self.EventProcessingOptions(
+            key_by_date=event.name == "heartbeat-no-reply"
+        )
+        return self.categorise_events(event, options=options)
 
 
 class EventCallbackSlowRequests(CephEventCallbackBase):
@@ -65,8 +67,8 @@ class EventCallbackCRCErrors(CephEventCallbackBase):
 
             results.append({'date': r.get(1), 'key': key})
 
-        ret = self.categorise_events(event, results=results,
-                                     squash_if_none_keys=True)
+        options = self.EventProcessingOptions(squash_if_none_keys=True)
+        ret = self.categorise_events(event, results=results, options=options)
 
         # If on any particular day there were > 3 crc errors for a
         # particular osd we raise an issue since that indicates they are
@@ -112,8 +114,8 @@ class EventCallbackHeartbeatPings(CephEventCallbackBase):
 
             results.append({'date': r.get(1), 'key': key})
 
-        return self.categorise_events(event, results=results,
-                                      squash_if_none_keys=True)
+        options = self.EventProcessingOptions(squash_if_none_keys=True)
+        return self.categorise_events(event, results=results, options=options)
 
 
 class CephEventHandler(CephChecks, EventHandlerBase):

--- a/pylintrc
+++ b/pylintrc
@@ -26,7 +26,6 @@ disable=
  missing-module-docstring,
  too-few-public-methods,
  too-many-ancestors,
- too-many-arguments,
  too-many-branches,
  too-many-instance-attributes,
  too-many-locals,

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -188,10 +188,20 @@ class TestOpenvswitchServiceInfo(TestOpenvswitchBase):
                              'sos_commands/openvswitch/ovs-vsctl_-t_5_list_'
                              'Open_vSwitch': OVS_DB_GENEVE_ENCAP})
     def test_summary_ovn_tunnels_no_remotes(self):
-        with mock.patch('hotsos.core.host_helpers.HostNetworkingHelper.'
-                        'host_interfaces_all',
-                        [NetworkPort('bondX', ['10.3.4.24'], None,
-                                     None, None, None)]):
+        with mock.patch(
+            "hotsos.core.host_helpers.HostNetworkingHelper."
+            "host_interfaces_all",
+            [
+                NetworkPort(
+                    name="bondX",
+                    addresses=["10.3.4.24"],
+                    hwaddr=None,
+                    state=None,
+                    encap_info=None,
+                    mtu=None,
+                )
+            ],
+        ):
             expected = {'geneve': {
                             'iface': {
                                 'bondX': {'addresses': ['10.3.4.24'],
@@ -210,10 +220,20 @@ class TestOpenvswitchServiceInfo(TestOpenvswitchBase):
                              'sos_commands/openvswitch/ovs-vsctl_-t_5_list_'
                              'Open_vSwitch': OVS_DB_GENEVE_ENCAP})
     def test_summary_tunnels_ovn(self):
-        with mock.patch('hotsos.core.host_helpers.HostNetworkingHelper.'
-                        'host_interfaces_all',
-                        [NetworkPort('bondX', ['10.3.4.24'], None,
-                                     None, None, None)]):
+        with mock.patch(
+            "hotsos.core.host_helpers.HostNetworkingHelper."
+            "host_interfaces_all",
+            [
+                NetworkPort(
+                    name="bondX",
+                    addresses=["10.3.4.24"],
+                    hwaddr=None,
+                    state=None,
+                    encap_info=None,
+                    mtu=None,
+                )
+            ],
+        ):
             expected = {'geneve': {
                             'iface': {
                                 'bondX': {'addresses': ['10.3.4.24'],

--- a/tests/unit/test_plugintools.py
+++ b/tests/unit/test_plugintools.py
@@ -1,11 +1,14 @@
 import json
 
-from hotsos.client import OutputManager
+from hotsos.client import OutputManager, OutputBuilder
 from hotsos.core.host_helpers.cli import CLIHelper
 from hotsos.core.issues import IssuesManager
 from hotsos.core import plugintools
 
 from . import utils
+
+# It is fine for a test to access a protected member so allow it for all tests
+# pylint: disable=protected-access
 
 HTML1 = """<ul class="tree">
 <li>
@@ -161,7 +164,7 @@ ISSUES_NEW_FORMAT = {
 class TestPluginTools(utils.BaseTestCase):
     """ Unit tests for plugintools code. """
     def test_summary_empty(self):
-        filtered = OutputManager().get()
+        filtered = OutputManager().get_builder().to(fmt="json")
         self.assertEqual(filtered, '{}')
 
     def test_summary_mode_short_legacy(self):
@@ -174,8 +177,7 @@ class TestPluginTools(utils.BaseTestCase):
                             'id': '1234',
                             'message': 'a msg'}]}}
 
-        filtered = OutputManager().minimise(ISSUES_LEGACY_FORMAT,
-                                            mode='short')
+        filtered = OutputBuilder._minimise(ISSUES_LEGACY_FORMAT, mode='short')
         self.assertEqual(filtered, expected)
 
     def test_summary_mode_short(self):
@@ -186,7 +188,7 @@ class TestPluginTools(utils.BaseTestCase):
                         'testplugin': [{
                             'id': '1234',
                             'message': 'a msg'}]}}
-        filtered = OutputManager().minimise(ISSUES_NEW_FORMAT, mode='short')
+        filtered = OutputBuilder._minimise(ISSUES_NEW_FORMAT, mode='short')
         self.assertEqual(filtered, expected)
 
     def test_summary_mode_very_short_legacy(self):
@@ -195,8 +197,8 @@ class TestPluginTools(utils.BaseTestCase):
                             'MemoryWarning': 1}},
                     IssuesManager.SUMMARY_OUT_BUGS_ROOT: {
                         'testplugin': ['1234']}}
-        filtered = OutputManager().minimise(ISSUES_LEGACY_FORMAT,
-                                            mode='very-short')
+        filtered = OutputBuilder._minimise(ISSUES_LEGACY_FORMAT,
+                                           mode='very-short')
         self.assertEqual(filtered, expected)
 
     def test_summary_mode_very_short(self):
@@ -206,18 +208,13 @@ class TestPluginTools(utils.BaseTestCase):
                     IssuesManager.SUMMARY_OUT_BUGS_ROOT: {
                         'testplugin': ['1234']}}
 
-        filtered = OutputManager().minimise(ISSUES_NEW_FORMAT,
-                                            mode='very-short')
+        filtered = OutputBuilder._minimise(ISSUES_NEW_FORMAT,
+                                           mode='very-short')
         self.assertEqual(filtered, expected)
-
-    def test_apply_output_formatting_defaults(self):
-        summary = {'opt': 'value'}
-        filtered = OutputManager(summary).get()
-        self.assertEqual(filtered, plugintools.yaml_dump(summary))
 
     def test_apply_output_formatting_json(self):
         summary = {'opt': 'value'}
-        filtered = OutputManager(summary).get(fmt='json')
+        filtered = OutputManager(summary).get_builder().to("json")
         self.assertEqual(filtered, json.dumps(summary, indent=2,
                                               sort_keys=True))
 
@@ -256,7 +253,7 @@ plain value
 - a
 - b
 - c'''
-        filtered = OutputManager(summary).get(fmt='markdown')
+        filtered = OutputManager(summary).get_builder().to(fmt="markdown")
         self.assertEqual(filtered, expected)
 
     def test_apply_output_formatting_html_1(self):
@@ -276,7 +273,7 @@ plain value
                 ['a', 'b', 'c'],
         }
         expected = htmlout.header + HTML1 + htmlout.footer
-        filtered = OutputManager(summary).get(fmt='html')
+        filtered = OutputManager(summary).get_builder().to(fmt="html")
         self.assertEqual(filtered, expected)
 
     def test_apply_output_formatting_html_2(self):
@@ -296,7 +293,7 @@ plain value
                 ['a', 'b', 'c'],
         }
         expected = htmlout.header + HTML2 + htmlout.footer
-        filtered = OutputManager(summary).get(fmt='html')
+        filtered = OutputManager(summary).get_builder().to(fmt="html")
         self.assertEqual(filtered, expected)
 
     def test_apply_output_formatting_html_3(self):
@@ -316,5 +313,5 @@ plain value
                 ['a', 'b', 'c'],
         }
         expected = htmlout.header + HTML3 + htmlout.footer
-        filtered = OutputManager(summary).get(fmt='html')
+        filtered = OutputManager(summary).get_builder().to(fmt="html")
         self.assertEqual(filtered, expected)

--- a/tests/unit/test_ut_scenario_loader.py
+++ b/tests/unit/test_ut_scenario_loader.py
@@ -220,8 +220,10 @@ class TestScenarioTestLoader(utils.BaseTestCase):
                 fd.write(FAKE_SCENARIO)
             with mock.patch.object(utils, 'DEFS_TESTS_DIR', dtmp):
                 utils.TemplatedTest(
-                    os.path.join(dtmp, 'test1.yaml'),
-                    {}, [], [], [], '/')()(self)
+                    target_path=os.path.join(dtmp, "test1.yaml"),
+                    data_root={},
+                    sub_root="/",
+                )()(self)
 
     def test_scenarios(self):
         with tempfile.TemporaryDirectory() as dtmp, \

--- a/tests/unit/ycheck/test_events.py
+++ b/tests/unit/ycheck/test_events.py
@@ -291,15 +291,16 @@ class TestYamlEvents(utils.BaseTestCase):
                    {'date': '2000-01-01', 'key': 'f3'},
                    {'date': '2000-01-02', 'key': 'f2'}]
         for r in results:
-            EventProcessingUtils._get_tally(r, info, key_by_date=True,
-                                            include_time=False,
-                                            squash_if_none_keys=False)
+            EventProcessingUtils._get_tally(
+                r, info, options=EventProcessingUtils.EventProcessingOptions()
+            )
         self.assertEqual(info, {'2000-01-04': {'f4': 1},
                                 '2000-01-01': {'f1': 1,
                                                'f3': 1},
                                 '2000-01-02': {'f2': 1}})
-        ret = EventProcessingUtils._sort_results(info, key_by_date=True,
-                                                 include_time=False,)
+        ret = EventProcessingUtils._sort_results(
+            info, options=EventProcessingUtils.EventProcessingOptions()
+        )
         expected = {'2000-01-01': {'f1': 1,
                                    'f3': 1},
                     '2000-01-02': {'f2': 1},
@@ -316,16 +317,21 @@ class TestYamlEvents(utils.BaseTestCase):
                    {'date': '2000-01-03', 'key': 'f3'},
                    {'date': '2000-01-02', 'key': 'f2'}]
         for r in results:
-            EventProcessingUtils._get_tally(r, info, key_by_date=False,
-                                            include_time=False,
-                                            squash_if_none_keys=False)
+            EventProcessingUtils._get_tally(
+                r,
+                info,
+                options=EventProcessingUtils.EventProcessingOptions(
+                  key_by_date=False),
+            )
         self.assertEqual(info, {'f1': {'2000-01-01': 1},
                                 'f2': {'2000-01-02': 1},
                                 'f3': {'2000-01-01': 1,
                                        '2000-01-03': 1},
                                 'f4': {'2000-01-04': 1}})
-        ret = EventProcessingUtils._sort_results(info, key_by_date=False,
-                                                 include_time=False,)
+        ret = EventProcessingUtils._sort_results(
+            info, options=EventProcessingUtils.EventProcessingOptions(
+              key_by_date=False)
+        )
         expected = {'f4': {'2000-01-04': 1},
                     'f3': {'2000-01-01': 1,
                            '2000-01-03': 1},

--- a/tests/unit/ycheck/test_scenarios.py
+++ b/tests/unit/ycheck/test_scenarios.py
@@ -241,6 +241,7 @@ class TestYamlScenarios(utils.BaseTestCase):  # noqa, pylint: disable=too-many-p
     @mock.patch('hotsos.core.ycheck.engine.properties.common.log')
     @utils.init_test_scenario(test_data.SCENARIO_W_ERROR)
     @utils.global_search_context
+    # pylint: disable-next=too-many-arguments
     def test_failed_scenario_caught(self, global_searcher, mock_log1,
                                     mock_log2, _mock_log3,
                                     mock_log4, mock_log5, mock_log6):
@@ -353,6 +354,7 @@ class TestYamlScenarios(utils.BaseTestCase):  # noqa, pylint: disable=too-many-p
     @mock.patch('hotsos.core.ycheck.engine.properties.common.log')
     @utils.init_test_scenario(test_data.LOGIC_TEST)
     @utils.global_search_context
+    # pylint: disable-next=too-many-arguments
     def test_logical_collection_and_with_fail(self, global_searcher, mock_log1,
                                               mock_log2, _mock_log3, mock_log4,
                                               mock_log5, mock_log6,


### PR DESCRIPTION
started using dataclass types for grouping long list of arguments.

Suppressed the warning for test functions.