### PR TITLE
Introduce affinity for PathFinder and cli commands

### DIFF
--- a/hotsos/core/host_helpers/cli/commands/ovs.py
+++ b/hotsos/core/host_helpers/cli/commands/ovs.py
@@ -148,6 +148,11 @@ class OVSOFCtlBinCmd(BinCmd):
         self.prefix = prefix
         super().__init__(*args, **kwargs)
 
+    @property
+    def _affinity_info(self):
+        """ Disable affinity for this command. """
+        return ()
+
     def __call__(self, *args, **kwargs):
         """
         First try without specifying protocol version. If error is raised
@@ -194,6 +199,11 @@ class OVSOFCtlFileCmd(FileCmd):
         path = (f'sos_commands/openvswitch/{prefix}ovs-ofctl'
                 '{ofversion}_{command}_{args}')
         super().__init__(path, *args, **kwargs)
+
+    @property
+    def _affinity_info(self):
+        """ Disable affinity for this command. """
+        return ()
 
     def __call__(self, *args, **kwargs):
         """

--- a/hotsos/core/ycheck/engine/properties/common.py
+++ b/hotsos/core/ycheck/engine/properties/common.py
@@ -297,7 +297,8 @@ class ImportHelper:
         @param key: key to retrieve
         """
         if context is None:
-            log.info("context not available - cannot load '%s'", key)
+            log.debug("context not available - cannot check cache for '%s'",
+                      key)
             return None
 
         # we save all imports in a dict called "import_cache" within the
@@ -350,7 +351,7 @@ class ImportHelper:
         @param value: value to save
         """
         if context is None:
-            log.info("context not available - cannot save '%s'", key)
+            log.debug("context not available - cannot save '%s' to cache", key)
             return
 
         c = getattr(context, 'import_cache')

--- a/tests/unit/host_helpers/test_cli.py
+++ b/tests/unit/host_helpers/test_cli.py
@@ -1,10 +1,12 @@
 import os
 import subprocess
+from dataclasses import dataclass
 from unittest import mock
 
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers.cli import (
     cli as host_cli,
+    catalog,
     common as cli_common,
 )
 
@@ -227,3 +229,166 @@ class TestCLIHelper(utils.BaseTestCase):
         expected = {'apiVersion': 'v1', 'items': [{'apiVersion': 'v1',
                                                    'kind': 'Service'}]}
         self.assertEqual(out, expected)
