### PR TITLE
Fall back to dmesg if kern.log not found

### DIFF
--- a/hotsos/core/plugins/kernel/kernlog/calltrace.py
+++ b/hotsos/core/plugins/kernel/kernlog/calltrace.py
@@ -484,7 +484,8 @@ class CallTraceManager(KernLogBase):
 
     def run(self):
         for tracetype in self.tracetypes:
-            self.searcher.add(tracetype.searchdef, self.path)
+            self.searcher.add(tracetype.searchdef, self.path[0],
+                              allow_global_constraints=self.path[1])
 
         self.results = self.searcher.run()
         for tracetype in self.tracetypes:

--- a/hotsos/core/plugins/kernel/kernlog/common.py
+++ b/hotsos/core/plugins/kernel/kernlog/common.py
@@ -92,8 +92,21 @@ class KernLogBase():
 
     @property
     def path(self):
-        path = os.path.join(HotSOSConfig.data_root, 'var/log/kern.log')
-        if HotSOSConfig.use_all_logs:
-            return f"{path}*"
+        """
+        Return path we want to search. By default we search kern.log but that
+        may not exist e.g. if rsyslogd is not running so fallback to dmesg if
+        not.
 
-        return path
+        @return: tuple (path, bool value indicating whether to allow global
+                              search constraints on the path)
+        """
+        path = os.path.join(HotSOSConfig.data_root, 'var/log/kern.log')
+        if os.path.exists(path):
+            if HotSOSConfig.use_all_logs:
+                path = f"{path}*"
+
+            return path, True
+
+        # NOTE: don't allow constraints for dmesg since it doesn't have
+        #       proper timestamps.
+        return os.path.join(HotSOSConfig.data_root, 'var/log/dmesg'), False

--- a/hotsos/core/plugins/kernel/kernlog/events.py
+++ b/hotsos/core/plugins/kernel/kernlog/events.py
@@ -8,7 +8,8 @@ class KernLogEvents(KernLogBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for event in [self.over_mtu_dropped_packets_search_def]:
-            self.searcher.add(event, self.path)
+            self.searcher.add(event, self.path[0],
+                              allow_global_constraints=self.path[1])
 
         self.results = self.searcher.run()
 


### PR DESCRIPTION
On some hosts kern.log may be missing so we fall back to dmesg for calltrace checking if this is the case.