### PR TITLE
Add rabbitmq log event checks

### DIFF
--- a/hotsos/core/plugins/rabbitmq/common.py
+++ b/hotsos/core/plugins/rabbitmq/common.py
@@ -1,3 +1,4 @@
+import abc
 from dataclasses import dataclass, field
 
 from hotsos.core import plugintools
@@ -8,6 +9,8 @@ from hotsos.core.host_helpers import (
     SystemdHelper,
 )
 from hotsos.core.plugins.rabbitmq.report import RabbitMQReport
+from hotsos.core.utils import sorted_dict
+from hotsos.core.ycheck.events import EventCallbackBase, EventHandlerBase
 
 RMQ_SERVICES_EXPRS = [
     r"beam.smp",
@@ -38,7 +41,7 @@ class RabbitMQChecks(plugintools.PluginPartBase):
     plugin_root_index = 7
 
     def __init__(self, *args, **kwargs):
-        super().__init__()
+        super().__init__(*args, **kwargs)
         RabbitMQInstallInfo().mixin(self)
 
     @property
@@ -56,3 +59,23 @@ class RabbitMQChecks(plugintools.PluginPartBase):
             return True
 
         return False
+
+
+class RabbitMQEventCallbackBase(EventCallbackBase):
+    """ Base class for RabbitMQ events callbacks. """
+
+    @abc.abstractmethod
+    def __call__(self):
+        """ Callback method. """
+
+
+class RabbitMQEventHandlerBase(RabbitMQChecks, EventHandlerBase):
+    """ Base class for RabbitMQ event handlers. """
+    @property
+    def summary(self):
+        # mainline all results into summary root
+        ret = self.run()
+        if ret:
+            return sorted_dict(ret)
+
+        return None

--- a/hotsos/defs/events/rabbitmq/errors.yaml
+++ b/hotsos/defs/events/rabbitmq/errors.yaml
@@ -1,0 +1,8 @@
+input:
+  path: 'var/log/rabbitmq/rabbit@*.log'
+delivery-ack-timeout:
+  expr: '([\d-]+) ([\d:]+)\.[\d+:]+ \[error\] .+ channel exception precondition_failed: delivery acknowledgement on channel \d+ timed out. Timeout value used: (\d+) ms'
+connection-exception:
+  expr: '([\d-]+) ([\d:]+)\.[\d+:]+ \[error\] .+ connection exception (\S+):'
+mnesia-error-event:
+  expr: '([\d-]+) ([\d:]+)\.[\d+:]+ \[error\] .+ Mnesia\S+ .+ mnesia_event got {(.+)}'

--- a/hotsos/plugin_extensions/rabbitmq/__init__.py
+++ b/hotsos/plugin_extensions/rabbitmq/__init__.py
@@ -1,1 +1,9 @@
-from . import summary  # noqa: F401
+from . import (
+    summary,
+    event_checks,
+)
+
+__all__ = [
+    event_checks,
+    summary,
+    ]

--- a/hotsos/plugin_extensions/rabbitmq/event_checks.py
+++ b/hotsos/plugin_extensions/rabbitmq/event_checks.py
@@ -1,0 +1,25 @@
+from hotsos.core.plugins.rabbitmq.common import (
+    RabbitMQEventHandlerBase,
+    RabbitMQEventCallbackBase,
+)
+
+
+class RabbitMQEventsCallback(RabbitMQEventCallbackBase):
+    """ Callback for rabbitmq error events. """
+    event_group = 'errors'
+    event_names = ['connection-exception', 'delivery-ack-timeout',
+                   'mnesia-error-event']
+
+    def __call__(self, event):
+        ret = self.categorise_events(event)
+        return ret
+
+
+class RabbitMQEventChecks(RabbitMQEventHandlerBase):
+    """ Event handler for rabbitmq error events. """
+    event_group = 'errors'
+    summary_part_index = 1
+
+    @property
+    def summary_subkey(self):
+        return 'rabbitmq-checks'


### PR DESCRIPTION
Add some analysis of rabbitmq error logs including delivery ack timeouts, connection exceptions and
mnesia error events.