### PR TITLE
pylintrc: re-enable too-few-public-methods

### DIFF
--- a/hotsos/core/config.py
+++ b/hotsos/core/config.py
@@ -1,19 +1,21 @@
 import abc
 import copy
 from collections import UserDict
+from dataclasses import dataclass
 
 from hotsos.core.exceptions import (
     NameAlreadyRegisteredError,
 )
 
 
-class ConfigOpt():
+@dataclass
+class ConfigOpt:
     """ Basic information required to define a config option. """
-    def __init__(self, name, description, default_value, value_type):
-        self.name = name
-        self.description = description
-        self.default_value = default_value
-        self.value_type = value_type
+
+    name: str
+    description: str
+    default_value: str
+    value_type: type
 
 
 class ConfigOptGroupBase(UserDict):

--- a/hotsos/core/factory.py
+++ b/hotsos/core/factory.py
@@ -1,6 +1,7 @@
 import abc
 
 
+# pylint: disable-next= too-few-public-methods
 class FactoryBase(abc.ABC):
     """
     Provide a common way to implement factory objects.

--- a/hotsos/core/host_helpers/apparmor.py
+++ b/hotsos/core/host_helpers/apparmor.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from dataclasses import dataclass, field
 
 # NOTE: we import direct from searchkit rather than hotsos.core.search to
 #       avoid circular dependency issues.
@@ -11,11 +12,14 @@ from hotsos.core.factory import FactoryBase
 from hotsos.core.host_helpers.cli import CLIHelperFile
 
 
+@dataclass
 class AAProfile():
     """ Representation of an Apparmor profile. """
-    def __init__(self, name):
-        self.name = name
-        self.mode = ApparmorHelper().get_profile_mode(name)
+    name: str
+    mode: str = field(init=False)
+
+    def __post_init__(self):
+        self.mode = ApparmorHelper().get_profile_mode(self.name)
 
 
 class ApparmorHelper():

--- a/hotsos/core/host_helpers/cli.py
+++ b/hotsos/core/host_helpers/cli.py
@@ -323,13 +323,17 @@ class OVSAppCtlFileCmd(FileCmd):
         return out
 
 
-class OVSOFCtlCmdBase():
-    """ Base class for implementations of ovs-ofctl command. """
-    OFPROTOCOL_VERSIONS = ['OpenFlow15', 'OpenFlow14', 'OpenFlow13',
-                           'OpenFlow12', 'OpenFlow11', 'OpenFlow10']
+OFPROTOCOL_VERSIONS = [
+    "OpenFlow15",
+    "OpenFlow14",
+    "OpenFlow13",
+    "OpenFlow12",
+    "OpenFlow11",
+    "OpenFlow10",
+]
 
 
-class OVSOFCtlBinCmd(OVSOFCtlCmdBase, BinCmd):
+class OVSOFCtlBinCmd(BinCmd):
     """ Implementation of ovs-ofctl binary command. """
     def __call__(self, *args, **kwargs):
         """
@@ -347,7 +351,7 @@ class OVSOFCtlBinCmd(OVSOFCtlCmdBase, BinCmd):
         # catch_exceptions decorator and [] returned. We have no way of knowing
         # if that was the actual return or an exception was raised so we just
         # go ahead and retry with specific OF versions until we get a result.
-        for ver in self.OFPROTOCOL_VERSIONS:
+        for ver in OFPROTOCOL_VERSIONS:
             log.debug("%s: trying again with protocol version %s",
                       self.__class__.__name__, ver)
             self.reset()
@@ -361,14 +365,14 @@ class OVSOFCtlBinCmd(OVSOFCtlCmdBase, BinCmd):
         return CmdOutput([])
 
 
-class OVSOFCtlFileCmd(OVSOFCtlCmdBase, FileCmd):
+class OVSOFCtlFileCmd(FileCmd):
     """ Implementation of ovs-ofctl file-based command. """
     def __call__(self, *args, **kwargs):
         """
         We do this in reverse order to bin command since it won't actually
         raise an error.
         """
-        for ver in self.OFPROTOCOL_VERSIONS:
+        for ver in OFPROTOCOL_VERSIONS:
             log.debug("%s: trying again with protocol version %s",
                       self.__class__.__name__, ver)
             self.reset()

--- a/hotsos/core/host_helpers/common.py
+++ b/hotsos/core/host_helpers/common.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import re
 from functools import cached_property
