### PR TITLE
Add check for needrestart CVEs

### DIFF
--- a/hotsos/defs/scenarios/system/cve-libmodule-scandeps-perl.yaml
+++ b/hotsos/defs/scenarios/system/cve-libmodule-scandeps-perl.yaml
@@ -1,0 +1,35 @@
+checks:
+  has_scandeps_cve:
+    apt:
+      libmodule-scandeps-perl:
+        # Oracular
+        - min: '1.35-1'
+        - max: '1.35-1'
+        # Noble
+        - min: '1.35-1'
+        - max: '1.35-1'
+        # Jammy
+        - min: '1.31-1'
+        - max: '1.31-1'
+        # Focal
+        - min: '1.27-1'
+        - max: '1.27-1'
+        # Bionic
+        - min: '1.24-1'
+        - max: '1.24-1'
+        # Xenial
+        - min: '1.20-1'
+        - max: '1.20-1'
+conclusions:
+  scandeps_cve:
+    decision: has_scandeps_cve
+    raises:
+      type: MitreCVE
+      cve-id: CVE-2024-10224
+      message: >-
+        Installed package '{package}' with version {version} has a known
+        security vulnerability (CVE-2024-10224). Please upgrade to the
+        latest version to get the fix.
+      format-dict:
+        package: '@checks.has_scandeps_cve.requires.package'
+        version: '@checks.has_scandeps_cve.requires.version'

--- a/hotsos/defs/scenarios/system/cve-needrestart.yaml
+++ b/hotsos/defs/scenarios/system/cve-needrestart.yaml
@@ -1,0 +1,35 @@
+checks:
+  has_needrestart_cve:
+    apt:
+      needrestart:
+        # Oracular
+        - min: '3.6-8'
+        - max: '3.6-8ubuntu4'
+        # Noble
+        - min: '3.6-7'
+        - max: '3.6-7ubuntu4.1'
+        # Jammy
+        - min: '3.5-5'
+        - max: '3.5-5ubuntu2.1'
+        # Focal
+        - min: '3.4-6'
+        - max: '3.4-6ubuntu0.1'
+        # Bionic
+        - min: '3.1-1'
+        - max: '3.1-1ubuntu0.1'
+        # Xenial
+        - min: '2.6-1'
+        - max: '2.6-1'
+conclusions:
+  needrestart_cve:
+    decision: has_needrestart_cve
+    raises:
+      type: MitreCVE
+      cve-id: CVE-2024-48990
+      message: >-
+        Installed package '{package}' with version {version} has a known
+        security vulnerability (CVE-2024-48990). Please upgrade to the
+        latest version to get the fix.
+      format-dict:
+        package: '@checks.has_needrestart_cve.requires.package'
+        version: '@checks.has_needrestart_cve.requires.version'

--- a/hotsos/defs/tests/scenarios/system/cve-libmodule-scandeps-perl-false.yaml
+++ b/hotsos/defs/tests/scenarios/system/cve-libmodule-scandeps-perl-false.yaml
@@ -1,0 +1,9 @@
+target-name: cve-libmodule-scandeps-perl.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii libmodule-scandeps-perl 1.31-1ubuntu0.1 all
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-bugs:  # none expected

--- a/hotsos/defs/tests/scenarios/system/cve-libmodule-scandeps-perl.yaml
+++ b/hotsos/defs/tests/scenarios/system/cve-libmodule-scandeps-perl.yaml
@@ -1,0 +1,12 @@
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii libmodule-scandeps-perl 1.31-1 all
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-bugs:
+  https://www.cve.org/CVERecord?id=CVE-2024-10224: >-
+    Installed package 'libmodule-scandeps-perl' with version 1.31-1 has a known
+    security vulnerability (CVE-2024-10224). Please upgrade to the
+    latest version to get the fix.

--- a/hotsos/defs/tests/scenarios/system/cve-needrestart-false.yaml
+++ b/hotsos/defs/tests/scenarios/system/cve-needrestart-false.yaml
@@ -1,0 +1,9 @@
+target-name: cve-needrestart.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii needrestart 3.5-5ubuntu2.2 all
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-bugs:  # none expected

--- a/hotsos/defs/tests/scenarios/system/cve-needrestart.yaml
+++ b/hotsos/defs/tests/scenarios/system/cve-needrestart.yaml
@@ -1,0 +1,12 @@
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii needrestart 3.5-5ubuntu2.1 all
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-bugs:
+  https://www.cve.org/CVERecord?id=CVE-2024-48990: >-
+    Installed package 'needrestart' with version 3.5-5ubuntu2.1 has a known
+    security vulnerability (CVE-2024-48990). Please upgrade to the
+    latest version to get the fix.


### PR DESCRIPTION
Verifies if needrestart and libmodule-scandeps-perl packages are affected by multiple CVEs. The Focal and older release fixes are available for ESM customers.