### PR TITLE
SET-1988 Check for systemd units in bad state

### DIFF
--- a/hotsos/core/host_helpers/systemd.py
+++ b/hotsos/core/host_helpers/systemd.py
@@ -305,6 +305,22 @@ class SystemdHelper(ServiceManagerBase):
 
         return sorted(self._service_info.get('masked', []))
 
+    @property
+    def bad_units(self):
+        """
+        Return dictionary with service name and state for each unit
+        with state 'bad'.
+
+        The "bad" state means the unit file is invalid or some other error
+        occurred.
+        """
+        bad = {}
+        for svc in self.services.values():
+            if svc.state == 'bad':
+                bad[svc.name] = svc.state
+
+        return bad
+
     def get_services_expanded(self, name):
         _expanded = []
         for line in self._systemctl_list_units:

--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -63,6 +63,10 @@ class CephWarning(IssueTypeBase):
     """ Issue for ceph warnings. """
 
 
+class CephError(IssueTypeBase):
+    """ Issue for ceph errors. """
+
+
 class CephHealthWarning(IssueTypeBase):
     """ Issue for Ceph cluster health warnings. """
 
@@ -131,6 +135,10 @@ class RabbitMQWarning(IssueTypeBase):
     """ Issue for RabbitMQ warnings. """
 
 
+class OpenStackError(IssueTypeBase):
+    """ Issue for Openstack errors. """
+
+
 class OpenstackWarning(IssueTypeBase):
     """ Issue for Openstack warnings. """
 
@@ -161,6 +169,10 @@ class OpenstackError(IssueTypeBase):
 
 class KubernetesWarning(IssueTypeBase):
     """ Issue for Kubernetes warnings. """
+
+
+class KubernetesError(IssueTypeBase):
+    """ Issue for Kubernetes errors. """
 
 
 class PacemakerWarning(IssueTypeBase):

--- a/hotsos/core/plugins/kubernetes.py
+++ b/hotsos/core/plugins/kubernetes.py
@@ -126,6 +126,11 @@ class KubernetesChecks(KubernetesBase, plugintools.PluginPartBase):
         super().__init__()
         KubernetesInstallInfo().mixin(self)
 
