### PR TITLE
SET-766 Add support for multiple log locations

### DIFF
--- a/doc/source/contrib/language_ref/property_ref/shared_properties.rst
+++ b/doc/source/contrib/language_ref/property_ref/shared_properties.rst
@@ -3,7 +3,7 @@ NOTE: these properties can be used on their own or in conjunction with others e.
 Input
 =====
 
-Provides a common way to define input. Supports a filesystem
+Provides a common way to define input. Takes one or more filesystem
 path or `command <https://github.com/canonical/hotsos/blob/main/hotsos/core/host_helpers/cli.py>`_.
 When a command is provided, its output is written to a temporary file
 and *input.path* is set to the path of that file.
@@ -27,13 +27,41 @@ Usage:
 The *path* and *command* settings are mutually exclusive. A *path* can be a
 single or list of filesystem paths that must be relative to :ref:`Data Root`.
 
-By default if --all-logs is provided to the hotsos client that will apply
-to *path* but there may be cases where this is not desired and
-*disable-all-logs* can be used to disable this behaviour for a specific path.
+PathFinder
+----------
 
-When input is the output of a command, the execution of that command may
-itself require some input. Both *args* and *kwargs* can be set as a list and/or
-dictionary respectively and will be providing as input to the
+For applications that have more than one install method this can result in log
+files existing in different locations. To support this, some plugins provide a
+*PathFinder* which takes a relative log file path and returns the absolute path
+if it exists based on one or more choice. To use a *PathFinder* do the
+following:
+
+.. code-block:: yaml
+
+    input: '<plugin>:app.log'
+
+Where "plugin" results in *hotsos.core.plugins.<name>.PathFinder* being
+imported and called with *app.log* as a value. If the application uses either
+of e.g. /var/log and /snap/app/common/log then both are checked until
+one is found. This is useful so that we don't have to explicitly list all
+possible paths for every search.
+
+Logrotate Depth
+---------------
+
+By default if *--all-logs* is provided to the hotsos client that will apply
+to every *path* but there may be cases where this is not desired and
+*--disable-all-logs* can be used to disable this behaviour for a specific path.
+
+Using Command Output as Input
+-----------------------------
+
+If we want to take input as the output of a command, we can use the
+```command:``` stanza to specify a command that will be executed and its output
+captured.
+
+If the command requires some input, both *args* and *kwargs* can be set as a
+list and/or dictionary respectively and will be providing as input to the
 `CLIHelper command <https://github.com/canonical/hotsos/blob/main/hotsos/core/host_helpers/cli.py>`_.
 
 Sometimes we may way to dynamically generate the input args to *command*. For

