### PR TITLE
Fix module interface definitions

### DIFF
--- a/hotsos/core/host_helpers/__init__.py
+++ b/hotsos/core/host_helpers/__init__.py
@@ -1,39 +1,61 @@
-from .cli import (  # noqa: F403,F401
+from .cli import (
     CLIHelper,
     CLIHelperFile,
 )
-from .config import (  # noqa: F403,F401
+from .config import (
     ConfigBase,
     IniConfigBase,
 )
-from .network import (  # noqa: F403,F401
+from .network import (
     NetworkPort,
     HostNetworkingHelper,
 )
-from .packaging import (  # noqa: F403,F401
+from .packaging import (
     DPKGVersion,
     APTPackageHelper,
     DockerImageHelper,
     SnapPackageHelper,
 )
-from .pebble import (  # noqa: F403,F401 pylint: disable=cyclic-import
+from .pebble import (  # pylint: disable=cyclic-import
     PebbleHelper,
 )
-from .ssl import (  # noqa: F403,F401
+from .ssl import (
     SSLCertificate,
     SSLCertificatesHelper,
 )
-from .systemd import (  # noqa: F403,F401 pylint: disable=cyclic-import
+from .systemd import (  # pylint: disable=cyclic-import
     SystemdHelper,
 )
-from .uptime import (  # noqa: F403,F401 pylint: disable=cyclic-import
+from .uptime import (  # pylint: disable=cyclic-import
     UptimeHelper,
 )
-from .sysctl import (  # noqa: F403,F401
+from .sysctl import (
     SYSCtlFactory,
     SYSCtlConfHelper,
 )
-from .apparmor import (  # noqa: F403,F401
+from .apparmor import (
     AAProfileFactory,
     ApparmorHelper,
 )
+
+__all__ = [
+    CLIHelper.__name__,
+    CLIHelperFile.__name__,
+    ConfigBase.__name__,
+    IniConfigBase.__name__,
+    NetworkPort.__name__,
+    HostNetworkingHelper.__name__,
+    DPKGVersion.__name__,
+    APTPackageHelper.__name__,
+    DockerImageHelper.__name__,
+    SnapPackageHelper.__name__,
+    PebbleHelper.__name__,
+    SSLCertificate.__name__,
+    SSLCertificatesHelper.__name__,
+    SystemdHelper.__name__,
+    UptimeHelper.__name__,
+    SYSCtlFactory.__name__,
+    SYSCtlConfHelper.__name__,
+    AAProfileFactory.__name__,
+    ApparmorHelper.__name__,
+]

--- a/hotsos/core/issues/__init__.py
+++ b/hotsos/core/issues/__init__.py
@@ -1,5 +1,10 @@
 from .issue_types import *  # noqa: F403,F401
-from .utils import (   # noqa: F403,F401
+from .utils import (
     IssuesManager,
     IssueContext,
 )
+
+__all__ = [
+    IssuesManager.__name__,
+    IssueContext.__name__,
+    ]

--- a/hotsos/core/plugins/juju/__init__.py
+++ b/hotsos/core/plugins/juju/__init__.py
@@ -1,2 +1,7 @@
-from .common import JujuChecks  # noqa: F403,F401
-from .resources import JujuBinaryInterface  # noqa: F403,F401
+from .common import JujuChecks
+from .resources import JujuBinaryInterface
+
+__all__ = [
+    JujuChecks.__name__,
+    JujuBinaryInterface.__name__,
+    ]

--- a/hotsos/core/plugins/kernel/__init__.py
+++ b/hotsos/core/plugins/kernel/__init__.py
@@ -1,3 +1,9 @@
-from .common import KernelBase  # noqa: F403,F401
-from .config import SystemdConfig  # noqa: F403,F401
-from .kernlog import CallTraceManager  # noqa: F403,F401
+from .common import KernelBase
+from .config import SystemdConfig
+from .kernlog import CallTraceManager
+
+__all__ = [
+    CallTraceManager.__name__,
+    KernelBase.__name__,
+    SystemdConfig.__name__,
+    ]

--- a/hotsos/core/plugins/kernel/kernlog/__init__.py
+++ b/hotsos/core/plugins/kernel/kernlog/__init__.py
@@ -1,2 +1,7 @@
-from .calltrace import CallTraceManager  # noqa: F403,F401
-from .events import KernLogEvents  # noqa: F403,F401
+from .calltrace import CallTraceManager
+from .events import KernLogEvents
+
+__all__ = [
+    CallTraceManager.__name__,
+    KernLogEvents.__name__,
+    ]

--- a/hotsos/core/plugins/lxd/__init__.py
+++ b/hotsos/core/plugins/lxd/__init__.py
@@ -1,1 +1,6 @@
-from .common import LXD, LXDChecks  # noqa: F403,F401
+from .common import LXD, LXDChecks
+
+__all__ = [
+    LXD.__name__,
+    LXDChecks.__name__,
+    ]

--- a/hotsos/core/plugins/openstack/__init__.py
+++ b/hotsos/core/plugins/openstack/__init__.py
@@ -1,7 +1,15 @@
-from .common import (  # noqa: F403,F401
+from .common import (
     OpenstackBase,
     OpenStackChecks,
     OpenstackEventHandlerBase,
     OpenstackEventCallbackBase,
 )
-from .openstack import OpenstackConfig  # noqa: F403,F401
+from .openstack import OpenstackConfig
+
+__all__ = [
+    OpenstackBase.__name__,
+    OpenStackChecks.__name__,
+    OpenstackConfig.__name__,
+    OpenstackEventHandlerBase.__name__,
+    OpenstackEventCallbackBase.__name__,
+    ]

--- a/hotsos/core/plugins/openvswitch/__init__.py
+++ b/hotsos/core/plugins/openvswitch/__init__.py
@@ -1,5 +1,5 @@
-from .common import OpenvSwitchChecks  # noqa: F403,F401
-from .ovs import (  # noqa: F403,F401
+from .common import OpenvSwitchChecks
+from .ovs import (
     OpenvSwitchBase,
     OVSBFD,
     OVSDB,
@@ -7,3 +7,13 @@ from .ovs import (  # noqa: F403,F401
     OVSBridge,
     OVSDPDK,
 )
+
+__all__ = [
+    OpenvSwitchChecks.__name__,
+    OpenvSwitchBase.__name__,
+    OVSBFD.__name__,
+    OVSBridge.__name__,
+    OVSDB.__name__,
+    OVSDPDK.__name__,
+    OVSDPLookups.__name__,
+    ]

--- a/hotsos/core/plugins/rabbitmq/__init__.py
+++ b/hotsos/core/plugins/rabbitmq/__init__.py
@@ -1,2 +1,7 @@
-from .common import RabbitMQChecks  # noqa: F403,F401
-from .report import RabbitMQReport  # noqa: F403,F401
+from .common import RabbitMQChecks
+from .report import RabbitMQReport
+
+__all__ = [
+    RabbitMQChecks.__name__,
+    RabbitMQReport.__name__,
+    ]

--- a/hotsos/core/plugins/storage/ceph/__init__.py
+++ b/hotsos/core/plugins/storage/ceph/__init__.py
@@ -1,8 +1,10 @@
 from .common import CephChecks, CephConfig, CephDaemonAllOSDsFactory
 from .cluster import CephCluster, CephCrushMap
 
-__all__ = [CephChecks.__name__,
-           CephConfig.__name__,
-           CephDaemonAllOSDsFactory.__name__,
-           CephCluster.__name__,
-           CephCrushMap.__name__]
+__all__ = [
+    CephChecks.__name__,
+    CephConfig.__name__,
+    CephDaemonAllOSDsFactory.__name__,
+    CephCluster.__name__,
+    CephCrushMap.__name__
+    ]

--- a/hotsos/core/plugins/system/__init__.py
+++ b/hotsos/core/plugins/system/__init__.py
@@ -1,1 +1,6 @@
-from .common import SystemBase, SystemChecks  # noqa: F403,F401
+from .common import SystemBase, SystemChecks
+
+__all__ = [
+    SystemBase.__name__,
+    SystemChecks.__name__,
+    ]

--- a/hotsos/core/search.py
+++ b/hotsos/core/search.py
@@ -2,7 +2,7 @@ import os
 from datetime import timedelta
 from functools import cached_property
 
-from searchkit import (   # noqa: F403,F401, pylint: disable=W0611
+from searchkit import (
     FileSearcher as _FileSearcher,
     ResultFieldInfo,
     SearchDef,
@@ -15,6 +15,14 @@ from searchkit.constraints import (
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers import CLIHelper, UptimeHelper
 from hotsos.core.log import log
+
+
+# This module acts as a proxy to searchkit but with some addons/modifications
+__all__ = [
+    ResultFieldInfo.__name__,
+    SearchDef.__name__,
+    SequenceSearchDef.__name__,
+    ]
 
 
 class FileSearcher(_FileSearcher):

--- a/hotsos/core/ycheck/__init__.py
+++ b/hotsos/core/ycheck/__init__.py
@@ -1,1 +1,5 @@
-from .engine.common import YDefsLoader   # noqa: F403,F401
+from .engine.common import YDefsLoader
+
+__all__ = [
+    YDefsLoader.__name__,
+    ]

--- a/hotsos/core/ycheck/engine/__init__.py
+++ b/hotsos/core/ycheck/engine/__init__.py
@@ -1,5 +1,11 @@
-from .common import (  # noqa: F403,F401
+from .common import (
     YDefsLoader,
     YHandlerBase,
 )
-from .properties import YDefsSection  # noqa: F403,F401
+from .properties import YDefsSection
+
+__all__ = [
+    YDefsLoader.__name__,
+    YHandlerBase.__name__,
+    YDefsSection.__name__,
+    ]

--- a/hotsos/core/ycheck/engine/properties/__init__.py
+++ b/hotsos/core/ycheck/engine/properties/__init__.py
@@ -1,4 +1,6 @@
-# the following are done to allow the decorators to do their thing
+# The following check property modules need to be imported so that the property
+# classes within them get autoregistered. We do not add them to the interface
+# list for this module since they are not accessed that way.
 from hotsos.core.ycheck.engine.properties import (  # noqa: F403,F401
     checks,
     conclusions,
@@ -6,10 +8,9 @@ from hotsos.core.ycheck.engine.properties import (  # noqa: F403,F401
     search,
     vardef,
 )
-import hotsos.core.ycheck.engine.properties.requires.requires  # noqa:F403,F401
-from hotsos.core.ycheck.engine.properties.requires.types import (  \
-    # noqa:F403,F401
-    config,
-)
+from hotsos.core.ycheck.engine.properties.common import YDefsSection
 
-from .common import YDefsSection  # noqa: F403,F401
+
+__all__ = [
+    YDefsSection.__name__,
+    ]

--- a/hotsos/core/ycheck/engine/properties/requires/__init__.py
+++ b/hotsos/core/ycheck/engine/properties/requires/__init__.py
@@ -1,4 +1,4 @@
-from .common import (  # noqa: F403,F401
+from .common import (
     intercept_exception,
     OpsUtils,
     CheckItemsBase,
@@ -7,3 +7,13 @@ from .common import (  # noqa: F403,F401
     PackageCheckItemsBase,
     ServiceCheckItemsBase,
 )
+
+__all__ = [
+    intercept_exception.__name__,
+    OpsUtils.__name__,
+    CheckItemsBase.__name__,
+    YRequirementTypeBase.__name__,
+    YRequirementTypeWithOpsBase.__name__,
+    PackageCheckItemsBase.__name__,
+    ServiceCheckItemsBase.__name__,
+    ]

--- a/hotsos/plugin_extensions/openstack/__init__.py
+++ b/hotsos/plugin_extensions/openstack/__init__.py
@@ -1,11 +1,21 @@
-from . import (  # noqa: F401
+from . import (
     summary,
     service_features,
     service_network_checks,
     vm_info,
     nova_external_events,
 )
-from .agent import (  # noqa: F403,F401
+from .agent import (
     events,
     exceptions,
 )
+
+__all__ = [
+    events,
+    exceptions,
+    nova_external_events,
+    summary,
+    service_features,
+    service_network_checks,
+    vm_info,
+    ]


### PR DESCRIPTION
Removes flake8 error ignores from __init__ files and
add __all__ definitions for module interfaces.
