### PR TITLE
microcloud: add new plugin

### DIFF
--- a/doc/source/contrib/internals.rst
+++ b/doc/source/contrib/internals.rst
@@ -11,7 +11,7 @@ Hotsos supports the following plugins to cover common cloud applications as well
 * `juju <https://juju.is/>`_
 * `kernel <https://ubuntu.com/kernel>`_
 * `kubernetes <https://kubernetes.io/>`_
-* `lxd <https://linuxcontainers.org/lxd/>`_
+* `lxd <https://canonical.com/lxd>`_
 * `maas <https://maas.io/>`_
 * `mysql <https://dev.mysql.com/doc/refman/8.0/en/mysql-innodb-cluster-introduction.html>`_
 * `openstack <https://www.openstack.org/>`_

--- a/doc/source/contrib/internals.rst
+++ b/doc/source/contrib/internals.rst
@@ -13,6 +13,7 @@ Hotsos supports the following plugins to cover common cloud applications as well
 * `kubernetes <https://kubernetes.io/>`_
 * `lxd <https://canonical.com/lxd>`_
 * `maas <https://maas.io/>`_
+* `microcloud <https://canonical.com/microcloud>`_
 * `mysql <https://dev.mysql.com/doc/refman/8.0/en/mysql-innodb-cluster-introduction.html>`_
 * `openstack <https://www.openstack.org/>`_
 * `openvswitch <https://www.openvswitch.org/>`_ (includes `ovn <https://www.ovn.org/en/>`_)

--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -179,6 +179,10 @@ class MAASWarning(IssueTypeBase):
     """ Issue for MAAS warnings. """
 
 
+class MicroCloudWarning(IssueTypeBase):
+    """ Issue for MicroCloud warnings. """
+
+
 class VaultWarning(IssueTypeBase):
     """ Issue for Vault warnings. """
 

--- a/hotsos/core/plugins/kernel/common.py
+++ b/hotsos/core/plugins/kernel/common.py
@@ -49,7 +49,7 @@ class KernelBase():
 class KernelChecks(KernelBase, plugintools.PluginPartBase):
     """ Base class for all kernel checks. """
     plugin_name = 'kernel'
-    plugin_root_index = 15
+    plugin_root_index = 1000
 
     @classmethod
     def is_runnable(cls):

--- a/hotsos/core/plugins/microcloud/__init__.py
+++ b/hotsos/core/plugins/microcloud/__init__.py
@@ -1,0 +1,5 @@
+from .common import MicroCloudChecks
+
+__all__ = [
+    MicroCloudChecks.__name__,
+    ]

--- a/hotsos/core/plugins/microcloud/common.py
+++ b/hotsos/core/plugins/microcloud/common.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass, field
+
+from hotsos.core.host_helpers import (
+    InstallInfoBase,
+    SnapPackageHelper,
+    SystemdHelper,
+)
+from hotsos.core.plugintools import PluginPartBase
+
+SNAP_LIST = ['microceph', 'microovn', 'microcloud', 'lxd']
+CORE_SNAPS = [rf"(?:snap\.)?{p}" for p in SNAP_LIST]
+SERVICE_EXPRS = [rf"{s}\S*" for s in CORE_SNAPS]
+
+
+@dataclass
+class MicroCloudInstallInfo(InstallInfoBase):
+    """ MicroCloud installation information. """
+    snaps: SnapPackageHelper = field(default_factory=lambda:
+                                     SnapPackageHelper(core_snaps=CORE_SNAPS))
+    systemd: SystemdHelper = field(default_factory=lambda:
+                                   SystemdHelper(service_exprs=SERVICE_EXPRS))
+
+
+class MicroCloudChecks(PluginPartBase):
+    """ MicroCloud Checks. """
+    plugin_name = 'microcloud'
+    plugin_root_index = 15
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        MicroCloudInstallInfo().mixin(self)
+
+    @classmethod
+    def is_runnable(cls):
+        """
+        Determine whether or not this plugin can and should be run.
+
+        @return: True or False
+        """
+        if MicroCloudInstallInfo().snaps.core:
+            return True
+
+        return False

--- a/hotsos/defs/scenarios/microcloud/snap_channel.yaml
+++ b/hotsos/defs/scenarios/microcloud/snap_channel.yaml
@@ -1,0 +1,20 @@
+checks:
+  snap_using_latest_stable:
+    snap:
+      microcloud:
+        - channel: latest/stable
+conclusions:
+  snap_using_latest_stable:
+    decision: snap_using_latest_stable
+    raises:
+      type: MicroCloudWarning
+      message: >-
+        The {package} snap is installed from the {channel} channel which is
+        discouraged since the release of the snap in that channel can/will
+        change at random and will auto-upgrade which may be undesired. The
+        recommended way is to use a specific release track/channel so that
+        release (or major version) upgrades can be performed in a controlled
+        way. See 'snap info {package}' for available channels.
+      format-dict:
+        channel: '@checks.snap_using_latest_stable.requires.channel'
+        package: '@checks.snap_using_latest_stable.requires.package'

--- a/hotsos/defs/tests/scenarios/microcloud/snap_channel.yaml
+++ b/hotsos/defs/tests/scenarios/microcloud/snap_channel.yaml
@@ -1,0 +1,12 @@
+data-root:
+  files:
+    sos_commands/snap/snap_list_--all: |
+      microcloud  2.1.0-d29fd90           1281   latest/stable  canonical**  in-cohort
+raised-issues:
+  MicroCloudWarning: >-
+    The microcloud snap is installed from the latest/stable channel which is
+    discouraged since the release of the snap in that channel can/will change
+    at random and will auto-upgrade which may be undesired. The
+    recommended way is to use a specific release track/channel so that
+    release (or major version) upgrades can be performed in a controlled
+    way. See 'snap info microcloud' for available channels.

