### PR TITLE
Add /var/log/syslog* to the search path

### DIFF
--- a/hotsos/defs/scenarios/openstack/oslo_messaging/lp1934937.yaml
+++ b/hotsos/defs/scenarios/openstack/oslo_messaging/lp1934937.yaml
@@ -1,5 +1,5 @@
 vars:
-  expr: 'greenlet.error: cannot switch to a different thread'
+  expr: '.*greenlet.error: cannot switch to a different thread'
   msg_part_common: >-
     service(s) on this host are affected by this bug which is triggered when
     a non-wsgi service that uses greenthreads and oslo.messaging with
@@ -18,8 +18,12 @@ checks:
   gnocchi_has_1934937:
     input: var/log/gnocchi/*.log
     expr: $expr
+  syslog_has_1934937:
+    input: var/log/syslog*
+    expr: $expr
 conclusions:
   nova_1934937:
+    priority: 2
     decision: nova_has_1934937
     raises:
       type: LaunchpadBug
@@ -29,6 +33,7 @@ conclusions:
       format-dict:
         msg_part_common: $msg_part_common
   neutron_1934937:
+    priority: 2
     decision: neutron_has_1934937
     raises:
       type: LaunchpadBug
@@ -38,6 +43,7 @@ conclusions:
       format-dict:
         msg_part_common: $msg_part_common
   cinder_1934937:
+    priority: 2
     decision: cinder_has_1934937
     raises:
       type: LaunchpadBug
@@ -47,11 +53,21 @@ conclusions:
       format-dict:
         msg_part_common: $msg_part_common
   gnocchi_1934937:
+    priority: 2
     decision: gnocchi_has_1934937
     raises:
       type: LaunchpadBug
       bug-id: 1934937
       message: >-
         One or more Gnocchi {msg_part_common}.
+      format-dict:
+        msg_part_common: $msg_part_common
+  syslog_1934937:
+    decision: syslog_has_1934937
+    raises:
+      type: LaunchpadBug
+      bug-id: 1934937
+      message: >-
+        One or more {msg_part_common}.
       format-dict:
         msg_part_common: $msg_part_common

--- a/hotsos/defs/tests/scenarios/openstack/oslo_messaging/lp1934937_syslog.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/oslo_messaging/lp1934937_syslog.yaml
@@ -1,0 +1,20 @@
+target-name: lp1934937.yaml
+data-root:
+  files:
+    var/log/syslog: |
+      Mar 24 08:00:27 testnode02 nova-compute[3334105]: Traceback (most recent call last):
+      Mar 24 08:00:27 testnode02 nova-compute[3334105]:   File "/usr/lib/python3/dist-packages/eventlet/hubs/hub.py", line 476, in fire_timers
+      Mar 24 08:00:27 testnode02 nova-compute[3334105]:     timer()
+      Mar 24 08:00:27 testnode02 nova-compute[3334105]:   File "/usr/lib/python3/dist-packages/eventlet/hubs/timer.py", line 59, in __call__
+      Mar 24 08:00:27 testnode02 nova-compute[3334105]:     cb(*args, **kw)
+      Mar 24 08:00:27 testnode02 nova-compute[3334105]:   File "/usr/lib/python3/dist-packages/eventlet/semaphore.py", line 152, in _do_acquire
+      Mar 24 08:00:27 testnode02 nova-compute[3334105]:     waiter.switch()
+      Mar 24 08:00:27 testnode02 nova-compute[3334105]: greenlet.error: cannot switch to a different thread
+  copy-from-original:
+    - sos_commands/date/date
+raised-bugs:
+  https://bugs.launchpad.net/bugs/1934937: >-
+   One or more service(s) on this host are affected by this bug which is
+   triggered when a non-wsgi service that uses greenthreads and oslo.messaging
+   with heartbeat_in_pthread=True tries to send a heartbeat message
+   to rabbitmq.


### PR DESCRIPTION
/var/log/syslog is another place where this error message may show up.

I have a case/sosreport where the `greenlet.error: cannot switch to a different thread`, triggered by nova-compute was only logged to the /var/log/syslog. Therefore I am updating this check to search /var/log/syslog* in addition to the already defined paths.