### PR TITLE
Add juju-db CVE checker

### DIFF
--- a/hotsos/core/host_helpers/packaging.py
+++ b/hotsos/core/host_helpers/packaging.py
@@ -553,33 +553,39 @@ class SnapPackageHelper(PackageHelperBase):
     def get_revision(self, snap):
         """ Return revision of package.
         """
-        info = self._get_snap_info(snap)
-        if info:
-            return info[0]['revision']
-
-        return None
+        return self._get_active_info(snap).get('revision')
 
     def get_version(self, pkg):
-        """ Return version of snap package.
-
-        Assumes only one snap will be matched.
+        """ Return version of a package.
         """
-        info = self._get_snap_info(pkg)
-        if info:
-            return info[0]['version']
-
-        return None
+        return self._get_active_info(pkg).get('version')
 
     def get_channel(self, pkg):
         """ Return channel of snap package.
-
-        Assumes only one snap will be matched.
         """
-        info = self._get_snap_info(pkg)
-        if info:
-            return info[0]['channel']
+        return self._get_active_info(pkg).get('channel')
 
-        return None
+    def _get_active_info(self, snap):
+        """
+        Return info dict for the active (non-disabled) revision of snap.
+
+        Prefers the already-resolved cache in self.all; falls back to
+        scanning snap_list_all directly when the package was not part
+        of the exprs used at construction time. In both cases disabled
+        snap revisions are filtered out when self.ignore_disabled is True.
+        """
+        if snap in self.all:
+            return self.all[snap]
+
+        active = None
+        for snap_info in self._get_snap_info(snap) or []:
+            if self.ignore_disabled and 'disabled' in snap_info['notes']:
+                continue
+            # pick the highest version if multiple active entries exist
+            if active is None or snap_info['version'] > active['version']:
+                active = snap_info
+
+        return active or {}
 
     def _get_snap_info(self, snap_name_expr):
         """
@@ -621,23 +627,28 @@ class SnapPackageHelper(PackageHelperBase):
 
                 name = snap_info['name']
                 version = snap_info['version']
+                revision = snap_info['revision']
                 channel = snap_info['channel']
                 # only show latest version installed
                 if snap in self.exprs['core']:
                     if name in _core:
                         if version > _core[name]['version']:
                             _core[name]['version'] = version
+                            _core[name]['revision'] = revision
                             _core[name]['channel'] = channel
                     else:
                         _core[name] = {'version': version,
+                                       'revision': revision,
                                        'channel': channel}
                 else:
                     if name in _other:
                         if version > _other[name]['version']:
                             _other[name]['version'] = version
+                            _other[name]['revision'] = revision
                             _other[name]['channel'] = channel
                     else:
                         _other[name] = {'version': version,
+                                        'revision': revision,
                                         'channel': channel}
 
         # ensure sorted

--- a/hotsos/core/plugins/juju/common.py
+++ b/hotsos/core/plugins/juju/common.py
@@ -51,6 +51,10 @@ class JujuChecks(plugintools.PluginPartBase, JujuBase):
 
         return "unknown"
 
