### PR TITLE
fix ci breakage after commit dd51c3f

### DIFF
--- a/hotsos/core/ycheck/engine/properties/requires/types/pebble.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/pebble.py
@@ -24,7 +24,7 @@ class YRequirementTypePebble(service_manager_common.ServiceManagerTypeBase):
     override_autoregister = True
     default_op = 'eq'
 
-    def _check_item_settings(self, svc, svc_obj, settings, cache_info,
+    def _check_item_settings(self, svc_obj, settings, cache_info,
                              all_items):
         processes = None
         if isinstance(settings, str):
@@ -46,8 +46,8 @@ class YRequirementTypePebble(service_manager_common.ServiceManagerTypeBase):
                       "- %s", ', '.join(processes))
             return False
 
-        cache_info[svc]['ops'] = self.ops_to_str(ops)
-        return self.self.apply_ops(ops, input=svc_obj.state)
+        cache_info[svc_obj.name]['ops'] = self.ops_to_str(ops)
+        return self.apply_ops(ops, opinput=svc_obj.state)
 
     @property
     def items_to_check(self):

--- a/hotsos/core/ycheck/engine/properties/requires/types/service_manager_common.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/service_manager_common.py
@@ -37,7 +37,7 @@ class ServiceManagerTypeBase(YRequirementTypeBase):
                 if settings is None:
                     continue
 
-                _result = self._check_item_settings(svc, svc_obj, settings,
+                _result = self._check_item_settings(svc_obj, settings,
                                                     cache_info, items)
                 if not _result:
                     # bail on first fail

--- a/hotsos/core/ycheck/engine/properties/requires/types/systemd.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/systemd.py
@@ -73,7 +73,7 @@ class YRequirementTypeSystemd(service_manager_common.ServiceManagerTypeBase):
 
         return self.apply_ops(ops, opinput=svc.state)
 
-    def _check_item_settings(self, svc, svc_obj, settings, cache_info,
+    def _check_item_settings(self, svc_obj, settings, cache_info,
                              all_items):
         # pylint: disable=duplicate-code
         processes = None
@@ -100,7 +100,7 @@ class YRequirementTypeSystemd(service_manager_common.ServiceManagerTypeBase):
                       "- %s", ', '.join(processes))
             return False
 
-        cache_info[svc]['ops'] = self.ops_to_str(ops)
+        cache_info[svc_obj.name]['ops'] = self.ops_to_str(ops)
         return self._check_service(svc_obj, ops,
                                    started_after=started_after_obj)
 

--- a/hotsos/plugin_extensions/openstack/agent/events.py
+++ b/hotsos/plugin_extensions/openstack/agent/events.py
@@ -325,6 +325,7 @@ class ApparmorCallback(OpenstackEventCallbackBase):
     event_names = ['nova', 'neutron']
 
     def __call__(self, event):
+        # pylint: disable=duplicate-code
         results = [{'date': f"{r.get(1)} {r.get(2)}",
                     'time': r.get(3),
                     'key': r.get(4)} for r in event.results]

--- a/hotsos/plugin_extensions/openvswitch/event_checks.py
+++ b/hotsos/plugin_extensions/openvswitch/event_checks.py
@@ -54,6 +54,7 @@ class OVSEventCallbackDALR(OpenvSwitchEventCallbackBase):
     event_names = ['deferred-action-limit-reached']
 
     def __call__(self, event):
+        # pylint: disable=duplicate-code
         results = [{'date': f"{r.get(1)} {r.get(2)}",
                     'time': r.get(3),
                     'key': r.get(4)} for r in event.results]


### PR DESCRIPTION
dd51c3f5565ef14decf9273423ceaf7341600736

the ci is failing due to pylint too-many-arguments and duplicate-code warnings.

it's an example for the issue described here: https://github.com/canonical/hotsos/issues/957

fixed the following:

too-many-arguments: removed svc parameter from the _check_item_settings as it's already included in the service object.

duplicate-code: suppressed the warning.