### PR TITLE
SET-1834 Fix ceph binary command json decode

### DIFF
--- a/hotsos/core/host_helpers/cli/commands/ceph.py
+++ b/hotsos/core/host_helpers/cli/commands/ceph.py
@@ -9,20 +9,43 @@ from hotsos.core.host_helpers.exceptions import SourceNotFound
 CephAliases = ['microceph.']
 
 
+class CephJSONBinCmd(BinCmd):
+    """
+    Some ceph commands that use --format json have some extra text added to the
+    end of the output which causes it to be invalid json
+    so we have to strip that final line before decoding the contents.
+    """
+    def __init__(self, *args, last_line_filter=None, **kwargs):
+        super().__init__(*args, json_decode=True, **kwargs)
+        self.last_line_filter = last_line_filter
+
+    def json_decode_output(self, output):
+        """
+        Remove request line(s) before decoding.
+        """
+        if output:
+            output = output.strip()
+            _split = output.splitlines()
+            if (_split and self.last_line_filter and
+                    _split[-1].startswith(self.last_line_filter)):
+                output = '\n'.join(_split[:-1])
+
+        return super().json_decode_output(output)
+
+
 class CephJSONFileCmd(FileCmd):
     """
     Some ceph commands that use --format json have some extra text added to the
     end of the file (typically from stderr) which causes it to be invalid json
     so we have to strip that final line before decoding the contents.
     """
-    def __init__(self, *args, first_line_filter=None, last_line_filter=None,
+    def __init__(self, *args, last_line_filter=None,
                  **kwargs):
-        super().__init__(*args, **kwargs)
-        if first_line_filter or last_line_filter:
+        super().__init__(*args, json_decode=True, **kwargs)
+        if last_line_filter:
             self.register_hook('pre-exec', self.format_json_contents)
             self.register_hook('post-exec', self.cleanup)
             self.orig_path = None
-            self.first_line_filter = first_line_filter
             self.last_line_filter = last_line_filter
 
     def format_json_contents(self, *_args, **_kwargs):
@@ -32,12 +55,7 @@ class CephJSONFileCmd(FileCmd):
         with open(self.path, encoding='utf-8') as f:
             lines = f.readlines()
 
-        if self.first_line_filter:
-            line_filter = self.first_line_filter
-        else:
-            line_filter = self.last_line_filter
-
-        if lines and lines[-1].startswith(line_filter):
+        if lines and lines[-1].startswith(self.last_line_filter):
             lines = lines[:-1]
             with tempfile.NamedTemporaryFile(mode='w+t', delete=False) as tmp:
                 tmp.write(''.join(lines))
@@ -63,17 +81,16 @@ class CephHealthDetailCommands(UserList):
     def __init__(self):
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph health detail --format json-pretty',
-                       json_decode=True) for prefix in prefixes]
+        cmds = [CephJSONBinCmd(f'{prefix}ceph health detail --format '
+                               'json-pretty') for prefix in prefixes]
         # file-based
         # sosreport < 4.2
-        cmds.append(FileCmd('sos_commands/ceph/json_output/'
-                            'ceph_health_detail_--format_json-pretty',
-                            json_decode=True))
+        cmds.append(CephJSONFileCmd('sos_commands/ceph/json_output/'
+                                    'ceph_health_detail_--format_json-pretty'))
         # sosreport >= 4.2
