### PR TITLE
Use CLIHelper for smartctl

### DIFF
--- a/hotsos/core/plugins/storage/smartctl.py
+++ b/hotsos/core/plugins/storage/smartctl.py
@@ -1,10 +1,9 @@
 import os
 import re
-from collections import OrderedDict
 from functools import cached_property
 
 from hotsos.core.config import HotSOSConfig
-from hotsos.core.host_helpers import APTPackageHelper
+from hotsos.core.host_helpers import CLIHelper, APTPackageHelper
 from hotsos.core.log import log
 from hotsos.core.plugins.storage import StorageBase
 
@@ -35,18 +34,34 @@ class SmartctlChecks(StorageBase):
         log.debug("No smartctl data found")
         return False
 
+    @staticmethod
+    def get_system_disks():
+        """
+        Get physical disks available in this host. Ignores virtual devices e.g.
+        loop devices.
+
+        @return: list of devices
+        """
+        devs = []
+        out = CLIHelper().ls_lanR_sys_block()
+        for line in out:
+            if re.search(r'\s->\s\.\./devices/virtual', line):
+                continue
+
+            ret = re.search(r'\s(\S+)\s->', line)
+            if ret:
+                devs.append(ret.group(1))
+
+        return devs
+
     @cached_property
     def abnormal_disks(self):
         """ Summarize disk health from smartctl output. """
-
         results = {}
-        for directory in ['nvme', 'ata']:
-            smartctl_dir = os.path.join(
-                HotSOSConfig.data_root,
-                'sos_commands',
-                directory,
-            )
-            results.update(self._search_sosreport(smartctl_dir))
+        for dev in self.get_system_disks():
+            out = CLIHelper().smartctl_all(device=dev)
+            if out:
+                results[dev] = '\n'.join([line.strip() for line in out])
 
         if not results:
             log.debug('No smartctl output found in sosreport')
@@ -69,7 +84,7 @@ class SmartctlChecks(StorageBase):
         ]
 
         abnormal_disks = {}
