### PR TITLE
[core] Fix decode errors from searchkit

### DIFF
--- a/hotsos/core/search.py
+++ b/hotsos/core/search.py
@@ -39,6 +39,7 @@ class FileSearcher(_FileSearcher):
         super().__init__(*args,
                          max_parallel_tasks=HotSOSConfig.max_parallel_tasks,
                          max_logrotate_depth=max_logrotate_depth,
+                         decode_errors='backslashreplace',
                          **kwargs)
 
 


### PR DESCRIPTION
When UTF-8 decoding fails, searchkit throws an exception.

Passing decode_errors='backslashreplace' to cope with that.

Fixes #860.