### PR TITLE
Add check for LP#2085851

### DIFF
--- a/hotsos/defs/scenarios/openstack/cinder/bugs/lp2085851.yaml
+++ b/hotsos/defs/scenarios/openstack/cinder/bugs/lp2085851.yaml
@@ -1,0 +1,31 @@
+vars:
+  cinder_version: '@hotsos.core.host_helpers.packaging.AptFactory.version:cinder-common'
+checks:
+  pkg_with_regression:
+    apt:
+      cinder-common:
+        # caracal
+        - eq: '2:24.0.0-0ubuntu1.2'
+        # bobcat
+        - eq: '2:23.0.0-0ubuntu1.4~cloud0'
+        # antelope
+        - min: '2:22.1.1-0ubuntu1.3~cloud0'
+          max: '2:22.1.1-0ubuntu1.3~cloud1'
+        # yoga
+        - eq: '2:20.3.1-0ubuntu1.4'
+        # ussuri
+        - eq: '2:16.4.2-0ubuntu2.8'
+conclusions:
+  pkg_is_vulnerable:
+    decision:
+      - pkg_with_regression
+    raises:
+      type: LaunchpadBug
+      bug-id: 2085851
+      message: >-
+        The version of Openstack Cinder ({version}) running on this host is
+        impacted by regression LP2085851. There is a fix available in the Ubuntu
+        archives and upgrading is recommended. Please check the bug description
+        for more information.
+      format-dict:
+        version: $cinder_version

--- a/hotsos/defs/tests/scenarios/openstack/cinder/bugs/lp2085851_yoga_no_fix.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/cinder/bugs/lp2085851_yoga_no_fix.yaml
@@ -1,0 +1,15 @@
+target-name: lp2085851.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii  cinder-api                      2:20.3.1-0ubuntu1.4               all          Cinder storage service - API server
+      ii  cinder-common                   2:20.3.1-0ubuntu1.4               all          Cinder storage service - common files
+      ii  cinder-scheduler                2:20.3.1-0ubuntu1.4               all          Cinder storage service - Scheduler server
+      ii  cinder-volume                   2:20.3.1-0ubuntu1.4               all          Cinder storage service - Volume server
+      ii  python3-cinder                  2:20.3.1-0ubuntu1.4               all          Cinder Python 3 libraries
+raised-bugs:
+  https://bugs.launchpad.net/bugs/2085851: >-
+    The version of Openstack Cinder (2:20.3.1-0ubuntu1.4) running on this host is
+    impacted by regression LP2085851. There is a fix available in the Ubuntu
+    archives and upgrading is recommended. Please check the bug description
+    for more information.

--- a/hotsos/defs/tests/scenarios/openstack/cinder/bugs/lp2085851_yoga_w_fix.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/cinder/bugs/lp2085851_yoga_w_fix.yaml
@@ -1,0 +1,11 @@
+target-name: lp2085851.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii  cinder-api                      2:20.3.1-0ubuntu1.5               all          Cinder storage service - API server
+      ii  cinder-common                   2:20.3.1-0ubuntu1.5               all          Cinder storage service - common files
+      ii  cinder-scheduler                2:20.3.1-0ubuntu1.5               all          Cinder storage service - Scheduler server
+      ii  cinder-volume                   2:20.3.1-0ubuntu1.5               all          Cinder storage service - Volume server
+      ii  python3-cinder                  2:20.3.1-0ubuntu1.5               all          Cinder Python 3 libraries
+raised-bugs:  # none
+raised-issues:  # none


### PR DESCRIPTION
This check verifies if installed Cinder packages are affected by the regression reported in LP#2085851.
Affected versions are:
  # caracal
    - '2:24.0.0-0ubuntu1.2' # bobcat
    - '2:23.0.0-0ubuntu1.4~cloud0' # antelope
    - '2:22.1.1-0ubuntu1.3~cloud0'
    - '2:22.1.1-0ubuntu1.3~cloud1' # yoga
    - '2:20.3.1-0ubuntu1.4' # ussuri
    - '2:16.4.2-0ubuntu2.8'