+    @property
+    def bad_units(self):
+        """ Passthrough property to allow it to be called from yaml checks. """
+        return self.systemd.bad_units
+
     @classmethod
     def is_runnable(cls):
         """

--- a/hotsos/core/plugins/openstack/common.py
+++ b/hotsos/core/plugins/openstack/common.py
@@ -298,6 +298,11 @@ class OpenstackBase():  # pylint: disable=too-many-instance-attributes
         expected_masked = self.project_catalog.default_masked_services
         return sorted(list(masked.difference(expected_masked)))
 
+    @property
+    def bad_units(self):
+        """ Passthrough property to allow it to be called from yaml checks. """
+        return self.systemd.bad_units
+
 
 class OpenStackChecks(plugintools.PluginPartBase):
     """ OpenStack checks. """

--- a/hotsos/core/plugins/storage/ceph/common.py
+++ b/hotsos/core/plugins/storage/ceph/common.py
@@ -185,6 +185,11 @@ class CephChecks(StorageBase):
         CephInstallInfo().mixin(self)
 
     @property
+    def bad_units(self):
+        """ Passthrough property to allow it to be called from yaml checks. """
+        return self.systemd.bad_units
+
+    @property
     def summary_subkey_include_default_entries(self):
         return True
 

--- a/hotsos/defs/scenarios/kubernetes/ensure_healthy_systemd.yaml
+++ b/hotsos/defs/scenarios/kubernetes/ensure_healthy_systemd.yaml
@@ -1,0 +1,18 @@
+vars:
+  bad_units: '@hotsos.core.plugins.kubernetes.KubernetesChecks.bad_units'
+checks:
+  has_units_with_state_bad:
+    varops: [[$bad_units], [length_hint]]
+conclusions:
+  systemd_unexpected_status:
+    decision: has_units_with_state_bad
+    raises:
+      type: KubernetesError
+      message: >-
+        The host is running one or more Kubernetes systemd unit(s) with state
+        'bad': {units}. This means the unit file is invalid or another error
+        occurred. One common cause is when the unit is pending a restart
+        following a config change. See 'systemctl status <name>' for more
+        information.
+      format-dict:
+        units: '$bad_units:comma_join'

--- a/hotsos/defs/scenarios/openstack/ensure_healthy_systemd.yaml
+++ b/hotsos/defs/scenarios/openstack/ensure_healthy_systemd.yaml
@@ -1,0 +1,18 @@
+vars:
+  bad_units: '@hotsos.core.plugins.openstack.OpenstackBase.bad_units'
+checks:
+  has_units_with_state_bad:
+    varops: [[$bad_units], [length_hint]]
+conclusions:
+  systemd_unexpected_status:
+    decision: has_units_with_state_bad
+    raises:
+      type: OpenStackError
+      message: >-
+        The host is running one or more OpenStack systemd unit(s) with state
+        'bad': {units}. This means the unit file is invalid or another error
+        occurred. One common cause is when the unit is pending a restart
+        following a config change. See 'systemctl status <name>' for more
+        information.
+      format-dict:
+        units: '$bad_units:comma_join'

--- a/hotsos/defs/scenarios/storage/ceph/common/ensure_healthy_systemd.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/common/ensure_healthy_systemd.yaml
@@ -1,0 +1,18 @@
+vars:
+  bad_units: '@hotsos.core.plugins.storage.ceph.CephChecks.bad_units'
+checks:
+  has_units_with_state_bad:
+    varops: [[$bad_units], [length_hint]]
+conclusions:
+  systemd_unexpected_status:
+    decision: has_units_with_state_bad
+    raises:
+      type: CephError
+      message: >-
+        The host is running one or more Ceph systemd unit(s) with state
+        'bad': {units}. This means the unit file is invalid or another error
+        occurred. One common cause is when the unit is pending a restart
+        following a config change. See 'systemctl status <name>' for more
+        information.
+      format-dict:
+        units: '$bad_units:comma_join'

--- a/hotsos/defs/tests/scenarios/kubernetes/ensure_healthy_systemd.yaml
+++ b/hotsos/defs/tests/scenarios/kubernetes/ensure_healthy_systemd.yaml
@@ -1,0 +1,25 @@
+data-root:
+  files:
+    sos_commands/systemd/systemctl_list-unit-files: |
+      UNIT FILE                                     STATE           VENDOR PRESET
+      containerd.service                            bad             enabled
+      snap-kube\x2dapiserver-4152.mount             enabled         enabled
+      snap-kube\x2dcontroller\x2dmanager-3960.mount enabled         enabled
+      snap-kube\x2dproxy-3849.mount                 enabled         enabled
+      snap-kube\x2dscheduler-3821.mount             enabled         enabled
+      snap-kubectl-3746.mount                       enabled         enabled
+      snap-kubelet-3759.mount                       enabled         enabled
+      snap.kube-apiserver.daemon.service            bad             enabled
+      snap.kube-controller-manager.daemon.service   enabled         enabled
+      snap.kube-proxy.daemon.service                enabled         enabled
+      snap.kube-scheduler.daemon.service            enabled         enabled
+      snap.kubelet.daemon.service                   enabled         enabled
+  copy-from-original:
+    - sos_commands/systemd/systemctl_list-units
+raised-issues:
+  KubernetesError: >-
+    The host is running one or more Kubernetes systemd unit(s) with state
+    'bad': containerd, snap.kube-apiserver.daemon. This means the unit file is
+    invalid or another error occurred. One common cause is when the unit is
+    pending a restart following a config change. See 'systemctl status <name>'
+    for more information.

--- a/hotsos/defs/tests/scenarios/openstack/ensure_healthy_systemd.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/ensure_healthy_systemd.yaml
@@ -1,0 +1,15 @@
+data-root:
+  files:
+    sos_commands/systemd/systemctl_list-unit-files: |
+      UNIT FILE                              STATE           VENDOR PRESET
+      nova-compute.service                   bad         enabled
+  copy-from-original:
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/dpkg/dpkg_-l
+raised-issues:
+  OpenStackError: >-
+    The host is running one or more OpenStack systemd unit(s) with state
+    'bad': nova-compute. This means the unit file is invalid or another error
+    occurred. One common cause is when the unit is pending a restart
+    following a config change. See 'systemctl status <name>' for more
+    information.

--- a/hotsos/defs/tests/scenarios/storage/ceph/common/ensure_healthy_systemd.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/common/ensure_healthy_systemd.yaml
@@ -1,0 +1,17 @@
+data-root:
+  files:
+    sos_commands/systemd/systemctl_list-unit-files: |
+      UNIT FILE                              STATE           VENDOR PRESET
+      ceph-mon.service                       disabled        enabled
+      ceph-mon@.service                      bad             enabled
+      ceph-mon.target                        enabled         enabled
+  copy-from-original:
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/dpkg/dpkg_-l
+raised-issues:
+  CephError: >-
+    The host is running one or more Ceph systemd unit(s) with state
+    'bad': ceph-mon. This means the unit file is invalid or another error
+    occurred. One common cause is when the unit is pending a restart
+    following a config change. See 'systemctl status <name>' for more
+    information.


### PR DESCRIPTION
Adds check for OpenStack, Kubernetes and Ceph plugins to raise an error if any units are in state "bad".