-        cmds.extend([FileCmd('sos_commands/ceph_mon/json_output/'
-                             f'{prefix}ceph_health_detail_'
-                             '--format_json-pretty', json_decode=True)
+        cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/json_output/'
+                                     f'{prefix}ceph_health_detail_'
+                                     '--format_json-pretty')
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -82,24 +99,21 @@ class CephMonDumpCommands(UserList):
     """ Generate ceph mon dump command variants. """
 
     def __init__(self):
+        json_kwargs = {'last_line_filter': 'dumped monmap epoch'}
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph mon dump --format json-pretty',
-                       json_decode=True) for prefix in prefixes]
+        cmds = [CephJSONBinCmd(f'{prefix}ceph mon dump --format json-pretty',
+                               **json_kwargs) for prefix in prefixes]
         # file-based
         # sosreport < 4.2
         cmds.append(CephJSONFileCmd('sos_commands/ceph/json_output/'
                                     'ceph_mon_dump_--format_json-pretty',
-                                    json_decode=True,
-                                    first_line_filter='dumped monmap epoch',
-                                    last_line_filter='dumped monmap epoch'))
+                                    **json_kwargs))
         # sosreport >= 4.2
         cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/json_output/'
                                      f'{prefix}ceph_mon_dump_'
                                      '--format_json-pretty',
-                                     json_decode=True,
-                                     first_line_filter='dumped monmap epoch',
-                                     last_line_filter='dumped monmap epoch')
+                                     **json_kwargs)
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -110,18 +124,16 @@ class CephOSDDumpCommands(UserList):
     def __init__(self):
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph osd dump --format json-pretty',
-                       json_decode=True)
+        cmds = [CephJSONBinCmd(f'{prefix}ceph osd dump --format json-pretty')
                 for prefix in prefixes]
         # file-based
         # sosreport < 4.2
-        cmds.append(FileCmd('sos_commands/ceph/json_output/'
-                            'ceph_osd_dump_--format_json-pretty',
-                            json_decode=True))
+        cmds.append(CephJSONFileCmd('sos_commands/ceph/json_output/'
+                                    'ceph_osd_dump_--format_json-pretty'))
         # sosreport >= 4.2
-        cmds.extend([FileCmd('sos_commands/ceph_mon/json_output/'
-                             f'{prefix}ceph_osd_dump_--format_json-pretty',
-                             json_decode=True)
+        cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/json_output/'
+                                     f'{prefix}ceph_osd_dump_'
+                                     '--format_json-pretty')
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -132,17 +144,15 @@ class CephDFCommands(UserList):
     def __init__(self):
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph df --format json-pretty',
-                       json_decode=True) for prefix in prefixes]
+        cmds = [CephJSONBinCmd(f'{prefix}ceph df --format json-pretty')
+                for prefix in prefixes]
         # file-based
         # sosreport < 4.2
-        cmds.append(FileCmd('sos_commands/ceph/json_output/'
-                            'ceph_df_--format_json-pretty',
-                            json_decode=True))
+        cmds.append(CephJSONFileCmd('sos_commands/ceph/json_output/'
+                                    'ceph_df_--format_json-pretty'))
         # sosreport >= 4.2
-        cmds.extend([FileCmd('sos_commands/ceph_mon/json_output/'
-                             f'{prefix}ceph_df_--format_json-pretty',
-                             json_decode=True)
+        cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/json_output/'
+                                     f'{prefix}ceph_df_--format_json-pretty')
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -153,17 +163,17 @@ class CepOSDDFTreeCommands(UserList):
     def __init__(self):
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph osd df tree --format json-pretty',
-                       json_decode=True) for prefix in prefixes]
+        cmds = [CephJSONBinCmd(f'{prefix}ceph osd df tree '
+                               '--format json-pretty')
+                for prefix in prefixes]
         # file-based
         # sosreport < 4.2
-        cmds.append(FileCmd('sos_commands/ceph/json_output/'
-                            'ceph_osd_df_tree_--format_json-pretty',
-                            json_decode=True))
+        cmds.append(CephJSONFileCmd('sos_commands/ceph/json_output/'
+                                    'ceph_osd_df_tree_--format_json-pretty'))
         # sosreport >= 4.2