--- a/hotsos/core/plugins/openvswitch/__init__.py
+++ b/hotsos/core/plugins/openvswitch/__init__.py
@@ -1,4 +1,4 @@
-from .common import OpenvSwitchChecks
+from .common import OpenvSwitchChecks, PathFinder
 from .ovs import (
     OpenvSwitchBase,
     OVSBFD,
@@ -22,4 +22,5 @@ __all__ = [
     OVSDPLookups.__name__,
     OVNBase.__name__,
     OVSFDBStats.__name__,
+    PathFinder.__name__,
     ]

--- a/hotsos/core/plugins/openvswitch/common.py
+++ b/hotsos/core/plugins/openvswitch/common.py
@@ -13,7 +13,7 @@ from hotsos.core.host_helpers import (
 from hotsos.core.plugins.openstack.openstack import OST_SUNBEAM_SNAP_NAMES
 from hotsos.core.ycheck.events import EventCallbackBase, EventHandlerBase
 from hotsos.core.ycheck.common import GlobalSearcherAutoRegisterBase
-from hotsos.core.utils import sorted_dict
+from hotsos.core.utils import PathFinderBase, sorted_dict
 
 OVS_SERVICES_EXPRS = [r'ovsdb[a-zA-Z-]*',
                       r'ovs-vswitch[a-zA-Z-]*',
@@ -36,6 +36,19 @@ OVS_PKGS_DEPS = _OVS_PKGS_DEPS + \
                 [PY_CLIENT_PREFIX.format(p) for p in _OVS_PKGS_DEPS]
 
 OVS_SNAPS_CORE = ['microovn'] + OST_SUNBEAM_SNAP_NAMES
+
+
+class PathFinder(PathFinderBase):
+    """ Supports both snap and deb based installed of ovs/ovn.
+
+    Ensure this list contains every possible path available for openvswitch/ovn
+    log files.
+    """
+    @property
+    def paths(self):
+        return ['var/log',
+                'var/snap/openstack-hypervisor/common/log',
+                'var/snap/microovn/common/logs']
 
 
 class OpenvSwitchGlobalSearchBase(GlobalSearcherAutoRegisterBase):

--- a/hotsos/core/plugins/storage/ceph/__init__.py
+++ b/hotsos/core/plugins/storage/ceph/__init__.py
@@ -1,4 +1,9 @@
-from .common import CephChecks, CephConfig, CephDaemonAllOSDsFactory
+from .common import (
+    CephChecks,
+    CephConfig,
+    CephDaemonAllOSDsFactory,
+    PathFinder,
+)
 from .cluster import CephCluster, CephCrushMap
 
 __all__ = [
@@ -6,5 +11,6 @@ __all__ = [
     CephConfig.__name__,
     CephDaemonAllOSDsFactory.__name__,
     CephCluster.__name__,
-    CephCrushMap.__name__
+    CephCrushMap.__name__,
+    PathFinder.__name__,
     ]

--- a/hotsos/core/plugins/storage/ceph/common.py
+++ b/hotsos/core/plugins/storage/ceph/common.py
@@ -32,6 +32,7 @@ from hotsos.core.search import (
     SearchDef
 )
 from hotsos.core.ycheck.events import EventCallbackBase
+from hotsos.core.utils import PathFinderBase
 
 CEPH_SERVICES_EXPRS = [r"ceph-[a-z0-9-]+",
                        r"rados[a-z0-9-:]+",
@@ -76,6 +77,18 @@ CEPH_REL_INFO = {
         'kraken': '11.0',
         'jewel': '10.0'},
 }
+
+
+class PathFinder(PathFinderBase):
+    """ Supports both snap and deb based installed of ceph.
+
+    Ensure this list contains every possible path available for ceph
+    log files.
+    """
+    @property
+    def paths(self):
+        return ['var/log/ceph',
+                'var/snap/microceph/common/logs']
 
 
 def csv_to_set(f):

--- a/hotsos/core/utils.py
+++ b/hotsos/core/utils.py
@@ -1,3 +1,6 @@
+import abc
+import glob
+import os
 import tempfile
 from collections import namedtuple
 from operator import attrgetter
@@ -105,3 +108,25 @@ def sort_suffixed_integers(values, reverse=False):
 
     reals.sort(key=attrgetter('actual'), reverse=reverse)
     return [t.raw for t in reals]
+
+
+class PathFinderBase:
+    """
+    Discovers correct path to a file. This is used to support file locations
+    that differ depending on their install method e.g. snap vs. deb package.
+    """
+
+    @property
+    @abc.abstractmethod
+    def paths(self):
+        """ This must be implemented and return and list of root locations to
+        use when search for a given subpath. """
+
+    def resolve(self, subpath):
+        for path in self.paths:
+            path = os.path.join(path, subpath)
+            for _path in glob.glob(os.path.join(HotSOSConfig.data_root, path)):
+                if os.path.exists(_path):
+                    return path
+
+        return None

--- a/hotsos/core/ycheck/common.py
+++ b/hotsos/core/ycheck/common.py
@@ -207,9 +207,6 @@ class GlobalSearcherPreloaderBase():
         @param search_property: YPropertySearch object
         @param search_input: YPropertyInput object
         """
-        if len(search_input.paths) == 0:
-            return
-
         allow_constraints = True
         if search_input.command:
             # don't apply constraints to command outputs
@@ -226,6 +223,9 @@ class GlobalSearcherPreloaderBase():
                                     search_property.simple_search,
                                 'sequence_search':
                                     search_property.sequence_search}
+
+        if len(search_input.paths) == 0:
+            return
 
         for path in search_input.paths:
             log.debug("loading search (tag=%s, input_path=%s, "

--- a/hotsos/core/ycheck/engine/properties/conclusions.py
+++ b/hotsos/core/ycheck/engine/properties/conclusions.py
@@ -104,7 +104,7 @@ class YPropertyRaises(YPropertyOverrideBase):
 
             # process now since there is no cache to resolve
             path, _, func = v.partition(':')
-            value = self.get_import(path)
+            value = self.get_import(self.context, path)
             if func:
                 value = PropertyCacheRefResolver.apply_renderer(value, func)
 
@@ -117,7 +117,7 @@ class YPropertyRaises(YPropertyOverrideBase):
         """ Name of core.issues.IssueTypeBase object and will be used to raise
         an issue or bug using message as argument. """
         _type = f"hotsos.core.issues.{self.content['type']}"
-        return self.get_cls(_type)
+        return self.get_cls(self.context, _type)
 
 
 class DecisionBase():

--- a/hotsos/core/ycheck/engine/properties/requires/types/binary.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/binary.py
@@ -53,7 +53,8 @@ class YRequirementTypeBinary(YRequirementTypeBase):
     @intercept_exception
     def _result(self):
         items = BinCheckItems(self._bin_info,
-                              bin_handler=self.get_cls(self.handler))
+                              bin_handler=self.get_cls(self.context,
+                                                       self.handler))
 
         _result = True
         # bail on first fail i.e. if any not installed

--- a/hotsos/core/ycheck/engine/properties/requires/types/config.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/config.py
@@ -190,7 +190,7 @@ class YRequirementTypeConfig(YRequirementTypeBase):
 
     @property
     def handler(self):
-        return self.get_cls(self.content['handler'])
+        return self.get_cls(self.context, self.content['handler'])
 
     @property
     def path(self):

--- a/hotsos/core/ycheck/engine/properties/requires/types/property.py
+++ b/hotsos/core/ycheck/engine/properties/requires/types/property.py
@@ -21,7 +21,7 @@ class YRequirementTypeProperty(YRequirementTypeWithOpsBase):
         else:
             path = self.content['path']
 
-        actual = self.get_property(path)
+        actual = self.get_property(self.context, path)
         result = self.apply_ops(self.ops, opinput=actual)
         log.debug('requirement check: property %s %s (result=%s)',
                   path, self.ops_to_str(self.ops), result)

--- a/hotsos/core/ycheck/engine/properties/search.py
+++ b/hotsos/core/ycheck/engine/properties/search.py
@@ -153,7 +153,7 @@ class YPropertySearchBase(YPropertyOverrideBase):
             for pattern in patterns:
                 if self._is_import_path(pattern):
                     try:
-                        pattern = self.get_property(pattern[1:])
+                        pattern = self.get_property(self.context, pattern[1:])
                     except ModuleNotFoundError:
                         log.warning("failed to import pattern '%s' - using "
                                     "raw string as expression", pattern)

--- a/hotsos/core/ycheck/engine/properties/vardef.py
+++ b/hotsos/core/ycheck/engine/properties/vardef.py
@@ -35,7 +35,7 @@ class YPropertyVars(YPropertyOverrideBase):
             value = getattr(self, name)
             if self._is_import_path(value):
                 # NOTE: this path can be a property or a factory.
-                value = self.get_property(value[1:])
+                value = self.get_property(self.context, value[1:])
 
             log.debug("resolved var %s=%s (type=%s)", name, value, type(value))
         else:

--- a/hotsos/defs/events/openvswitch/ovn/errors-and-warnings.yaml
+++ b/hotsos/defs/events/openvswitch/ovn/errors-and-warnings.yaml
@@ -1,21 +1,17 @@
 # NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 ovsdb-server-sb:
-  input:
-    path: 'var/log/ovn/ovsdb-server-sb.log'
+  input: 'openvswitch:ovn/ovsdb-server-sb.log'
   hint: '(ERR|WARN|EMER)'
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)'
 ovsdb-server-nb:
-  input:
-    path: 'var/log/ovn/ovsdb-server-nb.log'
+  input: 'openvswitch:ovn/ovsdb-server-nb.log'
   hint: '(ERR|WARN|EMER)'
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)'
 ovn-northd:
-  input:
-    path: 'var/log/ovn/ovn-northd.log'
+  input: 'openvswitch:ovn/ovn-northd.log'
   hint: '(ERR|WARN|EMER)'
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)'
 ovn-controller:
-  input:
-    path: 'var/log/ovn/ovn-controller.log'
+  input: 'openvswitch:ovn/ovn-controller.log'
   hint: '(ERR|WARN|EMER)'
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)'

--- a/hotsos/defs/events/openvswitch/ovn/ovn-central.yaml
+++ b/hotsos/defs/events/openvswitch/ovn/ovn-central.yaml
@@ -1,7 +1,6 @@
 # NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 ovsdb-server-sb:
-  input:
-    path: 'var/log/ovn/ovsdb-server-sb.log'
+  input: 'openvswitch:ovn/ovsdb-server-sb.log'
   inactivity-probe:
     expr: '([\d-]+)T[\d:]+\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
   unreasonably-long-poll-interval:
@@ -13,8 +12,7 @@ ovsdb-server-sb:
   compactions:
     expr: '([\d-]+)T[\d:]+\.\d+Z.+\|ovsdb\|INFO\|OVN_Southbound: Database compaction'
 ovsdb-server-nb:
-  input:
-    path: 'var/log/ovn/ovsdb-server-nb.log'
+  input: 'openvswitch:ovn/ovsdb-server-nb.log'
   inactivity-probe:
     expr: '([\d-]+)T[\d:]+\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
   unreasonably-long-poll-interval:
@@ -26,8 +24,7 @@ ovsdb-server-nb:
   compactions:
     expr: '([\d-]+)T[\d:]+\.\d+Z.+\|ovsdb\|INFO\|OVN_Northbound: Database compaction'
 ovn-northd:
-  input:
-    path: 'var/log/ovn/ovn-northd.log'
+  input: 'openvswitch:ovn/ovn-northd.log'
   inactivity-probe:
     expr: '([\d-]+)T[\d:]+\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
   leadership-acquired:

--- a/hotsos/defs/events/openvswitch/ovn/ovn-controller.yaml
+++ b/hotsos/defs/events/openvswitch/ovn/ovn-controller.yaml
@@ -1,6 +1,5 @@
 # NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
-input:
-  path: 'var/log/ovn/ovn-controller.log'
+input: 'openvswitch:ovn/ovn-controller.log'
 unreasonably-long-poll-interval:
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|timeval(?:\([a-zA-Z]+\d+\))?\|WARN\|Unreasonably long \d+ms poll interval'
   hint: 'Unreasonably'

--- a/hotsos/defs/events/openvswitch/ovs/bfd.yaml
+++ b/hotsos/defs/events/openvswitch/ovs/bfd.yaml
@@ -1,5 +1,4 @@
 # NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
-input:
-  path: 'var/log/openvswitch/ovs-vswitchd.log'
+input: 'openvswitch:openvswitch/ovs-vswitchd.log'
 bfd-state-changes:
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|bfd(?:\S+)?\|\S+\|(\S+): BFD state change: (\S+)'

--- a/hotsos/defs/events/openvswitch/ovs/errors-and-warnings.yaml
+++ b/hotsos/defs/events/openvswitch/ovs/errors-and-warnings.yaml
@@ -1,9 +1,7 @@
 # NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
 ovs-vswitchd:
-  input:
-    path: 'var/log/openvswitch/ovs-vswitchd.log'
+  input: 'openvswitch:openvswitch/ovs-vswitchd.log'
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)'
 ovsdb-server:
-  input:
-    path: 'var/log/openvswitch/ovsdb-server.log'
+  input: 'openvswitch:openvswitch/ovsdb-server.log'
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(ERR|ERROR|WARN|EMER)'

--- a/hotsos/defs/events/openvswitch/ovs/ovs-vswitchd.yaml
+++ b/hotsos/defs/events/openvswitch/ovs/ovs-vswitchd.yaml
@@ -1,6 +1,5 @@
 # NOTE: for efficiency, do not capture time as subgroup unless actually necessary.
-input:
-  path: 'var/log/openvswitch/ovs-vswitchd.log'
+input: 'openvswitch:openvswitch/ovs-vswitchd.log'
 netdev-linux-no-such-device:
   expr: '([\d-]+)T[\d:]+\.\d+Z.+\|(\S+): .+ \S+: No such device'
 bridge-no-such-device:

--- a/hotsos/defs/scenarios/openstack/neutron/ovn_stale_db.yaml
+++ b/hotsos/defs/scenarios/openstack/neutron/ovn_stale_db.yaml
@@ -20,7 +20,7 @@ checks:
       min-results: 10
       search-result-age-hours: 6
   has_1829109_ovn_controller_log:
-    input: var/log/ovn/ovn-controller.log
+    input: 'openvswitch:ovn/ovn-controller.log'
     expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|ovsdb_idl\|WARN\|tcp:\S+:6642: clustered database server has stale data; trying another server'
     constraints:
       min-results: 10

--- a/hotsos/defs/scenarios/openvswitch/dpif_lost_packets.yaml
+++ b/hotsos/defs/scenarios/openvswitch/dpif_lost_packets.yaml
@@ -1,6 +1,5 @@
 # default input
-input:
-  path: var/log/openvswitch/ovs-vswitchd.log
+input: 'openvswitch:openvswitch/ovs-vswitchd.log'
 vars:
   num_lost_packets: '@hotsos.core.plugins.openvswitch.OVSDPLookups.lost'
   lost_packets_msg_part1: >-

--- a/hotsos/defs/scenarios/openvswitch/dpif_resubmit_actions.yaml
+++ b/hotsos/defs/scenarios/openvswitch/dpif_resubmit_actions.yaml
@@ -1,6 +1,5 @@
 # default input
-input:
-  path: var/log/openvswitch/ovs-vswitchd.log
+input: 'openvswitch:openvswitch/ovs-vswitchd.log'
 checks:
   dpif_resubmit_limit_reached:
     search:

--- a/hotsos/defs/scenarios/openvswitch/ovn/bfd_flapping.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/bfd_flapping.yaml
@@ -2,8 +2,7 @@ vars:
   bfd_transitions: '@hotsos.core.plugins.openvswitch.OVSBFD.max_transitions_last_24h_within_hour'
 checks:
   vswitchd_to_ovn_controller_inactivity_timeouts:
-    input:
-      path: var/log/openvswitch/ovs-vswitchd.log
+    input: 'openvswitch:openvswitch/ovs-vswitchd.log'
     search:
       expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|reconnect\|ERR\|ssl:(\S+):\d+: no response to inactivity probe'
       constraints:
@@ -14,8 +13,7 @@ checks:
   bfd_state_changes:
     varops: [[$bfd_transitions], [ge, 5]]
   chassis_gw_port_reassignments:
-    input:
-      path: var/log/ovn/ovn-controller.log
+    input: 'openvswitch:ovn/ovn-controller.log'
     search:
       expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|binding\|INFO\|(Claiming|Releasing) lport cr-lrp-\S+ for this chassis.'
       constraints:

--- a/hotsos/defs/scenarios/openvswitch/ovn/bugs/lp1865127.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/bugs/lp1865127.yaml
@@ -1,6 +1,6 @@
 checks:
   1865127_logs:
-    input: 'var/log/ovn/ovn-controller.log'
+    input: 'openvswitch:ovn/ovn-controller.log'
     search:
       expr: '([\d-]+)T([\d:]+)\.\d+Z.+ERR\|bridge not found for localnet port \S+ with network name'
       constraints:

--- a/hotsos/defs/scenarios/openvswitch/ovn/bugs/lp1917475.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/bugs/lp1917475.yaml
@@ -1,6 +1,6 @@
 checks:
   has_1917475:
-    input: 'var/log/ovn/ovn-controller.log'
+    input: 'openvswitch:ovn/ovn-controller.log'
     search:
       expr: '([\d-]+)T([\d:]+)\.\d+Z.+transaction error: {"details":"RBAC rules for client \\"\S+\\" role \\"\S+\\" prohibit .+ table\s+\\"\S+\\".","error":"permission error"'
       constraints:

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_central_certs_logs.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_central_certs_logs.yaml
@@ -23,26 +23,26 @@ checks:
     - varops: [[$host_cert_mtime], [gt, $ovsdb_sb_start_time]]
     - varops: [[$ovn_central_cert_mtime], [gt, $ovsdb_sb_start_time]]
   northd_certs_invalid_logs:
-    input: var/log/ovn/ovn-northd.log
+    input: 'openvswitch:ovn/ovn-northd.log'
     expr: $cert_invalid_expr
     constraints:
       search-result-age-hours: 24
   northd_certs_expired_logs:
-    input: var/log/ovn/ovn-northd.log
+    input: 'openvswitch:ovn/ovn-northd.log'
     expr: $cert_expired_expr
     constraints:
       search-result-age-hours: 24
   db_certs_invalid_logs:
     input:
-      - var/log/ovn/ovsdb-server-nb.log
-      - var/log/ovn/ovsdb-server-sb.log
+      - 'openvswitch:ovn/ovsdb-server-nb.log'
+      - 'openvswitch:ovn/ovsdb-server-sb.log'
     expr: $cert_invalid_expr
     constraints:
       search-result-age-hours: 24
   db_certs_expired_logs:
     input:
-      - var/log/ovn/ovsdb-server-nb.log
-      - var/log/ovn/ovsdb-server-sb.log
+      - 'openvswitch:ovn/ovsdb-server-nb.log'
+      - 'openvswitch:ovn/ovsdb-server-sb.log'
     expr: $cert_expired_expr
     constraints:
       search-result-age-hours: 24

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_chassis_certs_logs.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_chassis_certs_logs.yaml
@@ -11,12 +11,12 @@ checks:
     - varops: [[$host_cert_mtime], [gt, $ovn_controller_start_time]]
     - varops: [[$ovn_chassis_cert_mtime], [gt, $ovn_controller_start_time]]
   certs_expired_logs:
-    input: var/log/ovn/ovn-controller.log
+    input: 'openvswitch:ovn/ovn-controller.log'
     expr: $cert_expired_expr
     constraints:
       search-result-age-hours: 24
   certs_invalid_logs:
-    input: var/log/ovn/ovn-controller.log
+    input: 'openvswitch:ovn/ovn-controller.log'
     expr: $cert_invalid_expr
     constraints:
       search-result-age-hours: 24

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_elections.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_elections.yaml
@@ -1,7 +1,6 @@
 checks:
   sb_ovn_elections:
-    input:
-      path: var/log/ovn/ovsdb-server-sb.log
+    input: 'openvswitch:ovn/ovsdb-server-sb.log'
     search:
       expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|raft\|INFO\|term ([0-9]+):\s(([0-9]+) ms timeout expired, )?starting election$'
       constraints:
@@ -9,8 +8,7 @@ checks:
         search-period-hours: 1
         search-result-age-hours: 48
   nb_ovn_elections:
-    input:
-      path: var/log/ovn/ovsdb-server-nb.log
+    input: 'openvswitch:ovn/ovsdb-server-nb.log'
     search:
       expr: '([\d-]+)T([\d:]+)\.\d+Z.+\|raft\|INFO\|term ([0-9]+):\s(([0-9]+) ms timeout expired, )?starting election$'
       constraints:

--- a/hotsos/defs/scenarios/openvswitch/ovn/ovn_upgrades.yaml
+++ b/hotsos/defs/scenarios/openvswitch/ovn/ovn_upgrades.yaml
@@ -22,7 +22,7 @@ checks:
         - min: 21.09.0
           max: 21.09.0~git20210806.d08f89e21-0ubuntu1
   has_northd_version_mismatch:
-    input: var/log/ovn/ovn-controller.log
+    input: 'openvswitch:ovn/ovn-controller.log'
     expr: '([\d-]+)T([\d:]+)\.\d+Z\|\S+\|main\|WARN\|controller version - (\S+) mismatch with northd version - (\S+)'
     constraints:
       search-result-age-hours: 336  # 14 days

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots.yaml
@@ -1,7 +1,6 @@
 checks:
   overlapping_roots:
-    input:
-      path: ['var/log/ceph/ceph-mgr*.log', 'var/snap/microceph/common/logs/ceph-mgr*.log']
+    input: 'storage.ceph:ceph-mgr*.log'
     expr:
       - '.* pool \w+ scale due to overlapping roots:.*'
       - '.* pool \w+ has overlapping roots: .*'

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/mon_elections_flapping.yaml
@@ -1,7 +1,6 @@
 checks:
   ceph_log_has_election_calls:
-    input:
-      path: ['var/log/ceph/ceph*.log', 'var/snap/microceph/common/logs/ceph*.log']
+    input: 'storage.ceph:ceph*.log'
     search:
       expr: '^([\d-]+)[T ]([\d:]+)\S+ (\S+) .+ mon.\S+ calling monitor election'
       constraints:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_flapping.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_flapping.yaml
@@ -2,9 +2,8 @@ checks:
   # NOTE: the following check can be run on a mon or osd node since the same
   # logs should be available on both.
   osd_flapping:
-    input:
-      path: ['var/log/ceph/ceph*.log', 'var/snap/microceph/common/logs/ceph*.log']
-    expr: '([\d-])+[T ][\d:]+\S+ .+ wrongly marked me down at .+'
+    input: 'storage.ceph:ceph*.log'
+    search: '([\d-])+[T ][\d:]+\S+ .+ wrongly marked me down at .+'
   ceph_interfaces_have_errors:
     property: hotsos.core.plugins.storage.ceph.CephChecks.has_interface_errors
 conclusions:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_slow_heartbeats.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_slow_heartbeats.yaml
@@ -1,7 +1,6 @@
 checks:
   osd_slow_heartbeats:
-    input:
-      path: ['var/log/ceph/ceph*.log', 'var/snap/microceph/common/logs/ceph*.log']
+    input: 'storage.ceph:ceph*.log'
     search:
       expr: '^([\d-]+)[T ]([\d:]+)\S+ .+ Slow OSD heartbeats on .+'
       constraints:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_slow_ops.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/osd_slow_ops.yaml
@@ -2,8 +2,7 @@ checks:
   # NOTE: the following check can be run on a mon or osd node since the same
   # logs should be available on both.
   osd_slow_ops:
-    input:
-      path: ['var/log/ceph/ceph*.log', 'var/snap/microceph/common/logs/ceph*.log']
+    input: 'storage.ceph:ceph*.log'
     search:
       expr: '^([\d-]+)[T ]([\d:]+)\S+ .+ slow ops, oldest one blocked .+'
       constraints:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/recent_laggy_pgs.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/recent_laggy_pgs.yaml
@@ -1,7 +1,6 @@
 checks:
   recent_laggy_pgs:
-    input:
-      path: ['var/log/ceph/ceph*.log', 'var/snap/microceph/common/logs/ceph*.log']
+    input: 'storage.ceph:ceph*.log'
     search:
       expr: '^([\d-]+)[T ]([\d:]+)\S+ .+laggy, .+'
       constraints:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/bugs/lp1996010.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/bugs/lp1996010.yaml
@@ -6,8 +6,8 @@ vars:
 checks:
   has_1996010_osd_log:
     # NOTE: this needs quite a high debug level to appear - debug_bluestore=30/30
-    input: ['var/log/ceph/ceph-osd.*.log', 'var/snap/microceph/common/logs/ceph-osd*.log']
-    expr: '([\d-]+)[T ][\d:]+\S+ .+ bluestore\.MempoolThread\(\S+\) _resize_shards max_shard_onodes: 0 '
+    input: 'storage.ceph:ceph-osd*.log'
+    search: '([\d-]+)[T ][\d:]+\S+ .+ bluestore\.MempoolThread\(\S+\) _resize_shards max_shard_onodes: 0 '
   has_1996010_mempools:
     # this is a hack to check if a value less than 10 exists in the list
     or:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/osd_latency.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/osd_latency.yaml
@@ -1,7 +1,6 @@
 checks:
   osd_disk_latency:
-    input:
-      path: ['var/log/ceph/ceph*.log', 'var/snap/microceph/common/logs/ceph*.log']
+    input: 'storage.ceph:ceph*.log'
     search:
       expr: '^([\d-]+)[T ]([\d:]+)\S+ .+ slow operation observed .+'
       constraints:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/pg_overdose.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/pg_overdose.yaml
@@ -5,11 +5,9 @@ checks:
       ops: [[ne, HEALTH_OK]]
   ceph_osd_withhold_creation:
     input:
-      path: ['var/log/ceph/ceph-osd*.log', 'var/log/ceph/ceph.log',
-             'var/snap/microceph/common/logs/ceph-osd*.log',
-             'var/snap/microceph/common/logs/ceph.log']
-    search:
-      expr: '[\d-]+[T ][\d:]+\S+ .+ (osd.+) .+ maybe_wait_for_max_pg withhold creation of pg .+: (.+) >= (.+)'
+      - 'storage.ceph:ceph*.log'
+      - 'storage.ceph:ceph-osd*.log'
+    search: '[\d-]+[T ][\d:]+\S+ .+ (osd.+) .+ maybe_wait_for_max_pg withhold creation of pg .+: (.+) >= (.+)'
 conclusions:
   pending_creating_pgs:
     decision:


### PR DESCRIPTION
Openvswitch/OVN can be installed from deb or snap which have different log path locations. To support this without having to duplicate multiple paths all over the yaml files we now have a PathFinder class that can be used to dynamically discover file paths. This is supported by the input ycheck property by providing '<pluginname>:<subpath>' as a value.

Currently implemented for the openvswitch plugin but easily extensible to others.

Resolves: #1046