### PR TITLE
[functest] runs func tests in parallel

### DIFF
--- a/tools/test/functest.sh
+++ b/tools/test/functest.sh
@@ -67,9 +67,12 @@ export PYTHONPATH=.
 
 default=${PLUGIN_ROOTS[openstack]}
 for plugin in ${PLUGINS[@]}; do
-    test_plugin $plugin
-    test_plugin $plugin short
+    test_plugin $plugin &
+    test_plugin $plugin short &
 done
+
+# wait for all plugin tests
+wait
 
 # do a test run with --save to be sure we havent broken anything
 ./scripts/hotsos --kernel --save --output-path $dtmp


### PR DESCRIPTION
We can run the plugin functional tests in paraell to speed it up. They're independent.

On my system, it's 81 sec (current) vs. 24 secs (with this PR).

Currently:
```
$ time tox -p
bashate: OK ✔ in 0.16 seconds
pep8: OK ✔ in 0.74 seconds
hotyvalidate: OK ✔ in 0.78 seconds
yamllint: OK ✔ in 1.99 seconds
pylint: OK ✔ in 12.51 seconds
py3-coverage: OK ✔ in 15.88 seconds
coveragereport: OK ✔ in 2.61 seconds
  py3-coverage: OK (15.88=setup[0.10]+cmd[0.07,15.71] seconds)
  coveragereport: OK (2.61=setup[0.01]+cmd[0.15,0.66,0.94,0.80,0.06] seconds)
  pep8: OK (0.73=setup[0.10]+cmd[0.63] seconds)
  pylint: OK (12.51=setup[0.10]+cmd[12.40] seconds)
  bashate: OK (0.16=setup[0.09]+cmd[0.07] seconds)
  yamllint: OK (1.99=setup[0.08]+cmd[1.91] seconds)
  functional: OK (81.59=setup[0.10]+cmd[81.49] seconds)
  hotyvalidate: OK (0.78=setup[0.10]+cmd[0.68] seconds)
  congratulations :) (81.63 seconds)

real	1m21.709s
user	3m8.055s
sys	0m22.984s
```

With parallel jobs:
```
$ time tox -p
bashate: OK ✔ in 0.21 seconds
pep8: OK ✔ in 1.27 seconds
hotyvalidate: OK ✔ in 1.85 seconds
yamllint: OK ✔ in 2.95 seconds
pylint: OK ✔ in 16.02 seconds
py3-coverage: OK ✔ in 19.47 seconds
coveragereport: OK ✔ in 2.57 seconds
  py3-coverage: OK (19.47=setup[0.10]+cmd[0.19,19.18] seconds)
  coveragereport: OK (2.57=setup[0.01]+cmd[0.14,0.68,0.87,0.81,0.06] seconds)
  pep8: OK (1.27=setup[0.08]+cmd[1.19] seconds)
  pylint: OK (16.02=setup[0.08]+cmd[15.95] seconds)
  bashate: OK (0.21=setup[0.09]+cmd[0.12] seconds)
  yamllint: OK (2.95=setup[0.10]+cmd[2.85] seconds)
  functional: OK (24.42=setup[0.07]+cmd[24.34] seconds)
  hotyvalidate: OK (1.85=setup[0.09]+cmd[1.76] seconds)
  congratulations :) (24.46 seconds)

real	0m24.537s
user	3m28.233s
sys	0m24.745s
```