-        cmds.extend([FileCmd('sos_commands/ceph_mon/json_output/'
-                             f'{prefix}ceph_osd_df_tree_--format_json-pretty',
-                             json_decode=True)
+        cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/json_output/'
+                                     f'{prefix}ceph_osd_df_tree_'
+                                     '--format_json-pretty')
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -174,16 +184,14 @@ class CephOSDCrushDumpCommands(UserList):
     def __init__(self):
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph osd crush dump',
-                       json_decode=True) for prefix in prefixes]
+        cmds = [CephJSONBinCmd(f'{prefix}ceph osd crush dump')
+                for prefix in prefixes]
         # file-based
         # sosreport < 4.2
-        cmds.append(FileCmd('sos_commands/ceph/ceph_osd_crush_dump',
-                            json_decode=True))
+        cmds.append(CephJSONFileCmd('sos_commands/ceph/ceph_osd_crush_dump'))
         # sosreport >= 4.2
-        cmds.extend([FileCmd('sos_commands/ceph_mon/'
-                             f'{prefix}ceph_osd_crush_dump',
-                             json_decode=True)
+        cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/'
+                                     f'{prefix}ceph_osd_crush_dump')
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -192,25 +200,22 @@ class CephPGDumpCommands(UserList):
     """ Generate ceph pg dump command variants. """
 
     def __init__(self):
+        json_kwargs = {'last_line_filter': 'dumped all'}
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph pg dump --format json-pretty',
-                       json_decode=True)
+        cmds = [CephJSONBinCmd(f'{prefix}ceph pg dump --format json-pretty',
+                               **json_kwargs)
                 for prefix in prefixes]
         # file-based
         # sosreport < 4.2
         cmds.append(CephJSONFileCmd('sos_commands/ceph/json_output/'
                                     'ceph_pg_dump_--format_json-pretty',
-                                    json_decode=True,
-                                    first_line_filter='dumped all',
-                                    last_line_filter='dumped all'))
+                                    **json_kwargs))
         # sosreport >= 4.2
         cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/json_output/'
                                      f'{prefix}ceph_pg_dump_'
                                      '--format_json-pretty',
-                                     json_decode=True,
-                                     first_line_filter='dumped all',
-                                     last_line_filter='dumped all')
+                                     **json_kwargs)
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -221,17 +226,16 @@ class CephStatusCommands(UserList):
     def __init__(self):
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph status --format json-pretty',
-                       json_decode=True) for prefix in prefixes]
+        cmds = [CephJSONBinCmd(f'{prefix}ceph status --format json-pretty')
+                for prefix in prefixes]
         # file-based
         # sosreport < 4.2
-        cmds.append(FileCmd('sos_commands/ceph/json_output/'
-                            'ceph_status_--format_json-pretty',
-                            json_decode=True))
+        cmds.append(CephJSONFileCmd('sos_commands/ceph/json_output/'
+                                    'ceph_status_--format_json-pretty'))
         # sosreport >= 4.2
-        cmds.extend([FileCmd('sos_commands/ceph_mon/json_output/'
-                             f'{prefix}ceph_status_--format_json-pretty',
-                             json_decode=True)
+        cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/json_output/'
+                                     f'{prefix}ceph_status_'
+                                     '--format_json-pretty')
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -274,22 +278,18 @@ class CephReportCommands(UserList):
     """ Generate ceph XXX command variants. """
 
     def __init__(self):
+        json_kwargs = {'last_line_filter': 'report'}
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph report', json_decode=True)
+        cmds = [CephJSONBinCmd(f'{prefix}ceph report', **json_kwargs)
                 for prefix in prefixes]
         # file-based
         # sosreport < 4.2
         cmds.append(CephJSONFileCmd('sos_commands/ceph/ceph_report',
-                                    json_decode=True,
-                                    first_line_filter='report',
-                                    last_line_filter='report'))
+                                    **json_kwargs))
         # sosreport >= 4.2
         cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/'
-                                     f'{prefix}ceph_report',
-                                     json_decode=True,
-                                     first_line_filter='report',
-                                     last_line_filter='report')
+                                     f'{prefix}ceph_report', **json_kwargs)
                      for prefix in prefixes])
         super().__init__(cmds)
 
