### PR TITLE
SET-1765 Add check for rsyslog reading syslog file

### DIFF
--- a/hotsos/defs/scenarios/system/rsyslog-read-syslog.yaml
+++ b/hotsos/defs/scenarios/system/rsyslog-read-syslog.yaml
@@ -1,0 +1,21 @@
+checks:
+  syslog_in_imfiles:
+    input:
+      path: "etc/rsyslog.d/*.conf"
+    search:
+      expr: '\s+File="/var/log/syslog"'
+
+conclusions:
+  syslog_loop_possible:
+    decision: [syslog_in_imfiles]
+    raises:
+      type: SystemWarning
+      message: >-
+        rsyslog is configured to read from /var/log/syslog, which may cause a loop
+        if data is being logged locally to /var/log/syslog. This may happen
+        with a rule like "*.*;auth,authpriv.none		-/var/log/syslog "
+        which appears in the default configuration file
+        /etc/rsyslog.d/50-default.conf on ubuntu.
+
+        Please make sure not to configure /var/log/syslog
+        as an input file for rsyslog.

--- a/hotsos/defs/tests/scenarios/system/rsyslog-read-syslog-false.yaml
+++ b/hotsos/defs/tests/scenarios/system/rsyslog-read-syslog-false.yaml
@@ -1,0 +1,18 @@
+target-name: rsyslog-read-syslog.yaml
+data-root:
+  files:
+    etc/rsyslog.d/45-.log: |
+      module(load="imfile")
+
+      # Note StateFile is deprecated in rsyslog 8 but needed for rsyslog 7
+
+      input(type="imfile"
+            File="/var/log/dpkg.log"
+            StateFile="dpkg.log"
+            Tag="dpkg.log")
+
+      input(type="imfile"
+            File="/var/log/apt/history.log"
+            StateFile="history.log"
+            Tag="history.log")
+raised-issues: # none expected

--- a/hotsos/defs/tests/scenarios/system/rsyslog-read-syslog.yaml
+++ b/hotsos/defs/tests/scenarios/system/rsyslog-read-syslog.yaml
@@ -1,0 +1,31 @@
+data-root:
+  files:
+    etc/rsyslog.d/40-rsyslog-imfile.conf: |
+      module(load="imfile")
+
+      # Note StateFile is deprecated in rsyslog 8 but needed for rsyslog 7
+
+      input(type="imfile"
+            File="/var/log/dpkg.log"
+            StateFile="dpkg.log"
+            Tag="dpkg.log")
+
+      input(type="imfile"
+            File="/var/log/apt/history.log"
+            StateFile="history.log"
+            Tag="history.log")
+
+      input(type="imfile"
+            File="/var/log/syslog"
+            StateFile="syslog"
+            Tag="syslog")
+raised-issues:
+  SystemWarning: >-
+    rsyslog is configured to read from /var/log/syslog, which may cause a loop
+    if data is being logged locally to /var/log/syslog. This may happen
+    with a rule like "*.*;auth,authpriv.none		-/var/log/syslog "
+    which appears in the default configuration file
+    /etc/rsyslog.d/50-default.conf on ubuntu.
+
+    Please make sure not to configure /var/log/syslog
+    as an input file for rsyslog.


### PR DESCRIPTION
It is possible to have rsyslog read from /var/log/syslog as an imfile. This is dangerous, because if we are saving logs back to /var/log/syslog this will cause an infinite loop and fill the drive. See for example LP: #2130291