### PR TITLE
Add check for OVS FDB table wrapping

### DIFF
--- a/hotsos/core/plugins/openvswitch/__init__.py
+++ b/hotsos/core/plugins/openvswitch/__init__.py
@@ -6,6 +6,7 @@ from .ovs import (
     OVSDPLookups,
     OVSBridge,
     OVSDPDK,
+    OVSFDBStats,
 )
 from .ovn import (
     OVNBase,
@@ -20,4 +21,5 @@ __all__ = [
     OVSDPDK.__name__,
     OVSDPLookups.__name__,
     OVNBase.__name__,
+    OVSFDBStats.__name__,
     ]

--- a/hotsos/defs/scenarios/openvswitch/fdb_wrapping.yaml
+++ b/hotsos/defs/scenarios/openvswitch/fdb_wrapping.yaml
@@ -1,0 +1,24 @@
+vars:
+  bridges_with_fdb_overflow: '@hotsos.core.plugins.openvswitch.OVSFDBStats.bridges_with_fdb_overflow'
+  fdb_full_msg_part1: >-
+    The FDB table for bridge(s)
+  fdb_full_msg_part2: >-
+    is full. Usually it is a symptom of the FDB table wrapping which
+    negatively impacts performance of the ovs-vswitchd daemon. Inspect
+    the output of the 'ovs-appctl fdb/stats-show <bridge>' command and
+    check the https://developers.redhat.com/blog/2018/09/19/troubleshooting-fdb-table-wrapping-in-open-vswitch
+    for more details.
+checks:
+  fdb_is_full:
+    varops: [[$bridges_with_fdb_overflow], [length_hint]]
+conclusions:
+  fdb_is_wrapping:
+    decision: fdb_is_full
+    raises:
+      type: OpenvSwitchWarning
+      message: >-
+        {part1} {bridges} {part2}
+      format-dict:
+        part1: $fdb_full_msg_part1
+        part2: $fdb_full_msg_part2
+        bridges: '$bridges_with_fdb_overflow:comma_join'

--- a/hotsos/defs/tests/scenarios/openvswitch/fdb_wrapping.yaml
+++ b/hotsos/defs/tests/scenarios/openvswitch/fdb_wrapping.yaml
@@ -1,0 +1,22 @@
+data-root:
+  files:
+    sos_commands/openvswitch/ovs-appctl_fdb.stats-show_br-ex: |
+      Statistics for bridge "br-ex":
+        Current/maximum MAC entries in the table: 8192/8192
+        Current static MAC entries in the table : 0
+        Total number of learned MAC entries     : 404733358
+        Total number of expired MAC entries     : 1
+        Total number of evicted MAC entries     : 404725165
+        Total number of port moved MAC entries  : 3
+  copy-from-original:
+    - sos_commands/openvswitch/ovs-vsctl_-t_5_list-br
+    - sos_commands/openvswitch/ovs-appctl_fdb.stats-show_br-data
+    - sos_commands/openvswitch/ovs-appctl_fdb.stats-show_br-int
+    - sos_commands/openvswitch/ovs-appctl_fdb.stats-show_br-tun
+raised-issues:
+  OpenvSwitchWarning: >-
+    The FDB table for bridge(s) br-ex is full. Usually it is a symptom of the FDB table wrapping which
+    negatively impacts performance of the ovs-vswitchd daemon. Inspect
+    the output of the 'ovs-appctl fdb/stats-show <bridge>' command and
+    check the https://developers.redhat.com/blog/2018/09/19/troubleshooting-fdb-table-wrapping-in-open-vswitch
+    for more details.


### PR DESCRIPTION
New check for the FDB table wrapping in OVS (when the the FDB table current size == max size and there is no room for additional MAC addresses)