@@ -300,15 +300,13 @@ class CephMgrModuleLsCommands(UserList):
     def __init__(self):
         prefixes = [""] + CephAliases
         # binary
-        cmds = [BinCmd(f'{prefix}ceph mgr module ls',
-                       json_decode=True) for prefix in prefixes]
+        cmds = [CephJSONBinCmd(f'{prefix}ceph mgr module ls')
+                for prefix in prefixes]
         # file-based
         # sosreport < 4.2
-        cmds.append(CephJSONFileCmd('sos_commands/ceph/ceph_mgr_module_ls',
-                                    json_decode=True))
+        cmds.append(CephJSONFileCmd('sos_commands/ceph/ceph_mgr_module_ls'))
         # sosreport >= 4.2
         cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/'
-                                     f'{prefix}ceph_mgr_module_ls',
-                                     json_decode=True)
+                                     f'{prefix}ceph_mgr_module_ls')
                      for prefix in prefixes])
         super().__init__(cmds)

--- a/hotsos/core/host_helpers/cli/common.py
+++ b/hotsos/core/host_helpers/cli/common.py
@@ -213,6 +213,14 @@ class BinCmd(BinCmdBase):
     """ Implements binary command execution. """
     TYPE = "BIN"
 
+    def json_decode_output(self, output):  # pylint: disable=no-self-use
+        """
+        Decode JSON output.
+
+        This allows implementations to override the decoding if necessary.
+        """
+        return CmdOutput(json.loads(output))
+
     @catch_exceptions(*CLI_COMMON_EXCEPTIONS)
     @reset_command
     @run_post_exec_hooks
@@ -244,7 +252,7 @@ class BinCmd(BinCmdBase):
             output = ''
 
         if self.json_decode and not skip_json_decode:
-            return CmdOutput(json.loads(output))
+            return self.json_decode_output(output)
 
         if self.yaml_decode:
             return CmdOutput(yaml.safe_load(output))

--- a/tests/unit/host_helpers/test_cli.py
+++ b/tests/unit/host_helpers/test_cli.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from dataclasses import dataclass
 from unittest import mock
 
 from hotsos.core.config import HotSOSConfig
@@ -265,22 +264,13 @@ class TestCommandAffinity(utils.BaseTestCase):
         class CmdB(CmdBase):
             """ fake command """
 
-        @dataclass
-        class FakeOut:
-            """
-            Fake Popen output
-            """
-            stdout: str
-            stderr: str
-            returncode: int
-
         checked = []
         with mock.patch.object(cli_common.subprocess, 'run') as mock_run:
             for cmd in [(CmdA, 'cmd_a'), (CmdB, 'cmd_b')]:
                 cmd_cls, cmd_key = cmd
-                mock_run.return_value = FakeOut(f'i am {cmd_key}'.
-                                                encode('utf-8'),
-                                                ''.encode('utf-8'), 0)
+                mock_run.return_value = utils.FakeOut(f'i am {cmd_key}'.
+                                                      encode('utf-8'),
+                                                      ''.encode('utf-8'), 0)
                 source = cmd_cls(cmd_key)
                 self.assertEqual(cmd_cls.CMD_AFFINITY, None)
                 self.assertEqual(source().value, [f'i am {cmd_key}'])

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -32,6 +32,16 @@ TEST_TEMPLATE_SCHEMA = set(['target-name', 'data-root', 'mock',
                             'raised-issues', 'raised-bugs'])
 
 
+@dataclass
+class FakeOut:
+    """
+    Fake Popen output
+    """
+    stdout: str
+    stderr: str
+    returncode: int
+
+
 def find_all_templated_tests(path):
     """
     Generator to recursively find all templates (files) under path.


### PR DESCRIPTION
Some ceph commands append their json output with a string that needs to be removed before it can be decoded. We already did this for sosreport commands but now have it for binary/host commands.