### PR TITLE
Move smartctl warning to scenario

### DIFF
--- a/hotsos/core/issues/issue_types.py
+++ b/hotsos/core/issues/issue_types.py
@@ -203,6 +203,10 @@ class SSSDWarning(IssueTypeBase):
     """ Issue for SSSD warnings. """
 
 
+class SmartCtlWarning(IssueTypeBase):
+    """ smartctl warnings. """
+
+
 class UbuntuCVE(CVETypeBase):
     """ Ubuntu CVE bug type """
     @property

--- a/hotsos/core/plugins/storage/smartctl.py
+++ b/hotsos/core/plugins/storage/smartctl.py
@@ -1,4 +1,7 @@
 import os
+import re
+from collections import OrderedDict
+from functools import cached_property
 
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers import APTPackageHelper
@@ -8,6 +11,7 @@ from hotsos.core.plugins.storage import StorageBase
 
 class SmartctlChecks(StorageBase):
     """Base class for smartctl storage checks."""
+
     @classmethod
     def is_runnable(cls):
         """
@@ -30,3 +34,93 @@ class SmartctlChecks(StorageBase):
 
         log.debug("No smartctl data found")
         return False
+
+    @cached_property
+    def abnormal_disks(self):
+        """ Summarize disk health from smartctl output. """
+
+        results = {}
+        for directory in ['nvme', 'ata']:
+            smartctl_dir = os.path.join(
+                HotSOSConfig.data_root,
+                'sos_commands',
+                directory,
+            )
+            results.update(self._search_sosreport(smartctl_dir))
+
+        if not results:
+            log.debug('No smartctl output found in sosreport')
+            return None
+
+        # Strong indicators of problems that require immediate attention
+        failure_counters = [
+            'Current_Pending_Sector',
+            'Offline_Uncorrectable',
+        ]
+
+        # Informational counters that may indicate issues but require
+        # further analysis for proper interpretation
+        info_counters = [
+            'Reallocated_Sector_Ct',
+            'UDMA_CRC_Error_Count',
+            'Spin_Retry_Count',
+            'End-to-End_Error',
+            'Command_Timeout',
+        ]
+
+        abnormal_disks = {}
+        for path, content in results.items():
+            # Check overall health status
+            disk_issues = ({'health_status': 'FAILED'} if re.search(
+                r'SMART overall-health self-assessment test result: FAILED',
+                content
+            ) else {})
+
+            # Match SMART attribute lines format:
+            # ID# ATTRIBUTE_NAME FLAG VALUE WORST THRESH TYPE UPDATED
+            # WHEN_FAILED RAW_VALUE
+            failure_issues = {}
+            info_issues = {}
+
+            for counter in failure_counters:
+                pattern = rf'^\s*\d+\s+{re.escape(counter)}\b.*?(\d+)\s*$'
+                match = re.search(pattern, content, re.MULTILINE)
+                if match and int(match.group(1)) > 0:
+                    failure_issues[counter] = int(match.group(1))
+
+            for counter in info_counters:
+                pattern = rf'^\s*\d+\s+{re.escape(counter)}\b.*?(\d+)\s*$'
+                match = re.search(pattern, content, re.MULTILINE)
+                if match and int(match.group(1)) > 0:
+                    info_issues[counter] = int(match.group(1))
+
+            disk_issues.update({
+                key: value for key, value in {
+                    'failure_counters': failure_issues,
+                    'info_counters': info_issues,
+                }.items() if value
+            })
+
+            # Only report disk if there are issues
+            if disk_issues:
+                abnormal_disks[path] = disk_issues
+
+        return abnormal_disks
+
+    @staticmethod
+    def _search_sosreport(directory):
+        """
+        Search for and read all smartctl output files in the given directory.
+        """
+        results = OrderedDict()
+        if not os.path.isdir(directory):
+            return results
+        for fname in sorted(os.listdir(directory)):
+            fpath = os.path.join(directory, fname)
+            if os.path.isfile(fpath):
+                try:
+                    with open(fpath, encoding='utf-8', errors='ignore') as f:
+                        results[os.path.basename(fpath)] = f.read()
+                except OSError as exc:
+                    log.debug('Failed to read %s: %s', fpath, exc)
+        return results

--- a/hotsos/defs/scenarios/storage/smartctl/unhealthy_disks.yaml
+++ b/hotsos/defs/scenarios/storage/smartctl/unhealthy_disks.yaml
@@ -1,0 +1,16 @@
+vars:
+  abnormal_disks: '@hotsos.core.plugins.storage.smartctl.SmartctlChecks.abnormal_disks'
+
+checks:
+  abnormal_disks:
+    varops: [[$abnormal_disks], [length_hint]]
+
+conclusions:
+  abnormal_disks:
+    decision: abnormal_disks
+    raises:
+      type: SmartCtlWarning
+      message: >-
+        Smartctl is reporting unhealthy disks: {disks}
+      format-dict:
+        disks: '$abnormal_disks'

--- a/hotsos/defs/tests/scenarios/storage/smartctl/unhealthy_disks.yaml
+++ b/hotsos/defs/tests/scenarios/storage/smartctl/unhealthy_disks.yaml
@@ -1,0 +1,13 @@
+data-root:
+  files:
+    sos_commands/ata/smartctl_-a_sda: |
+      SMART overall-health self-assessment test result: FAILED
+    sos_commands/ata/smartctl_-a_sdb: |
+      SMART overall-health self-assessment test result: FAILED
+  copy-from-original:
+    - sos_commands/date/date
+    - uptime
+raised-issues:
+  SmartCtlWarning: >-
+    Smartctl is reporting unhealthy disks:
+    {'smartctl_-a_sda': {'health_status': 'FAILED'}, 'smartctl_-a_sdb': {'health_status': 'FAILED'}}

--- a/hotsos/plugin_extensions/storage/smartctl_summary.py
+++ b/hotsos/plugin_extensions/storage/smartctl_summary.py
@@ -1,10 +1,4 @@
 """ Plugin for analyzing disk health using smartctl output. """
-
-import re
-import os
-
-from hotsos.core.config import HotSOSConfig
-from hotsos.core.log import log
 from hotsos.core.plugins.storage.smartctl import SmartctlChecks
 from hotsos.core.plugintools import get_min_available_entry_index
 from hotsos.core.plugintools import summary_entry
@@ -14,102 +8,10 @@ class SmartctlSummary(SmartctlChecks):
     """Analyze disk health using smartctl output."""
     summary_part_index = 3
 
-    @summary_entry('disk_health', index=get_min_available_entry_index())
-    def disk_health(self):
-        """ Summarize disk health from smartctl output. """
+    @summary_entry('smartctl', index=get_min_available_entry_index())
+    def smartctl_summary(self):
+        summary = {}
+        if self.abnormal_disks:
+            summary['unhealthy-disks'] = self.abnormal_disks
 
-        results = {}
-        for directory in ['nvme', 'ata']:
-            smartctl_dir = os.path.join(
-                HotSOSConfig.data_root,
-                'sos_commands',
-                directory,
-            )
-            results.update(self._search_sosreport(smartctl_dir))
-
-        if not results:
-            log.debug('No smartctl output found in sosreport')
-            return None
-
-        # Strong indicators of problems that require immediate attention
-        failure_counters = [
-            'Current_Pending_Sector',
-            'Offline_Uncorrectable',
-        ]
-
-        # Informational counters that may indicate issues but require
-        # further analysis for proper interpretation
-        info_counters = [
-            'Reallocated_Sector_Ct',
-            'UDMA_CRC_Error_Count',
-            'Spin_Retry_Count',
-            'End-to-End_Error',
-            'Command_Timeout',
-        ]
-
-        abnormal_disks = {}
-        for path, content in results.items():
-            # Check overall health status
-            disk_issues = ({'health_status': 'FAILED'} if re.search(
-                r'SMART overall-health self-assessment test result: FAILED',
-                content
-            ) else {})
-
-            # Match SMART attribute lines format:
-            # ID# ATTRIBUTE_NAME FLAG VALUE WORST THRESH TYPE UPDATED
-            # WHEN_FAILED RAW_VALUE
-            failure_issues = {}
-            info_issues = {}
-
-            for counter in failure_counters:
-                pattern = rf'^\s*\d+\s+{re.escape(counter)}\b.*?(\d+)\s*$'
-                match = re.search(pattern, content, re.MULTILINE)
-                if match and int(match.group(1)) > 0:
-                    failure_issues[counter] = int(match.group(1))
-
-            for counter in info_counters:
-                pattern = rf'^\s*\d+\s+{re.escape(counter)}\b.*?(\d+)\s*$'
-                match = re.search(pattern, content, re.MULTILINE)
-                if match and int(match.group(1)) > 0:
-                    info_issues[counter] = int(match.group(1))
-
-            disk_issues.update({
-                key: value for key, value in {
-                    'failure_counters': failure_issues,
-                    'info_counters': info_issues,
-                }.items() if value
-            })
-
-            # Only report disk if there are issues
-            if disk_issues:
-                abnormal_disks[path] = disk_issues
-
-        if abnormal_disks:
-            return {
-                'abnormal_disks': abnormal_disks,
-                'message': ('Some disks reported SMART health failures or '
-                            'abnormal error counters.'),
-            }
-
-        return {
-            'message': ('No SMART health failures or abnormal error counters '
-                        'detected.'),
-        }
-
-    @staticmethod
-    def _search_sosreport(directory):
-        """
-        Search for and read all smartctl output files in the given directory.
-        """
-        results = {}
-        if not os.path.isdir(directory):
-            return results
-        for fname in os.listdir(directory):
-            fpath = os.path.join(directory, fname)
-            if os.path.isfile(fpath):
-                try:
-                    with open(fpath, encoding='utf-8', errors='ignore') as f:
-                        results[fpath] = f.read()
-                except OSError as exc:
-                    log.debug('Failed to read %s: %s', fpath, exc)
-        return results
+        return summary

--- a/tests/unit/storage/test_smartctl.py
+++ b/tests/unit/storage/test_smartctl.py
@@ -4,7 +4,14 @@ from hotsos.plugin_extensions.storage.smartctl_summary import SmartctlSummary
 from .. import utils
 
 
-class TestSmartctlSummary(utils.BaseTestCase):
+class SmartctlTestsBase(utils.BaseTestCase):
+    """ Custom test case that sets the storage plugin context. """
+    def setUp(self):
+        super().setUp()
+        HotSOSConfig.plugin_name = 'storage'
+
+
+class TestSmartctlSummary(SmartctlTestsBase):
     """Unit tests for SmartctlSummary plugin."""
     def setUp(self):
         super().setUp()
@@ -14,8 +21,8 @@ class TestSmartctlSummary(utils.BaseTestCase):
     def test_no_smartctl_output(self):
         # pylint: disable=protected-access
         self.plugin._search_sosreport = lambda directory: {}
-        result = self.plugin.disk_health()
-        self.assertIsNone(result)
+        result = self.plugin.smartctl_summary()
+        self.assertEqual(result, {})
 
     def test_failed_disk(self):
         fake_content = {
@@ -28,25 +35,17 @@ class TestSmartctlSummary(utils.BaseTestCase):
         }
         # pylint: disable=protected-access
         self.plugin._search_sosreport = lambda directory: fake_content
-        result = self.plugin.disk_health()
-        self.assertIn('abnormal_disks', result)
+        result = self.plugin.smartctl_summary()
+        self.assertIn('unhealthy-disks', result)
         self.assertIn(
             'sos_commands/ata/smartctl_-a_sda',
-            result['abnormal_disks']
+            result['unhealthy-disks']
         )
         self.assertEqual(
-            result['abnormal_disks']['sos_commands/ata/smartctl_-a_sda'][
+            result['unhealthy-disks']['sos_commands/ata/smartctl_-a_sda'][
                 'health_status'
             ],
             'FAILED'
-        )
-        self.assertIn('message', result)
-        self.assertEqual(
-            result['message'],
-            (
-                'Some disks reported SMART health failures or abnormal error '
-                'counters.'
-            )
         )
 
     def test_failed_and_abnormal_counters(self):
@@ -63,9 +62,9 @@ class TestSmartctlSummary(utils.BaseTestCase):
         }
         # pylint: disable=protected-access
         self.plugin._search_sosreport = lambda directory: fake_content
-        result = self.plugin.disk_health()
-        self.assertIn('abnormal_disks', result)
-        disk = result['abnormal_disks'][
+        result = self.plugin.smartctl_summary()
+        self.assertIn('unhealthy-disks', result)
+        disk = result['unhealthy-disks'][
             'sos_commands/ata/smartctl_-a_sda'
         ]
         self.assertEqual(disk['health_status'], 'FAILED')
@@ -73,14 +72,6 @@ class TestSmartctlSummary(utils.BaseTestCase):
         self.assertEqual(disk['failure_counters']['Current_Pending_Sector'], 2)
         # Reallocated_Sector_Ct is an info counter
         self.assertEqual(disk['info_counters']['Reallocated_Sector_Ct'], 3)
-        self.assertIn('message', result)
-        self.assertEqual(
-            result['message'],
-            (
-                'Some disks reported SMART health failures or abnormal error '
-                'counters.'
-            )
-        )
 
     def test_zero_error_counters(self):
         fake_content = {
@@ -96,16 +87,8 @@ class TestSmartctlSummary(utils.BaseTestCase):
         }
         # pylint: disable=protected-access
         self.plugin._search_sosreport = lambda directory: fake_content
-        result = self.plugin.disk_health()
-        self.assertNotIn('abnormal_disks', result)
-        self.assertIn('message', result)
-        self.assertEqual(
-            result['message'],
-            (
-                'No SMART health failures or abnormal error counters '
-                'detected.'
-            )
-        )
+        result = self.plugin.smartctl_summary()
+        self.assertNotIn('unhealthy-disks', result)
 
     def test_abnormal_error_counters(self):
         fake_content = {
@@ -120,23 +103,15 @@ class TestSmartctlSummary(utils.BaseTestCase):
         }
         # pylint: disable=protected-access
         self.plugin._search_sosreport = lambda directory: fake_content
-        result = self.plugin.disk_health()
-        self.assertIn('abnormal_disks', result)
-        disk = result['abnormal_disks'][
+        result = self.plugin.smartctl_summary()
+        self.assertIn('unhealthy-disks', result)
+        disk = result['unhealthy-disks'][
             'sos_commands/ata/smartctl_-a_sda'
         ]
         # Reallocated_Sector_Ct is an info counter
         self.assertEqual(disk['info_counters']['Reallocated_Sector_Ct'], 2)
         # Current_Pending_Sector is a failure counter
         self.assertEqual(disk['failure_counters']['Current_Pending_Sector'], 1)
-        self.assertIn('message', result)
-        self.assertEqual(
-            result['message'],
-            (
-                'Some disks reported SMART health failures or abnormal error '
-                'counters.'
-            )
-        )
 
     def test_all_disks_passed(self):
         fake_content = {
@@ -146,12 +121,16 @@ class TestSmartctlSummary(utils.BaseTestCase):
         }
         # pylint: disable=protected-access
         self.plugin._search_sosreport = lambda directory: fake_content
-        result = self.plugin.disk_health()
-        self.assertIn('message', result)
-        self.assertEqual(
-            result['message'],
-            (
-                'No SMART health failures or abnormal error counters '
-                'detected.'
-            )
-        )
+        result = self.plugin.smartctl_summary()
+        self.assertEqual(result, {})
+
+
+@utils.load_templated_tests('scenarios/storage/smartctl')
+class TestSmartCtlScenarios(SmartctlTestsBase):
+    """
+    Scenario tests can be written using YAML templates that are auto-loaded
+    into this test runner. This is the recommended way to write tests for
+    scenarios. It is however still possible to write the tests in Python if
+    required. See https://hotsos.readthedocs.io/en/latest/contrib/testing.html
+    for more information.
+    """


### PR DESCRIPTION
Adds a scenario to raise a warning when unhealthy disks are reported by smartcl. Also make output none if nothing to report.