+from dataclasses import dataclass
 
 from searchkit.utils import MPCache
 from hotsos.core.config import HotSOSConfig
@@ -194,15 +195,14 @@ class NullSource():
         return CmdOutput([])
 
 
+@dataclass(frozen=True)
 class CmdOutput():
     """ Representation of the output of a command. """
-    def __init__(self, value, source=None):
-        """
-        @param value: output value.
-        @param source: optional command source path.
-        """
-        self.value = value
-        self.source = source
+
+    # Output value.
+    value: str
+    # Optional command source path.
+    source: str = None
 
 
 class SourceRunner():

--- a/hotsos/core/host_helpers/packaging.py
+++ b/hotsos/core/host_helpers/packaging.py
@@ -1,6 +1,7 @@
 import abc
 import re
 import subprocess
+from dataclasses import dataclass
 
 from hotsos.core.factory import FactoryBase
 from hotsos.core.host_helpers.cli import CLIHelper
@@ -476,11 +477,11 @@ class APTPackageHelper(PackageHelperBase):
         return self._core_packages
 
 
-class AptPackage():
+@dataclass(frozen=True)
+class AptPackage:
     """ Representation of an APT package.  """
-    def __init__(self, name, version):
-        self.name = name
-        self.version = version
+    name: str
+    version: str
 
 
 class AptFactory(FactoryBase):

--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-few-public-methods
+
 import abc
 
 

--- a/hotsos/core/plugins/juju/resources.py
+++ b/hotsos/core/plugins/juju/resources.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 from functools import cached_property
+from dataclasses import dataclass
 
 import yaml
 from hotsos.core.config import HotSOSConfig
@@ -167,11 +168,12 @@ class JujuUnit():
         return info
 
 
-class JujuCharm():
+@dataclass(frozen=True)
+class JujuCharm:
     """ Juju charm interface. """
-    def __init__(self, name, version):
-        self.name = name
-        self.version = int(version)
+
+    name: str
+    version: int
 
 
 class JujuBase():

--- a/hotsos/core/plugins/kernel/net.py
+++ b/hotsos/core/plugins/kernel/net.py
@@ -36,7 +36,7 @@ class ProcNetBase(abc.ABC):
 
         return round((count * 100.0) / total, 2)
 
-    def _process_file(self, fname):
+    def process_file(self, fname):
         if not os.path.exists(fname):
             log.debug("file not found '%s' - skipping load", fname)
             return
@@ -104,8 +104,8 @@ class SNMPBase(ProcNetBase):
     """ Base class for /proc/net/snmp interface implementations. """
     def __init__(self):
         super().__init__()
-        self._process_file(os.path.join(HotSOSConfig.data_root,
-                                        'proc/net/snmp'))
+        self.process_file(os.path.join(HotSOSConfig.data_root,
+                                       'proc/net/snmp'))
 
 
 class SNMPTcp(SNMPBase):
@@ -202,8 +202,8 @@ class NetStatBase(ProcNetBase):
     """ Base class for /proc/net/netstat implementations.  """
     def __init__(self):
         super().__init__()
-        self._process_file(os.path.join(HotSOSConfig.data_root,
-                                        'proc/net/netstat'))
+        self.process_file(os.path.join(HotSOSConfig.data_root,
+                                       'proc/net/netstat'))
         self.net_snmp_tcp = SNMPTcp()
 
 

--- a/hotsos/core/plugins/openstack/neutron.py
+++ b/hotsos/core/plugins/openstack/neutron.py
@@ -1,6 +1,7 @@
 import os
 import re
 from functools import cached_property
+from dataclasses import dataclass
 
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.factory import FactoryBase
@@ -67,12 +68,13 @@ class ServiceChecks():
         return run_manually
 
 
-class NeutronRouter():
+@dataclass
+class NeutronRouter:
     """ Representation of a Neutron router. """
-    def __init__(self, uuid, ha_state):
-        self.uuid = uuid
-        self.ha_state = ha_state
-        self.vr_id = None
+
+    uuid: str
+    ha_state: str
+    vr_id: str = None
 
 
 class NeutronHAInfo():

--- a/hotsos/core/plugins/openvswitch/ovn.py
+++ b/hotsos/core/plugins/openvswitch/ovn.py
@@ -1,5 +1,6 @@
 import abc
 from functools import cached_property
