### PR TITLE
Check for rabbitmq queues with no consumers

### DIFF
--- a/hotsos/core/plugins/rabbitmq/report.py
+++ b/hotsos/core/plugins/rabbitmq/report.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 
+from searchkit import ResultFieldInfo
 from hotsos.core.log import log
 from hotsos.core.utils import sorted_dict
 from hotsos.core.search import (
@@ -8,6 +9,10 @@ from hotsos.core.search import (
     FileSearcher,
 )
 from hotsos.core.host_helpers import CLIHelperFile
+
+
+class RabbitmqReportError(Exception):
+    """ Error raised when we fail to parse a rabbitmq report. """
 
 
 class RabbitMQReport():
@@ -31,27 +36,47 @@ class RabbitMQReport():
             searcher.add(self.connections_searchdef, fout)
             searcher.add(self.memory_searchdef, fout)
             searcher.add(self.cluster_partition_handling_searchdef, fout)
-            searcher.add(self.queues_searchdef, fout)
+            searcher.add(self.queues_searchdef_36, fout)
+            searcher.add(self.queues_searchdef_38, fout)
             self.results = searcher.run()
 
     @cached_property
-    def queues_searchdef(self):
-        start = SearchDef([r"^Queues on ([^:]+):",
-                           (r"^Listing queues for vhost ([^:]+) "
-                            r"...")])
-        # NOTE: we don't use a list for the body here because
-        # we need to know which expression matched so that we
-        # can know in which order to retrieve the columns since
-        # their order is inverted between 3.6.x and 3.8.x
-        body = SearchDef(r"^(?:<([^.\s]+)[.0-9]+>\s+(\S+)|"
-                         r"(\S+)\s+(?:\S+\s+){4}<([^.\s]+)[.0-9]"
-                         r"+>)\s+.+")
+    def queues_searchdef_36(self):
+        """ Expression matching report format from rabbitmq 3.6. """
+        start = SearchDef(r"^Queues on ([^:]+):",
+                          field_info=ResultFieldInfo({'VHOST': str}))
+        body = SearchDef(r"^<([^.\s]+)[.0-9]+>\s+(\S+)\s+.+",
+                         field_info=ResultFieldInfo({'NODE': str,
+                                                     'QUEUE': str}))
         end = SearchDef(r"^$")
         return SequenceSearchDef(start=start, body=body, end=end,
-                                 tag='queues')
+                                 tag='queues-v36')
+
+    @cached_property
+    def queues_searchdef_38(self):
+        """ Expression matching report format from rabbitmq 3.8 and above. """
+        start = SearchDef(r"^Listing queues for vhost ([^:]+) ...",
+                          field_info=ResultFieldInfo({'VHOST': str}))
+        # The position of values varies in the output of rabbtmq-report so
+        # these readings of messages and consumers risk being inaccurate.
+        body = SearchDef(r"^(\S+)\s+(?:\S+\s+){4}<([^.\s]+)[.0-9]+>"
+                         r"\s+(?:\S+\s+){2}(\d+)\s+(?:\S+\s+){13}(\S+).+",
+                         field_info=ResultFieldInfo({'QUEUE': str,
+                                                     'NODE': str,
+                                                     'MESSAGES_UNACK': int,
+                                                     'NUM_CONSUMERS': float}))
+        end = SearchDef(r"^$")
+        return SequenceSearchDef(start=start, body=body, end=end,
+                                 tag='queues-v38')
 
     @cached_property
     def skewed_nodes(self):
+        """
+        Returns nodes holding more than 2/3 queues or any given vhost. This
+        implies a cluster imbalance which has performance implications.
+
+        @return: dictionary of nodes and lists of highlighted vhosts.
+        """
         vhosts = self.vhosts
         _skewed_nodes = {}
         skewed_queue_nodes = {}
@@ -86,33 +111,56 @@ class RabbitMQReport():
         return _skewed_nodes
 
     @cached_property
+    def queues_w_messages_no_consumers(self):
+        _queues = []
+        for vhost in self.vhosts:
+            if not vhost.no_consumer_queues:
+                continue
+
+            _queues.extend(vhost.no_consumer_queues.keys())
+
+        return _queues
+
+    @cached_property
     def vhosts(self):
-        seq_def = self.queues_searchdef
+        """ List of vhosts containing a count of queues per host.
+
+        @return : list of RabbitMQVhost objects.
+        """
         vhosts = []
-        for section in self.results.find_sequence_sections(seq_def).values():
+        for seq_def in [self.queues_searchdef_36, self.queues_searchdef_38]:
+            sections = self.results.find_sequence_sections(seq_def)
+            if sections:
+                break
+
+        for section in sections.values():
             vhost = None
             # ensure we get vhost before the rest
             for result in section:
                 if result.tag == seq_def.start_tag:
-                    # check both report formats
-                    vhost = RabbitMQVhost(result.get(1))
+                    vhost = RabbitMQVhost(result.VHOST)
                     break
+            else:
+                raise RabbitmqReportError("failed to identify rabbitmq vhost")
 
             for result in section:
                 if result.tag == seq_def.body_tag:
-                    node_name = result.get(1) or result.get(4)
                     # if we matched the section header, skip
-                    if node_name == "pid":
+                    if result.NODE == "pid":
                         continue
 
-                    queue = result.get(2) or result.get(3)
                     # if we matched the section header, skip
-                    if queue == "name":
+                    if result.QUEUE == "name":
                         continue
 
-                    vhost.node_inc_queue_count(node_name)
+                    vhost.node_inc_queue_count(result.NODE)
+                    if seq_def.tag == 'queues-v38':
+                        if (result.MESSAGES_UNACK and
+                                result.NUM_CONSUMERS == 0):
+                            vhost.add_queue_no_consumer(result.QUEUE,
+                                                        result.MESSAGES_UNACK)
 
-            log.debug(vhost.name)
+            log.debug("adding vhost: %s", vhost.name)
             vhosts.append(vhost)
 
         return vhosts
@@ -208,6 +256,7 @@ class RabbitMQVhost():
     def __init__(self, name):
         self.name = name
         self._node_queues = {}
+        self.no_consumer_queues = {}
 
     def node_inc_queue_count(self, node):
         if node not in self._node_queues:
@@ -237,3 +286,6 @@ class RabbitMQVhost():
                 dists[node] = {'queues': 0, 'pcent': 0}
 
         return dists
+
+    def add_queue_no_consumer(self, queue, messages_unack):
+        self.no_consumer_queues[queue] = messages_unack

--- a/hotsos/defs/scenarios/rabbitmq/no_consumer_queues.yaml
+++ b/hotsos/defs/scenarios/rabbitmq/no_consumer_queues.yaml
@@ -1,0 +1,15 @@
+checks:
+  queues_no_consumers:
+    property:
+      path: hotsos.core.plugins.rabbitmq.RabbitMQReport.queues_w_messages_no_consumers
+      ops: [[length_hint], [gt, 0]]
+conclusions:
+  queues_no_consumers:
+    decision: queues_no_consumers
+    raises:
+      type: RabbitMQWarning
+      message: >-
+        One or more RabbitMQ queue(s) "{queues}" appear to have unacknowledged
+        messages but no consumers. Please investigate (e.g. rabbitmqctl report).
+      format-dict:
+        queues: '@checks.queues_no_consumers.requires.value_actual:comma_join'

--- a/hotsos/defs/tests/scenarios/rabbitmq/no_consumer_queues.yaml
+++ b/hotsos/defs/tests/scenarios/rabbitmq/no_consumer_queues.yaml
@@ -1,0 +1,14 @@
+data-root:
+  files:
+    sos_commands/rabbitmq/rabbitmqctl_report: |
+        Listing queues for vhost openstack ...
+        name    durable auto_delete     arguments       policy  pid     owner_pid       exclusive       exclusive_consumer_pid  exclusive_consumer_tag  messages_ready  messages_unacknowledged messages        messages_ready_ram      messages_unacknowledged_ram     messages_ram    messages_persistent        message_bytes   message_bytes_ready     message_bytes_unacknowledged    message_bytes_ram       message_bytes_persistent        head_message_timestamp  disk_reads      disk_writes     consumers       #       these   are     aliases consumer_utilisation       consumer_capacity       memory  slave_pids      synchronised_slave_pids state   type    leader  members online
+        notifications.info      false   false   []      TTL     <rabbit@juju-deb001-8-lxd-10.1718612959.18683.1>                false                   0       12      12      0       12      12      0       38221   0       38221   38221   0               0       0       96                                         1.0     1.0     1917912                 running classic
+        notifications.sample    false   false   []      TTL     <rabbit@juju-deb001-8-lxd-10.1718612959.14168.1>                false                   0       30      30      0       30      30      0       2029518 0       2029518 2029518 0               0       0       96                                         0     1.0     459080                  running classic
+  copy-from-original:
+    - sos_commands/date/date
+raised-issues:
+  RabbitMQWarning: >-
+    One or more RabbitMQ queue(s) "notifications.sample" appear to have
+    unacknowledged messages but no consumers. Please investigate (e.g.
+    rabbitmqctl report).


### PR DESCRIPTION
If there are queues with unacknowledged messages but no consumers that is now flagged with a RabbitMQWarning.