### PR TITLE
Show OpenStack nova lock held times

### DIFF
--- a/examples/hotsos-example-openstack.summary.yaml
+++ b/examples/hotsos-example-openstack.summary.yaml
@@ -276,6 +276,14 @@ openstack:
           stdev: 0.0
           avg: 0.0
           samples: 2500
+    nova:
+      nova-compute:
+        lock-held-times:
+          '2022-02-10':
+            '61': 1
+            '22': 1
+            '3': 1
+            '2': 2
     neutron-l3ha:
       keepalived:
         transitions:

--- a/hotsos/defs/events/openstack/nova/nova-compute.yaml
+++ b/hotsos/defs/events/openstack/nova/nova-compute.yaml
@@ -7,3 +7,5 @@ warnings:
     hint: 'WARNING'
 vm-build-times:
   expr: '([\d-]+) ([\d:]+)\.\d{3} .+ nova.compute.manager .+ \[instance: \S+\] Took ([0-9]+)(?:.[0-9]+)? seconds to build instance.'
+lock-held-times:
+  expr: '([\d-]+) ([\d:]+)\.\d{3} .+ oslo_concurrency.lockutils .+ Lock .+ :: held ([0-9]+).[0-9]+s'

--- a/tests/unit/ycheck/test_events.py
+++ b/tests/unit/ycheck/test_events.py
@@ -1,4 +1,5 @@
 import os
+from collections import OrderedDict
 
 import yaml
 from hotsos.core.config import HotSOSConfig
@@ -326,11 +327,11 @@ class TestYamlEvents(utils.BaseTestCase):
         ret = EventProcessingUtils._sort_results(
             info, options=EventProcessingUtils.EventProcessingOptions()
         )
-        expected = {'2000-01-01': {'f1': 1,
-                                   'f3': 1},
-                    '2000-01-02': {'f2': 1},
-                    '2000-01-04': {'f4': 1}}
-        self.assertDictEqual(ret, expected)
+        expected = OrderedDict({'2000-01-01': {'f1': 1,
+                                               'f3': 1},
+                                '2000-01-02': {'f2': 1},
+                                '2000-01-04': {'f4': 1}})
+        self.assertEqual(ret, expected)
         # check key order
         self.assertEqual(list(ret), list(expected))
 
@@ -357,11 +358,29 @@ class TestYamlEvents(utils.BaseTestCase):
             info, options=EventProcessingUtils.EventProcessingOptions(
               key_by_date=False)
         )
-        expected = {'f4': {'2000-01-04': 1},
-                    'f3': {'2000-01-01': 1,
-                           '2000-01-03': 1},
-                    'f2': {'2000-01-02': 1},
-                    'f1': {'2000-01-01': 1}}
-        self.assertDictEqual(ret, expected)
+        expected = OrderedDict({'f4': {'2000-01-04': 1},
+                                'f3': {'2000-01-01': 1,
+                                       '2000-01-03': 1},
+                                'f2': {'2000-01-02': 1},
+                                'f1': {'2000-01-01': 1}})
+        self.assertEqual(ret, expected)
+        # check key order
+        self.assertEqual(list(ret), list(expected))
+
+    def test_processing_utils_top5_results(self):
+        results = [{'date': '2000-01-01', 'key': '10'},
+                   {'date': '2000-01-01', 'key': '9'},
+                   {'date': '2000-01-01', 'key': '6'},
+                   {'date': '2000-01-01', 'key': '6'},
+                   {'date': '2000-01-01', 'key': '2'}]
+        options = EventProcessingUtils.EventProcessingOptions(
+                                                        max_results_per_date=3)
+        ret = EventProcessingUtils.categorise_events('testevent', results,
+                                                     options=options)
+        expected = OrderedDict({'2000-01-01': {'top3': {
+                                                   '10': 1,
+                                                   '9': 1,
+                                                   '6': 2}, 'total': 4}})
+        self.assertEqual(ret, expected)
         # check key order
         self.assertEqual(list(ret), list(expected))


### PR DESCRIPTION
Fetch lock held times from logs and print a tally of the top5 per day.

Also extends the event categorisation logic to allow sorting based in tally keys rather than values since in this case we want to sort on hold times not how often they occured. Also applies this logic to the vm build time event.