### PR TITLE
[ceph] Skip suboptimal PG count warning on low utilisation

### DIFF
--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/pg_imbalance_p1.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/pg_imbalance_p1.yaml
@@ -1,9 +1,11 @@
+target-name: pg_imbalance.yaml
 data-root:
   files:
     sos_commands/ceph_mon/json_output/ceph_osd_df_tree_--format_json-pretty: |
       {"nodes": [{"id": 0, "pgs": 295, "name": "osd.0"},
                  {"id": 1, "pgs": 501, "name": "osd.1"},
-                 {"id": 2, "pgs": 200, "name": "osd.2"}]}
+                 {"id": 2, "pgs": 200, "name": "osd.2"}],
+       "summary": {"average_utilization": 20.00}}
   copy-from-original:
     - sos_commands/date/date
     - sos_commands/systemd/systemctl_list-units

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/pg_imbalance_p2.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/pg_imbalance_p2.yaml
@@ -1,0 +1,14 @@
+target-name: pg_imbalance.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/json_output/ceph_osd_df_tree_--format_json-pretty: |
+      # PG counts are outside the recommended range, but cluster util is under 10%
+      {"nodes": [{"id": 0, "pgs": 5, "name": "osd.0"},
+                 {"id": 1, "pgs": 10, "name": "osd.1"},
+                 {"id": 2, "pgs": 15, "name": "osd.2"}],
+       "summary": {"average_utilization": 5.00}}
+  copy-from-original:
+    - sos_commands/date/date
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+raised-issues:

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -165,7 +165,8 @@ class CephMonTestsBase(utils.BaseTestCase):
         mock_cli_helper.return_value = inst
         out = {'nodes': [{'id': 0, 'pgs': 295, 'name': "osd.0"},
                          {'id': 1, 'pgs': 501, 'name': "osd.1"},
-                         {'id': 2, 'pgs': 200, 'name': "osd.2"}]}
+                         {'id': 2, 'pgs': 200, 'name': "osd.2"}],
+               'summary': {'average_utilization': 20.00}}
         inst.ceph_osd_df_tree_json_decoded.return_value = out
 
         return {'osd-pgs-suboptimal': {


### PR DESCRIPTION
When the cluster is empty or utilised at a very low level, the PG autoscaler won't increase the PGs/OSD to the optimal level - it'll be done as the cluster hosts more data. In such cases, the PGs/OSD count will be lower than what we consider as optimal range (50 - 200). In such cases, this warning has no benefit and becomes a false positive. So we only report this if the cluster usage is 10% or more.

Fixes #1016.