+    @property
+    def is_controller(self):
+        return self.machine and self.machine.is_controller
+
     @classmethod
     def is_runnable(cls):
         """

--- a/hotsos/core/plugins/juju/resources.py
+++ b/hotsos/core/plugins/juju/resources.py
@@ -104,6 +104,16 @@ class JujuMachine():
         return self.config.get("upgradedToVersion", "unknown")
 
     @cached_property
+    def is_controller(self):
+        """
+        Check if this machine is a Juju controller.
+
+        Controllers have JobManageModel in their jobs list.
+        """
+        jobs = self.config.get("jobs", [])
+        return "JobManageModel" in jobs
+
+    @cached_property
     def deployed_units(self):
         units = []
         # requires >= 2.9.x

--- a/hotsos/defs/scenarios/juju/juju_db_cve.yaml
+++ b/hotsos/defs/scenarios/juju/juju_db_cve.yaml
@@ -1,0 +1,28 @@
+checks:
+  is_juju_controller:
+    property:
+      path: hotsos.core.plugins.juju.JujuChecks.is_controller
+      ops: [[truth]]
+  has_affected_juju_db_snap:
+    snap:
+      juju-db:
+        - version:
+            min: '0'
+            max: '4.4.29'
+conclusions:
+  juju_db_cve_2025_14847:
+    decision:
+      - is_juju_controller
+      - has_affected_juju_db_snap
+    raises:
+      type: MitreCVE
+      cve-id: CVE-2025-14847
+      message: >-
+        This Juju controller is running juju-db snap version {version}
+        which is affected by CVE-2025-14847. To mitigate this
+        vulnerability, upgrade the controller to juju >= 3.6.21 or juju >=2.9.59
+        and refresh the juju-db snap to >= 4.4.30. This involves a channel change
+        'snap refresh --channel 4.4.30 juju-db' and also a MongoDB update.
+        You should reference the upstream helper script: https://github.com/juju/juju/blob/3.6/scripts/set-juju-db-snap-channel.sh
+      format-dict:
+        version: '@checks.has_affected_juju_db_snap.requires.version'

--- a/hotsos/defs/tests/scenarios/juju/juju_db_cve_affected.yaml
+++ b/hotsos/defs/tests/scenarios/juju/juju_db_cve_affected.yaml
@@ -1,0 +1,26 @@
+target-name: juju_db_cve.yaml
+data-root:
+  files:
+    var/lib/juju/agents/machine-0/agent.conf: |
+      # format 2.0
+      tag: machine-0
+      datadir: /var/lib/juju
+      logdir: /var/log/juju
+      jobs:
+      - JobManageModel
+      - JobHostUnits
+      upgradedToVersion: 3.6.14
+      juju-db-snap-channel: 4.4/stable
+      values:
+        AGENT_SERVICE_NAME: jujud-machine-0
+    sos_commands/snap/snap_list_--all: |
+      Name     Version   Rev    Tracking       Publisher    Notes
+      juju-db  4.4.24    178    4.4/stable     juju-qa      -
+raised-bugs:
+  https://www.cve.org/CVERecord?id=CVE-2025-14847: >-
+      This Juju controller is running juju-db snap version 4.4.24
+      which is affected by CVE-2025-14847. To mitigate this
+      vulnerability, upgrade the controller to juju >= 3.6.21 or juju >=2.9.59
+      and refresh the juju-db snap to >= 4.4.30. This involves a channel change
+      'snap refresh --channel 4.4.30 juju-db' and also a MongoDB update.
+      You should reference the upstream helper script: https://github.com/juju/juju/blob/3.6/scripts/set-juju-db-snap-channel.sh

--- a/hotsos/defs/tests/scenarios/juju/juju_db_cve_not_affected.yaml
+++ b/hotsos/defs/tests/scenarios/juju/juju_db_cve_not_affected.yaml
@@ -1,0 +1,18 @@
+target-name: juju_db_cve.yaml
+data-root:
+  files:
+    var/lib/juju/agents/machine-0/agent.conf: |
+      # format 2.0
+      tag: machine-0
+      datadir: /var/lib/juju
+      logdir: /var/log/juju
+      jobs:
+      - JobManageModel
+      - JobHostUnits
+      upgradedToVersion: 3.6.15
+      juju-db-snap-channel: 4.4/stable
+      values:
+        AGENT_SERVICE_NAME: jujud-machine-0
+    sos_commands/snap/snap_list_--all: |
+      Name     Version   Rev    Tracking       Publisher    Notes
+      juju-db  4.4.30    189    4.4.30/candidate  juju-qa      -

--- a/hotsos/defs/tests/scenarios/juju/juju_db_cve_not_controller.yaml
+++ b/hotsos/defs/tests/scenarios/juju/juju_db_cve_not_controller.yaml
@@ -1,0 +1,16 @@
+target-name: juju_db_cve.yaml
+data-root:
+  files:
+    var/lib/juju/agents/machine-3/agent.conf: |
+      # format 2.0
+      tag: machine-3
+      datadir: /var/lib/juju
+      logdir: /var/log/juju
+      jobs:
+      - JobHostUnits
+      upgradedToVersion: 3.6.14
+      values:
+        AGENT_SERVICE_NAME: jujud-machine-3
+    sos_commands/snap/snap_list_--all: |
+      Name     Version   Rev    Tracking       Publisher    Notes
+      core20   20260105  2717   latest/stable  canonical**  base

--- a/tests/unit/host_helpers/test_packaging.py
+++ b/tests/unit/host_helpers/test_packaging.py
@@ -46,7 +46,8 @@ class TestSnapPackageHelper(utils.BaseTestCase):
     """ Unit tests for snap helper """
     def test_all(self):
         expected = {'core20': {'channel': 'latest/stable',
-                               'version': '20220114'}}
+                               'version': '20220114',
+                               'revision': '1328'}}
         obj = host_pack.SnapPackageHelper(["core20"])
         self.assertEqual(obj.all, expected)
         # lookup package already loaded

--- a/tests/unit/openstack/test_sunbeam.py
+++ b/tests/unit/openstack/test_sunbeam.py
@@ -150,9 +150,11 @@ class TestOpenstackSunbeamPluginCore(TestOpenstackSunbeamBase):
     def test_project_catalog_snap_packages(self):
         ost_base = openstack_core.OpenstackBase()
         core = {'openstack':
-                {'version': '2024.1', 'channel': '2024.1/stable'},
+                {'version': '2024.1', 'revision': '727',
+                 'channel': '2024.1/stable'},
                 'openstack-hypervisor':
-                {'version': '2024.1', 'channel': '2024.1/stable'}}
+                {'version': '2024.1', 'revision': '244',
+                 'channel': '2024.1/stable'}}
         self.assertEqual(ost_base.snaps.core, core)
 
 


### PR DESCRIPTION
This adds a checker for  the MongoDB CVE-2025-14847 that affects juju controllers.