### PR TITLE
Fix systemd support for snapped services

### DIFF
--- a/examples/hotsos-example-storage.summary.yaml
+++ b/examples/hotsos-example-storage.summary.yaml
@@ -33,6 +33,7 @@ storage:
           - ceph-crash
           - ceph-mgr
           - ceph-mon
+          - rbdmap
         masked:
           - ceph-create-keys
         disabled:

--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -242,7 +242,8 @@ class SystemdHelper(ServiceManagerBase):
             return
 
         unit = ret.group(1)
-        state = ret.group(2)
+        # state is always at the end
+        state = ret.group(len(ret.groups()))
         has_instances = False
         units_expr = r"\*?\s+({})\.service\s+(\S+)\s+(\S+)\s+(\S+)"
         if unit.endswith('@'):

--- a/hotsos/core/plugins/storage/ceph/common.py
+++ b/hotsos/core/plugins/storage/ceph/common.py
@@ -35,7 +35,8 @@ from hotsos.core.ycheck.events import EventCallbackBase
 
 CEPH_SERVICES_EXPRS = [r"ceph-[a-z0-9-]+",
                        r"rados[a-z0-9-:]+",
-                       r"microceph.(mon|mgr|mds|osd|rgw)"]
+                       r"rbd[a-z0-9-:]+",
+                       r"microceph.(mon|mgr|mds|osd|rgw|rbd[a-z-]*)"]
 CEPH_PKGS_CORE = [r"ceph",
                   r"rados",
                   r"rbd",

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -289,7 +289,8 @@ class TestCephMonSummary(CephMonTestsBase):
         svc_info = {'systemd': {'enabled': [
                                     'ceph-crash',
                                     'ceph-mgr',
-                                    'ceph-mon'],
+                                    'ceph-mon',
+                                    'rbdmap'],
                                 'disabled': [
                                     'ceph-mds',
                                     'ceph-osd',

--- a/tests/unit/storage/test_ceph_osd.py
+++ b/tests/unit/storage/test_ceph_osd.py
@@ -120,7 +120,8 @@ class TestCephOSDSummary(StorageCephOSDTestsBase):
     def test_service_info(self):
         svc_info = {'systemd': {'enabled': [
                                     'ceph-crash',
-                                    'ceph-osd'],
+                                    'ceph-osd',
+                                    'rbdmap'],
                                 'disabled': [
                                     'ceph-mds',
                                     'ceph-mgr',


### PR DESCRIPTION
Services running as snap.<name> were not have their state represented correctly in the SystemdHelper
summary.