### PR TITLE
Update searchkit dependency to the latest version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2
 progress
 propertree >= 1.1.0.post9
 pyyaml
-searchkit >= 0.4.3-post1
+searchkit >= 0.4.3.post6
 simplejson
 sphinx>=4.3.2
 python-dateutil


### PR DESCRIPTION
searchkit 0.4.3.post6 contains fix that prevents hotsos from crashing if searchkit couldn't find EOL before reaching the line length limit of 1048576 chars.

Closes Issue: #992
Signed-off-by: Marcin Wilk <marcin.wilk@canonical.com>