### PR TITLE
Add check for rsync CVEs

### DIFF
--- a/hotsos/defs/scenarios/system/cve-rsync.yaml
+++ b/hotsos/defs/scenarios/system/cve-rsync.yaml
@@ -1,0 +1,38 @@
+checks:
+  has_rsync_cve:
+    apt:
+      rsync:
+        # Oracular
+        - min: '3.3.0'
+        - max: '3.3.0-1'
+        # Noble
+        - min: '3.2.7'
+        - max: '3.2.7-1ubuntu1'
+        # Jammy
+        - min: '3.2.3'
+        - max: '3.2.7-0ubuntu0.22.04.2'
+        # Focal
+        - min: '3.1.3'
+        - max: '3.1.3-8ubuntu0.7'
+        # Bionic
+        - min: '3.1.2'
+        - max: '3.1.2-2ubuntu1.6'
+        # Xenial
+        - min: '3.1.1'
+        - max: '3.1.1-3ubuntu1.3'
+        # Trusty
+        - min: '3.1.0'
+        - max: '3.1.0-2ubuntu0.4'
+conclusions:
+  rsync_cve:
+    decision: has_rsync_cve
+    raises:
+      type: MitreCVE
+      cve-id: CVE-2024-12084
+      message: >-
+        Installed package '{package}' with version {version} has a known
+        security vulnerability (CVE-2024-12084). Please upgrade to the
+        latest version to get the fix.
+      format-dict:
+        package: '@checks.has_rsync_cve.requires.package'
+        version: '@checks.has_rsync_cve.requires.version'

--- a/hotsos/defs/tests/scenarios/system/cve-rsync-false.yaml
+++ b/hotsos/defs/tests/scenarios/system/cve-rsync-false.yaml
@@ -1,0 +1,9 @@
+target-name: cve-needrestart.yaml
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii rsync 3.2.7-0ubuntu0.22.04.3 all
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-bugs:  # none expected

--- a/hotsos/defs/tests/scenarios/system/cve-rsync.yaml
+++ b/hotsos/defs/tests/scenarios/system/cve-rsync.yaml
@@ -1,0 +1,12 @@
+data-root:
+  files:
+    sos_commands/dpkg/dpkg_-l: |
+      ii rsync 3.2.7-0ubuntu0.22.04.2 all
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-bugs:
+  https://www.cve.org/CVERecord?id=CVE-2024-12084: >-
+    Installed package 'rsync' with version 3.2.7-0ubuntu0.22.04.2 has a known
+    security vulnerability (CVE-2024-12084). Please upgrade to the
+    latest version to get the fix.

--- a/tests/unit/fake_data_root/kubernetes/sos_commands/dpkg/dpkg_-l
+++ b/tests/unit/fake_data_root/kubernetes/sos_commands/dpkg/dpkg_-l
@@ -585,7 +585,7 @@ ii  python3.8                      3.8.10-0ubuntu1~20.04.2               amd64  
 ii  python3.8-dev                  3.8.10-0ubuntu1~20.04.2               amd64        Header files and a static library for Python (v3.8)
 ii  python3.8-minimal              3.8.10-0ubuntu1~20.04.2               amd64        Minimal subset of the Python language (version 3.8)
 ii  readline-common                8.0-4                                 all          GNU readline and history libraries, common files
-ii  rsync                          3.1.3-8ubuntu0.1                      amd64        fast, versatile, remote (and local) file-copying tool
+ii  rsync                          3.1.3-8ubuntu0.8                      amd64        fast, versatile, remote (and local) file-copying tool
 ii  rsyslog                        8.2001.0-1ubuntu1.1                   amd64        reliable system and kernel logging daemon
 ii  run-one                        1.17-0ubuntu1                         all          run just one instance of a command and its args at a time
 ii  runc                           1.0.1-0ubuntu2~20.04.1                amd64        Open Container Project - runtime

--- a/tests/unit/fake_data_root/openstack/sos_commands/dpkg/dpkg_-l
+++ b/tests/unit/fake_data_root/openstack/sos_commands/dpkg/dpkg_-l
@@ -996,7 +996,7 @@ ii  radosgw                              15.2.14-0ubuntu0.20.04.2               
 ii  radvd                                1:2.17-2                                             amd64        Router Advertisement Daemon
 ii  readline-common                      8.0-4                                                all          GNU readline and history libraries, common files
 ii  rpcbind                              1.2.5-8                                              amd64        converts RPC program numbers into universal addresses
