### PR TITLE
Use ovs PathFinder for OVSBFDSearch

### DIFF
--- a/hotsos/core/plugins/openvswitch/common.py
+++ b/hotsos/core/plugins/openvswitch/common.py
@@ -52,7 +52,14 @@ class PathFinder(PathFinderBase):
 
 
 class OpenvSwitchGlobalSearchBase(GlobalSearcherAutoRegisterBase):
-    """ Base class for global searcher registration for OpenvSwitch. """
+    """ Base class for global searcher registration for OpenvSwitch.
+
+    Event and scenario searches already leverage the global searcher and this
+    is an extension for searches done in code that is called from events and
+    scenarios such that it does not incur an extra search run. In other words
+    this ensures that these searches are bundled with the others in the global
+    search.
+    """
     plugin_name = "openvswitch"
 
     @classmethod

--- a/hotsos/core/plugins/openvswitch/ovs.py
+++ b/hotsos/core/plugins/openvswitch/ovs.py
@@ -20,6 +20,7 @@ from hotsos.core.search import (
 from hotsos.core.plugins.openvswitch.common import (
     OpenvSwitchGlobalSearchBase,
     OVSDBTableBase,
+    PathFinder,
 )
 
 
@@ -242,8 +243,11 @@ class OVSBFDSearch(OpenvSwitchGlobalSearchBase):
 
     @classmethod
     def paths(cls):
-        return [os.path.join(HotSOSConfig.data_root,
-                             'var/log/openvswitch/ovs-vswitchd.log')]
+        path = PathFinder().resolve('openvswitch/ovs-vswitchd.log')
+        if path:
+            return [os.path.join(HotSOSConfig.data_root, path)]
+
+        return []
 
 
 class OVSBFD(OpenvSwitchBase):

--- a/hotsos/core/ycheck/common.py
+++ b/hotsos/core/ycheck/common.py
@@ -259,11 +259,13 @@ class GlobalSearcherAutoRegisterMeta(type):
 class GlobalSearcherAutoRegisterBase(metaclass=GlobalSearcherAutoRegisterMeta):
     """
     Generic interface for loading search definitions into the global searcher.
+
     The attributes of this class are intentionally similar to those of
     hotsos.core.ycheck.engine.properties.search so as to be able to give them
     equivalent meaning but this is really intended for use by code that wants
     to perform searches but that is not using YPropertySearch (i.e. not event
-    or scenario yaml).
+    or scenario yaml). An example of this would be imported code that performs
+    searches that is called from an event or scenario.
     """
     # This must be set to the same value as used by corresponding
     # implementation of PluginPartBase.plugin_name.


### PR DESCRIPTION
Was previously hardcoded to the debian/apt install path. This is required to work with microovn.

Also adds more detailed docstring to ovs global searcher extension and GlobalSearcherAutoRegisterBase class.