-        for path, content in results.items():
+        for dev, content in results.items():
             # Check overall health status
             disk_issues = ({'health_status': 'FAILED'} if re.search(
                 r'SMART overall-health self-assessment test result: FAILED',
@@ -103,24 +118,6 @@ class SmartctlChecks(StorageBase):
 
             # Only report disk if there are issues
             if disk_issues:
-                abnormal_disks[path] = disk_issues
+                abnormal_disks[dev] = disk_issues
 
         return abnormal_disks
-
-    @staticmethod
-    def _search_sosreport(directory):
-        """
-        Search for and read all smartctl output files in the given directory.
-        """
-        results = OrderedDict()
-        if not os.path.isdir(directory):
-            return results
-        for fname in sorted(os.listdir(directory)):
-            fpath = os.path.join(directory, fname)
-            if os.path.isfile(fpath):
-                try:
-                    with open(fpath, encoding='utf-8', errors='ignore') as f:
-                        results[os.path.basename(fpath)] = f.read()
-                except OSError as exc:
-                    log.debug('Failed to read %s: %s', fpath, exc)
-        return results

--- a/hotsos/defs/tests/scenarios/storage/smartctl/unhealthy_disks.yaml
+++ b/hotsos/defs/tests/scenarios/storage/smartctl/unhealthy_disks.yaml
@@ -1,13 +1,14 @@
 data-root:
   files:
-    sos_commands/ata/smartctl_-a_sda: |
+    sos_commands/ata/smartctl_-a_vda: |
       SMART overall-health self-assessment test result: FAILED
-    sos_commands/ata/smartctl_-a_sdb: |
+    sos_commands/ata/smartctl_-a_vdb: |
       SMART overall-health self-assessment test result: FAILED
   copy-from-original:
     - sos_commands/date/date
     - uptime
+    - sos_commands/block/ls_-lanR_.sys.block
 raised-issues:
   SmartCtlWarning: >-
     Smartctl is reporting unhealthy disks:
-    {'smartctl_-a_sda': {'health_status': 'FAILED'}, 'smartctl_-a_sdb': {'health_status': 'FAILED'}}
+    {'vda': {'health_status': 'FAILED'}, 'vdb': {'health_status': 'FAILED'}}

--- a/tests/unit/storage/test_smartctl.py
+++ b/tests/unit/storage/test_smartctl.py
@@ -4,6 +4,27 @@ from hotsos.plugin_extensions.storage.smartctl_summary import SmartctlSummary
 from .. import utils
 
 
+SMARTCTL_OUT1 = """
+SMART overall-health self-assessment test result: PASSED
+ID# ATTRIBUTE_NAME FLAG VALUE WORST THRESH TYPE UPDATED WHEN_FAILED RAW_VALUE
+  5 Reallocated_Sector_Ct 0x0033 100 100 036 Pre-fail Always - 0
+197 Current_Pending_Sector 0x0012 100 100 000 Old_age Always - 0
+"""  # noqa
+
+SMARTCTL_OUT2 = """
+SMART overall-health self-assessment test result: FAILED
+ID# ATTRIBUTE_NAME FLAG VALUE WORST THRESH TYPE UPDATED WHEN_FAILED RAW_VALUE
+  5 Reallocated_Sector_Ct 0x0033 100 100 036 Pre-fail Always - 3
+197 Current_Pending_Sector 0x0012 100 100 000 Old_age Always - 2
+"""  # noqa
+
+SMARTCTL_OUT3 = """
+ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE UPDATED  WHEN_FAILED RAW_VALUE
+  5 Reallocated_Sector_Ct   0x0033   100   100   036 Pre-fail Always - 2
+197 Current_Pending_Sector  0x0012   100   100   000 Old_age Always - 1
+"""  # noqa
+
+
 class SmartctlTestsBase(utils.BaseTestCase):
     """ Custom test case that sets the storage plugin context. """
     def setUp(self):
@@ -24,103 +45,62 @@ class TestSmartctlSummary(SmartctlTestsBase):
         result = self.plugin.smartctl_summary()
         self.assertEqual(result, {})
 
+    @utils.create_data_root({'sos_commands/ata/smartctl_-a_vda':
+                             ('SMART overall-health self-assessment test '
+                              'result: FAILED'),
+                             'sos_commands/ata/smartctl_-a_vdb':
+                             ('SMART overall-health self-assessment test '
+                              'result: PASSED')},
+                            copy_from_original=[
+                                'sos_commands/block/ls_-lanR_.sys.block'])
     def test_failed_disk(self):
-        fake_content = {
-            'sos_commands/ata/smartctl_-a_sda': (
-                'SMART overall-health self-assessment test result: FAILED'
-            ),
-            'sos_commands/ata/smartctl_-a_sdb': (
-                'SMART overall-health self-assessment test result: PASSED'
-            ),
-        }
-        # pylint: disable=protected-access
-        self.plugin._search_sosreport = lambda directory: fake_content
         result = self.plugin.smartctl_summary()
         self.assertIn('unhealthy-disks', result)
-        self.assertIn(
-            'sos_commands/ata/smartctl_-a_sda',
-            result['unhealthy-disks']
-        )
-        self.assertEqual(
-            result['unhealthy-disks']['sos_commands/ata/smartctl_-a_sda'][
-                'health_status'
-            ],
-            'FAILED'
-        )
+        self.assertIn('vda', result['unhealthy-disks'])
+        self.assertEqual(result['unhealthy-disks']['vda']['health_status'],
+                         'FAILED')
 
+    @utils.create_data_root({'sos_commands/ata/smartctl_-a_vda':
+                             SMARTCTL_OUT2},
+                            copy_from_original=[
+                                'sos_commands/block/ls_-lanR_.sys.block'])
     def test_failed_and_abnormal_counters(self):
-        fake_content = {
-            'sos_commands/ata/smartctl_-a_sda': (
-                'SMART overall-health self-assessment test result: FAILED\n'
-                'ID# ATTRIBUTE_NAME FLAG VALUE WORST THRESH TYPE UPDATED '
-                'WHEN_FAILED RAW_VALUE\n'
-                '  5 Reallocated_Sector_Ct 0x0033 100 100 036 Pre-fail '
-                'Always - 3\n'
-                '197 Current_Pending_Sector 0x0012 100 100 000 Old_age '
-                'Always - 2\n'
-            ),
-        }
-        # pylint: disable=protected-access
-        self.plugin._search_sosreport = lambda directory: fake_content
         result = self.plugin.smartctl_summary()
         self.assertIn('unhealthy-disks', result)
-        disk = result['unhealthy-disks'][
-            'sos_commands/ata/smartctl_-a_sda'
-        ]
+        disk = result['unhealthy-disks']['vda']
         self.assertEqual(disk['health_status'], 'FAILED')
         # Current_Pending_Sector is a failure counter
         self.assertEqual(disk['failure_counters']['Current_Pending_Sector'], 2)
         # Reallocated_Sector_Ct is an info counter
         self.assertEqual(disk['info_counters']['Reallocated_Sector_Ct'], 3)
 
+    @utils.create_data_root({'sos_commands/ata/smartctl_-a_vda':
+                             SMARTCTL_OUT1},
+                            copy_from_original=[
+                                'sos_commands/block/ls_-lanR_.sys.block'])
     def test_zero_error_counters(self):
-        fake_content = {
-            'sos_commands/ata/smartctl_-a_sda': (
-                'SMART overall-health self-assessment test result: PASSED\n'
-                'ID# ATTRIBUTE_NAME FLAG VALUE WORST THRESH TYPE UPDATED '
-                'WHEN_FAILED RAW_VALUE\n'
-                '  5 Reallocated_Sector_Ct 0x0033 100 100 036 Pre-fail '
-                'Always - 0\n'
-                '197 Current_Pending_Sector 0x0012 100 100 000 Old_age '
-                'Always - 0\n'
-            ),
-        }
-        # pylint: disable=protected-access
-        self.plugin._search_sosreport = lambda directory: fake_content
         result = self.plugin.smartctl_summary()
         self.assertNotIn('unhealthy-disks', result)
 
+    @utils.create_data_root({'sos_commands/ata/smartctl_-a_vda':
+                             SMARTCTL_OUT3},
+                            copy_from_original=[
+                                'sos_commands/block/ls_-lanR_.sys.block'])
     def test_abnormal_error_counters(self):
-        fake_content = {
-            'sos_commands/ata/smartctl_-a_sda': (
-                'ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE '
-                'UPDATED  WHEN_FAILED RAW_VALUE\n'
-                '  5 Reallocated_Sector_Ct   0x0033   100   100   036    '
-                'Pre-fail  Always       -       2\n'
-                '197 Current_Pending_Sector  0x0012   100   100   000    '
-                'Old_age   Always       -       1\n'
-            ),
-        }
-        # pylint: disable=protected-access
-        self.plugin._search_sosreport = lambda directory: fake_content
         result = self.plugin.smartctl_summary()
         self.assertIn('unhealthy-disks', result)
-        disk = result['unhealthy-disks'][
-            'sos_commands/ata/smartctl_-a_sda'
-        ]
+        disk = result['unhealthy-disks']['vda']
         # Reallocated_Sector_Ct is an info counter
         self.assertEqual(disk['info_counters']['Reallocated_Sector_Ct'], 2)
         # Current_Pending_Sector is a failure counter
         self.assertEqual(disk['failure_counters']['Current_Pending_Sector'], 1)
 
+    @utils.create_data_root({'sos_commands/ata/smartctl_-a_vda':
+                             ('SMART overall-health self-assessment test '
+                              'result: PASSED')},
+                            copy_from_original=[
+                                'sos_commands/block/ls_-lanR_.sys.block'])
     def test_all_disks_passed(self):
-        fake_content = {
-            'sos_commands/ata/smartctl_-a_sda': (
-                'SMART overall-health self-assessment test result: PASSED'
-            ),
-        }
-        # pylint: disable=protected-access
-        self.plugin._search_sosreport = lambda directory: fake_content
         result = self.plugin.smartctl_summary()
         self.assertEqual(result, {})
 


### PR DESCRIPTION
Current implementation was only looking at sosreport output. Now uses the CLIHelper which will look at system first then sos depending on data_root and availability.