-ii  rsync                                3.1.3-8ubuntu0.1                                     amd64        fast, versatile, remote (and local) file-copying tool
+ii  rsync                                3.1.3-8ubuntu0.8                                     amd64        fast, versatile, remote (and local) file-copying tool
 ii  rsyslog                              8.2001.0-1ubuntu1.1                                  amd64        reliable system and kernel logging daemon
 ii  run-one                              1.17-0ubuntu1                                        all          run just one instance of a command and its args at a time
 ii  sbsigntool                           0.9.2-2ubuntu1                                       amd64        Tools to manipulate signatures on UEFI binaries and drivers

--- a/tests/unit/fake_data_root/rabbitmq/sos_commands/dpkg/dpkg_-l
+++ b/tests/unit/fake_data_root/rabbitmq/sos_commands/dpkg/dpkg_-l
@@ -590,7 +590,7 @@ ii  python3.8-dev                  3.8.10-0ubuntu1~20.04.2               amd64  
 ii  python3.8-minimal              3.8.10-0ubuntu1~20.04.2               amd64        Minimal subset of the Python language (version 3.8)
 ii  rabbitmq-server                3.8.2-0ubuntu1.3                      all          AMQP server written in Erlang
 ii  readline-common                8.0-4                                 all          GNU readline and history libraries, common files
-ii  rsync                          3.1.3-8ubuntu0.1                      amd64        fast, versatile, remote (and local) file-copying tool
+ii  rsync                          3.1.3-8ubuntu0.8                      amd64        fast, versatile, remote (and local) file-copying tool
 ii  rsyslog                        8.2001.0-1ubuntu1.1                   amd64        reliable system and kernel logging daemon
 ii  run-one                        1.17-0ubuntu1                         all          run just one instance of a command and its args at a time
 ii  sbsigntool                     0.9.2-2ubuntu1                        amd64        Tools to manipulate signatures on UEFI binaries and drivers

--- a/tests/unit/fake_data_root/storage/ceph-mon/sos_commands/dpkg/dpkg_-l
+++ b/tests/unit/fake_data_root/storage/ceph-mon/sos_commands/dpkg/dpkg_-l
@@ -630,7 +630,7 @@ ii  python3.8-dev                        3.8.10-0ubuntu1~20.04.2               a
 ii  python3.8-minimal                    3.8.10-0ubuntu1~20.04.2               amd64        Minimal subset of the Python language (version 3.8)
 ii  radosgw                              15.2.14-0ubuntu0.20.04.2              amd64        REST gateway for RADOS distributed object store
 ii  readline-common                      8.0-4                                 all          GNU readline and history libraries, common files
-ii  rsync                                3.1.3-8ubuntu0.1                      amd64        fast, versatile, remote (and local) file-copying tool
+ii  rsync                                3.1.3-8ubuntu0.8                      amd64        fast, versatile, remote (and local) file-copying tool
 ii  rsyslog                              8.2001.0-1ubuntu1.1                   amd64        reliable system and kernel logging daemon
 ii  run-one                              1.17-0ubuntu1                         all          run just one instance of a command and its args at a time
 ii  sbsigntool                           0.9.2-2ubuntu1                        amd64        Tools to manipulate signatures on UEFI binaries and drivers

--- a/tests/unit/fake_data_root/vault/sos_commands/dpkg/dpkg_-l
+++ b/tests/unit/fake_data_root/vault/sos_commands/dpkg/dpkg_-l
@@ -680,7 +680,7 @@ ii  python3.8-dev                  3.8.10-0ubuntu1~20.04.2               amd64  
 ii  python3.8-minimal              3.8.10-0ubuntu1~20.04.2               amd64        Minimal subset of the Python language (version 3.8)
 ii  readline-common                8.0-4                                 all          GNU readline and history libraries, common files
 ii  resource-agents                1:4.5.0-2ubuntu2.2                    amd64        Cluster Resource Agents
-ii  rsync                          3.1.3-8ubuntu0.1                      amd64        fast, versatile, remote (and local) file-copying tool
+ii  rsync                          3.1.3-8ubuntu0.8                      amd64        fast, versatile, remote (and local) file-copying tool
 ii  rsyslog                        8.2001.0-1ubuntu1.1                   amd64        reliable system and kernel logging daemon
 ii  run-one                        1.17-0ubuntu1                         all          run just one instance of a command and its args at a time
 ii  sbsigntool                     0.9.2-2ubuntu1                        amd64        Tools to manipulate signatures on UEFI binaries and drivers


### PR DESCRIPTION
Verifies if rsync package is affected by multiple CVEs. The Focal and older release fixes are available for ESM customers.

Had to update fake_data_root 'dpkg -l' entries to get past functional test failures.