--- a/hotsos/plugin_extensions/__init__.py
+++ b/hotsos/plugin_extensions/__init__.py
@@ -6,6 +6,7 @@ from . import (  # noqa: F401
     landscape,
     lxd,
     maas,
+    microcloud,
     mysql,
     openstack,
     openvswitch,

--- a/hotsos/plugin_extensions/microcloud/__init__.py
+++ b/hotsos/plugin_extensions/microcloud/__init__.py
@@ -1,0 +1,1 @@
+from . import summary  # noqa: F401

--- a/hotsos/plugin_extensions/microcloud/summary.py
+++ b/hotsos/plugin_extensions/microcloud/summary.py
@@ -1,0 +1,15 @@
+from hotsos.core.plugins.microcloud import MicroCloudChecks
+
+
+class MicroCloudSummary(MicroCloudChecks):
+    """ Implementation of MicroCloud summary. """
+    summary_part_index = 0
+
+    # REMINDER: Common entries are implemented in
+    #           plugintools.ApplicationSummaryBase. Only customisations are
+    #           implemented here. See
+    #           plugintools.get_min_available_entry_index() for an explanation
+    #           on how entry indices are managed.
+
+    # NOTE: no custom entries defined here yet so plugin will only use
+    #       defaults.

--- a/tests/unit/test_microcloud.py
+++ b/tests/unit/test_microcloud.py
@@ -1,0 +1,49 @@
+from hotsos.core.config import HotSOSConfig
+from hotsos.plugin_extensions.microcloud import summary
+
+from . import utils
+
+SNAPS = """
+Name        Version                 Rev    Tracking       Publisher      Notes
+core24      20241217                739    latest/stable  canonical**    base
+lxd         5.21.3-75def3c          32455  5.21/stable    canonical**    in-cohort
+microceph   19.2.0+snap2fbf0bad05   1271   latest/stable  canonical**    in-cohort
+microcloud  2.1.0-d29fd90           1281   latest/stable  canonical**    in-cohort
+microovn    24.03.2+snapa2c59c105b  667    latest/stable  canonical**    in-cohort
+snapd       2.67.1                  23771  latest/stable  canonical**    snapd
+"""  # noqa
+
+
+class MicroCloudTestsBase(utils.BaseTestCase):
+    """ Custom base testcase that sets microcloud plugin context. """
+    def setUp(self):
+        super().setUp()
+        HotSOSConfig.plugin_name = "microcloud"
+
+
+class TestMicroCloudSummary(MicroCloudTestsBase):
+    """Unit tests for microcloud summary"""
+
+    @utils.create_data_root({"sos_commands/snap/snap_list_--all": SNAPS})
+    def test_summary_keys(self):
+        expected = {
+            "snaps": [
+                "lxd 5.21.3-75def3c (5.21/stable)",
+                "microceph 19.2.0+snap2fbf0bad05 (latest/stable)",
+                "microcloud 2.1.0-d29fd90 (latest/stable)",
+                "microovn 24.03.2+snapa2c59c105b (latest/stable)",
+            ]
+        }
+        inst = summary.MicroCloudSummary()
+        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+
+
+@utils.load_templated_tests("scenarios/microcloud")
+class TestMicroCloudScenarios(MicroCloudTestsBase):
+    """
+    Scenario tests can be written using YAML templates that are auto-loaded
+    into this test runner. This is the recommended way to write tests for
+    scenarios. It is however still possible to write the tests in Python if
+    required. See https://hotsos.readthedocs.io/en/latest/contrib/testing.html
+    for more information.
+    """


### PR DESCRIPTION
Produces something like this:

```
microcloud:
  services:
    systemd:
      enabled:
        - lxd-agent
        - snap.lxd.activate
        - snap.microceph.daemon
        - snap.microceph.mds
        - snap.microceph.mgr
        - snap.microceph.mon
        - snap.microceph.osd
        - snap.microcloud.daemon
        - snap.microovn.chassis
        - snap.microovn.daemon
        - snap.microovn.ovn-northd
        - snap.microovn.ovn-ovsdb-server-nb
        - snap.microovn.ovn-ovsdb-server-sb
        - snap.microovn.switch
      static:
        - snap.lxd.daemon
        - snap.lxd.user-daemon
        - snap.microovn.refresh-expiring-certs
      transient:
        - snap.lxd.workaround
      disabled:
        - snap.microceph.rbd-mirror
        - snap.microceph.rgw
    ps:
      - microcephd (1)
      - microcloudd (1)
      - microovnd (1)
  snaps:
    - lxd 5.21.3-75def3c (5.21/stable)
    - microceph 19.2.0+snap2fbf0bad05 (latest/stable)
    - microcloud 2.1.0-d29fd90 (latest/stable)
    - microovn 24.03.2+snapa2c59c105b (latest/stable)
  potential-issues:
    MicroCloudWarnings:
      - The microceph, microcloud, microovn snap is installed from the latest/stable,
        latest/stable, latest/stable channel which is discouraged since the release
        of the snap in that channel can/will change at random and will auto-upgrade
        which may be undesired. The recommended way is to use a specific release track/channel
        so that release (or major version) upgrades can be performed in a controlled
        way. See 'snap info microceph, microcloud, microovn' for available channels.
```

Partly addresses #905