+
+
+class TestCommandAffinity(utils.BaseTestCase):
+    """ Tests for command affinity. """
+
+    CMD_KWARGS = {'ovs_appctl':
+                  {'command': 'dpctl/dump-dps'},
+                  'ovs_ofctl':
+                  {'command': 'dump-flows', 'args': 'br-data'},
+                  'ovs_vsctl_list':
+                  {'table': 'bridge'},
+                  'ovs_vsctl_get':
+                  {'table': 'Open_vSwitch', 'record': '.',
+                   'column': 'other_config'},
+                  'ethtool':
+                  {'interface': 'ens3'},
+                  'ns_ip_addr':
+                  {'namespace': 'fip-32981f34-497a-4fae-914a-8576055c8d0d'}}
+
+    # Allow the code to use affinity for this test
+    @mock.patch.object(host_cli.os, 'environ', {})
+    def test_cmd_affinity(self):
+
+        class CmdBase(cli_common.BinCmd):
+            """ fake command base """
+
+            @property
+            def _affinity_info(self):
+                return self.__class__, self.cmd
+
+        class CmdA(CmdBase):
+            """ fake command """
+
+        class CmdB(CmdBase):
+            """ fake command """
+
+        @dataclass
+        class FakeOut:
+            """
+            Fake Popen output
+            """
+            stdout: str
+            stderr: str
+            returncode: int
+
+        checked = []
+        with mock.patch.object(cli_common.subprocess, 'run') as mock_run:
+            for cmd in [(CmdA, 'cmd_a'), (CmdB, 'cmd_b')]:
+                cmd_cls, cmd_key = cmd
+                mock_run.return_value = FakeOut(f'i am {cmd_key}'.
+                                                encode('utf-8'),
+                                                ''.encode('utf-8'), 0)
+                source = cmd_cls(cmd_key)
+                self.assertEqual(cmd_cls.CMD_AFFINITY, None)
+                self.assertEqual(source().value, [f'i am {cmd_key}'])
+                source.affinity.set(cmd_key)
+                self.assertTrue(source.affinity.matches(cmd_key))
+                self.assertEqual(list(source.CMD_AFFINITY), [cmd_key])
+                checked.append(source)
+
+        self.assertEqual(len(checked), 2)
+        # ensure each cmd only has affinity info for itself
+        self.assertTrue(all(len(list(s.CMD_AFFINITY)) == 1
+                            for s in checked))
+
+    # Allow the code to use affinity for this test
+    @mock.patch.object(host_cli.os, 'environ', {})
+    def test_all_cmds(self):
+        cmds = set()
+        cmd_no_output = set()
+        skipped = set()
+        for cmd in catalog.CommandCatalog():
+            kwargs = self.CMD_KWARGS.get(cmd, {})
+            try:
+                if getattr(host_cli.CLIHelper(), cmd)(**kwargs):
+                    cmds.add(cmd)
+                else:
+                    cmd_no_output.add(cmd)
+
+            except KeyError:
+                skipped.add(cmd)
+
+        # These are commands where the data root does not contain info to
+        # return as output of the command and therefore an affinity was not
+        # set for he command source.
+        expected = set(['udevadm_info_dev',
+                        'kubectl_get',
+                        'docker_ps',
+                        'ceph_osd_df_tree_json_decoded',
+                        'ovn_nbctl_show',
+                        'ovn_sbctl_list',
+                        'pebble_services',
+                        'sunbeam_cluster_list_yaml_decoded',
+                        'ceph_daemon_osd_config_show',
+                        'ceph_report_json_decoded',
+                        'ps_axo_flags',
+                        'docker_images',
+                        'ovn_nbctl_list',
+                        'pacemaker_crm_status',
+                        'rabbitmqctl_report',
+                        'ceph_pg_dump_json_decoded',
+                        'ovn_sbctl_show',
+                        'ceph_mgr_module_ls',
+                        'ceph_health_detail_json_decoded',
+                        'sunbeam_cluster_list',
+                        'ceph_status_json_decoded',
+                        'ceph_daemon_osd_dump_mempools',
+                        'ceph_osd_crush_dump_json_decoded',
+                        'ceph_versions',
+                        'ceph_mon_dump_json_decoded',
+                        'ceph_osd_dump_json_decoded',
+                        'ceph_df_json_decoded',
+                        'kubectl_logs',
+                        ])
+        self.assertEqual(cmd_no_output, expected)
+        self.assertEqual(skipped, set())
+        # These are commands where the data root DOES contain info to
+        # return as output of the command and therefore an affinity WAS
+        # set for he command source.
+        expected = set(['apt_config_dump',
+                        'apparmor_status',
+                        'ceph_volume_lvm_list',
+                        'date',
+                        'df',
+                        'dmesg',
+                        'dpkg_l',
+                        'ethtool',
+                        'hostname',
+                        'hostnamectl',
+                        'ip_netns',
+                        'ip_addr',
+                        'ip_link',
+                        'ls_lanR_sys_block',
+                        'lscpu',
+                        'lsof_Mnlc',
+                        'lxd_buginfo',
+                        'numactl',
+                        'ns_ip_addr',
+                        'ovs_appctl',
+                        'ovs_vsctl_get',
+                        'ovs_vsctl_list',
+                        'ovs_vsctl_list_br',
+                        'ps',
+                        'pro_status',
+                        'snap_list_all',
+                        'sysctl_all',
+                        'systemctl_status_all',
+                        'systemctl_list_units',
+                        'systemctl_list_unit_files',
+                        'udevadm_info_exportdb',
+                        'uname',
+                        'uptime'])
+        self.assertEqual(cmds, expected.union(set(['ovs_ofctl'])))
+
+        affinity = set()
+        for cmd in cmds:
+            for source in catalog.CommandCatalog()[cmd]:
+                if source.CMD_AFFINITY:
+                    affinity.update(list(source.CMD_AFFINITY.keys()))
+
+        cmds.remove('ovs_ofctl')  # no affinity for this one
+        self.assertEqual(cmds, expected)
+        self.assertEqual(affinity, expected)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -507,6 +507,7 @@ class BaseTestCase(unittest.TestCase):
         self.maxDiff = None  # pylint: disable=invalid-name
         # ensure locale consistency wherever tests are run
         os.environ["LANG"] = 'C.UTF-8'
+        os.environ["HOTSOS_DISABLE_AFFINITY"] = 'True'
         # Always reset env globals
         HotSOSConfig.set(**self.hotsos_config)
         if not self.global_tmp_dir:


### PR DESCRIPTION
The recently added PathFinder makes it easier to define multiple
locations for application files to support more than one install
method. Since the root path for an application will not vary
while hotsos is running we can remember which one was last used
so we dont have to keep checking all options.

We can also apply similar logic when running CLI command and
try the last successful version of a command variant to avoid
having to search from scratch each time.

We call this path or command "affinity". This is disabled for
all unit tests using an environment variable since they are run
in parallel and modify the data_root across tests.