+from dataclasses import dataclass
 
 from hotsos.core.log import log
 from hotsos.core.search import (
@@ -14,11 +15,12 @@ from hotsos.core.host_helpers import SystemdHelper
 from hotsos.core.plugins.openvswitch.common import OVS_SERVICES_EXPRS
 
 
-class OVNSBDBPort():
+@dataclass
+class OVNSBDBPort:
     """ Representation of OVS SBDB port """
-    def __init__(self, name, port_type):
-        self.name = name
-        self.type = port_type
+
+    name: str
+    port_type: str
 
 
 class OVNSBDBChassis():
@@ -47,7 +49,7 @@ class OVNSBDBChassis():
 
     @cached_property
     def cr_ports(self):
-        return [p for p in self._ports if p.type == 'cr-lrp']
+        return [p for p in self._ports if p.port_type == 'cr-lrp']
 
 
 class OVNDBBase():

--- a/pylintrc
+++ b/pylintrc
@@ -23,8 +23,10 @@ score=yes
 disable=
  missing-function-docstring,
  missing-module-docstring,
- too-few-public-methods,
  too-many-ancestors,
  too-many-branches,
  too-many-instance-attributes,
  too-many-locals,
+
+[DESIGN]
+min-public-methods=1

--- a/tests/unit/test_openvswitch.py
+++ b/tests/unit/test_openvswitch.py
@@ -541,7 +541,7 @@ class TestOpenvswitchScenarios(TestOpenvswitchBase):
                 new=utils.is_def_filter('ovn_central_services.yaml',
                                         'scenarios/openvswitch'))
     def test_ovn_northd_running(self, mock_systemd):
-
+        # pylint: disable-next=too-few-public-methods
         class FakeSystemdHelper():
             """ fake systemd helper """
             def __init__(self, svcs):

--- a/tests/unit/test_ut_scenario_loader.py
+++ b/tests/unit/test_ut_scenario_loader.py
@@ -160,7 +160,7 @@ class TestScenarioTestLoader(utils.BaseTestCase):
             self.create_tests(dtmp)
             with mock.patch.object(utils, 'DEFS_TESTS_DIR',
                                    os.path.join(dtmp, 'tests')):
-                class FakeTests():
+                class FakeTests():  # pylint: disable=R0903
                     """ dummy tests """
                     @utils.load_templated_tests('scenarios/testplugin/1')
                     @staticmethod
@@ -180,7 +180,8 @@ class TestScenarioTestLoader(utils.BaseTestCase):
             self.create_tests(dtmp, levels=3)
             with mock.patch.object(utils, 'DEFS_TESTS_DIR', dtmp + '/tests'):
                 @utils.load_templated_tests('scenarios/testplugin/1')
-                class FakeTests():  # pylint: disable=W0612
+                # pylint: disable-next=too-few-public-methods, unused-variable
+                class FakeTests():
                     """ dummy tests """
 
                 plugin_path = 'tests/scenarios/testplugin'

--- a/tests/unit/ycheck/test_properties.py
+++ b/tests/unit/ycheck/test_properties.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 from functools import cached_property
 from unittest import mock
+from dataclasses import dataclass
 
 import yaml
 from hotsos.core.config import HotSOSConfig
@@ -53,21 +54,27 @@ class TestConfig(IniConfigBase):
 
 class FakeServiceObjectManager():
     """ Fake service manager. """
+
     def __init__(self, start_times):
         self._start_times = start_times
 
     def __call__(self, name, state, has_instances):
-        return FakeService(name, state, has_instances,
-                           start_time=self._start_times[name])
+        return FakeService(
+            name=name,
+            state=state,
+            has_instances=has_instances,
+            start_time=self._start_times[name],
+        )
 
 
+@dataclass
 class FakeService():
     """ Fake service """
-    def __init__(self, name, state, has_instances, start_time):
-        self.name = name
-        self.state = state
-        self.start_time = start_time
-        self.has_instances = has_instances
+
+    name: str
+    state: str
+    start_time: str
+    has_instances: bool
 
 
 YAML_DEF_REQUIRES_BIN_SHORT = """


### PR DESCRIPTION
converted classes without any public methods to dataclasses 
suppressed the warning where it's a legitimate use case (e.g. issue types)

set the min-public-methods to 1