### PR TITLE
[ceph] improve 'overlapping root' detection

### DIFF
--- a/hotsos/core/host_helpers/cli/catalog.py
+++ b/hotsos/core/host_helpers/cli/catalog.py
@@ -67,6 +67,8 @@ class CommandCatalog(UserDict):
             'ceph_osd_df_tree_json_decoded': ceph.CepOSDDFTreeCommands(),
             'ceph_osd_crush_dump_json_decoded':
                 ceph.CephOSDCrushDumpCommands(),
+            'ceph_osd_crush_tree_json_decoded':
+                ceph.CephOSDCrushTreeCommands(),
             'ceph_pg_dump_json_decoded': ceph.CephPGDumpCommands(),
             'ceph_status_json_decoded': ceph.CephStatusCommands(),
             'ceph_versions': ceph.CephVersionsCommands(),

--- a/hotsos/core/host_helpers/cli/commands/ceph.py
+++ b/hotsos/core/host_helpers/cli/commands/ceph.py
@@ -196,6 +196,29 @@ class CephOSDCrushDumpCommands(UserList):
         super().__init__(cmds)
 
 
+class CephOSDCrushTreeCommands(UserList):
+    """ Generate ceph osd crush tree --show-shadow command variants. """
+
+    def __init__(self):
+        prefixes = [""] + CEPH_ALIASES
+        # binary
+        cmds = [CephJSONBinCmd(f'{prefix}ceph osd crush tree --show-shadow '
+                               '--format json-pretty')
+                for prefix in prefixes]
+        # file-based
+        # sosreport < 4.2
+        cmds.append(CephJSONFileCmd(
+            'sos_commands/ceph/json_output/'
+            'ceph_osd_crush_tree_--show-shadow_--format_json-pretty'))
+        # sosreport >= 4.2
+        cmds.extend([CephJSONFileCmd(
+            'sos_commands/ceph_mon/json_output/'
+            f'{prefix}ceph_osd_crush_tree_--show-shadow_'
+            '--format_json-pretty')
+            for prefix in prefixes])
+        super().__init__(cmds)
+
+
 class CephPGDumpCommands(UserList):
     """ Generate ceph pg dump command variants. """
 

--- a/hotsos/core/plugins/storage/ceph/cluster.py
+++ b/hotsos/core/plugins/storage/ceph/cluster.py
@@ -195,6 +195,21 @@ class CephCrushMap():
 
         return None
 
+    @staticmethod
+    def collect_osd_classes(node_id, nodes):
+        """Recursively collect device classes of all OSDs under a node."""
+        node = nodes.get(node_id)
+        if node is None:
+            return set()
+        if node.get('type') == 'osd':
+            dc = node.get('device_class')
+            return {dc} if dc else set()
+        classes = set()
+        for child_id in node.get('children', []):
+            classes.update(
+                CephCrushMap.collect_osd_classes(child_id, nodes))
+        return classes
+
     @cached_property
     def crush_tree_has_overlapping_roots(self):
         """
@@ -209,26 +224,13 @@ class CephCrushMap():
 
         nodes = {n['id']: n for n in crush_tree.get('nodes', [])}
 
-        def collect_osd_classes(node_id):
-            """Recursively collect device classes of all OSDs under a node."""
-            node = nodes.get(node_id)
-            if node is None:
-                return set()
-            if node.get('type') == 'osd':
-                dc = node.get('device_class')
-                return {dc} if dc else set()
-            classes = set()
-            for child_id in node.get('children', []):
-                classes.update(collect_osd_classes(child_id))
-            return classes
-
         for node in crush_tree.get('nodes', []):
             if node.get('type') != 'root':
                 continue
             # Skip shadow roots (their names contain '~')
             if '~' in node.get('name', ''):
                 continue
-            classes = collect_osd_classes(node['id'])
+            classes = self.collect_osd_classes(node['id'], nodes)
             if len(classes) > 1:
                 return True
 

--- a/hotsos/core/plugins/storage/ceph/cluster.py
+++ b/hotsos/core/plugins/storage/ceph/cluster.py
@@ -196,6 +196,45 @@ class CephCrushMap():
         return None
 
     @cached_property
+    def crush_tree_has_overlapping_roots(self):
+        """
+        Detect overlapping roots from ceph osd crush tree --show-shadow.
+
+        A non-shadow root has overlapping roots when it contains OSDs from
+        multiple device classes.
+        """
+        crush_tree = CLIHelper().ceph_osd_crush_tree_json_decoded()
+        if not crush_tree:
+            return False
+
+        nodes = {n['id']: n for n in crush_tree.get('nodes', [])}
+
+        def collect_osd_classes(node_id):
+            """Recursively collect device classes of all OSDs under a node."""
+            node = nodes.get(node_id)
+            if node is None:
+                return set()
+            if node.get('type') == 'osd':
+                dc = node.get('device_class')
+                return {dc} if dc else set()
+            classes = set()
+            for child_id in node.get('children', []):
+                classes.update(collect_osd_classes(child_id))
+            return classes
+
+        for node in crush_tree.get('nodes', []):
+            if node.get('type') != 'root':
+                continue
+            # Skip shadow roots (their names contain '~')
+            if '~' in node.get('name', ''):
+                continue
+            classes = collect_osd_classes(node['id'])
+            if len(classes) > 1:
+                return True
+
+        return False
+
+    @cached_property
     def autoscaler_enabled_pools(self):
         if not self.ceph_report:
             return []

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots.yaml
@@ -1,3 +1,11 @@
+vars:
+  overlap_common_msg: >-
+    This will prevent PG autoscaler from scaling those pools. This happens
+    when a pool uses a crush rule that doesn't distinguish between OSD
+    device classes. Any pool using that crush rule would use OSDs from
+    multiple device classes. Identify those pools
+    (ceph osd crush tree --show-shadow) and change their crush rule to
+    use only one of the device classes.
 checks:
   overlapping_roots:
     input: 'storage.ceph:ceph-mgr*.log'
@@ -5,17 +13,26 @@ checks:
       - '.* pool (\w+) scale due to overlapping roots:.*'
       - '.* pool (\w+) has overlapping roots: .*'
       - '.* pool (\w+) contains an overlapping root .*'
+  overlapping_roots_crush_tree:
+    property: hotsos.core.plugins.storage.ceph.CephCrushMap.crush_tree_has_overlapping_roots
 conclusions:
-  overlapping-roots:
+  overlapping-roots-from-crush-tree:
+    priority: 1
+    decision: overlapping_roots_crush_tree
+    raises:
+      type: CephMgrError
+      message: >-
+        Overlapping CRUSH roots detected via ceph osd crush tree
+        --show-shadow. {common}
+      format-dict:
+        common: $overlap_common_msg
+  overlapping-roots-with-pools:
+    priority: 2
     decision: overlapping_roots
     raises:
       type: CephMgrError
       message: >-
-        PG autoscaler found overlapping roots for pools: {pools}. As a result,
-        PG autoscaler won't scale those pools. This happens when a pool uses
-        a crush rule that doesn't distinguish between OSD device classes.
-        Any pool using that crush rule would use OSDs from multiple device
-        classes. Identify those pools (ceph osd crush tree --show-shadow)
-        and change their crush rule to use only one of the device classes.
+        PG autoscaler found overlapping roots for pools: {pools}. {common}
       format-dict:
         pools: "@checks.overlapping_roots.search.results_group_1:unique_comma_join"
+        common: $overlap_common_msg

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots.yaml
@@ -9,10 +9,11 @@ data-root:
     - sos_commands/systemd/systemctl_list-unit-files
 raised-issues:
   CephMgrError: >-
-    PG autoscaler found overlapping roots for pools: 14, 4. As a
-    result, PG autoscaler won't scale those pools. This happens
-    when a pool uses a crush rule that doesn't distinguish
-    between OSD device classes. Any pool using that crush rule
-    would use OSDs from multiple device classes. Identify those
-    pools (ceph osd crush tree --show-shadow) and change their
-    crush rule to use only one of the device classes.
+    PG autoscaler found overlapping roots for pools: 14, 4.
+    This will prevent PG autoscaler from scaling those pools.
+    This happens when a pool uses a crush rule that doesn't
+    distinguish between OSD device classes. Any pool using that
+    crush rule would use OSDs from multiple device classes.
+    Identify those pools (ceph osd crush tree --show-shadow)
+    and change their crush rule to use only one of the device
+    classes.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots_crush_tree.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots_crush_tree.yaml
@@ -1,0 +1,35 @@
+target-name: autoscaler_overlap_roots.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/json_output/ceph_osd_crush_tree_--show-shadow_--format_json-pretty: |
+      {
+        "nodes": [
+          {"id": -5, "name": "default~nvme", "type": "root", "type_id": 11, "children": [-4]},
+          {"id": -4, "name": "storage-001~nvme", "type": "host", "type_id": 1, "children": [3]},
+          {"id": 3, "name": "osd.3", "type": "osd", "type_id": 0, "device_class": "nvme"},
+          {"id": -3, "name": "default~hdd", "type": "root", "type_id": 11, "children": [-2]},
+          {"id": -2, "name": "storage-001~hdd", "type": "host", "type_id": 1, "children": [1, 2]},
+          {"id": 1, "name": "osd.1", "type": "osd", "type_id": 0, "device_class": "hdd"},
+          {"id": 2, "name": "osd.2", "type": "osd", "type_id": 0, "device_class": "hdd"},
+          {"id": -1, "name": "default", "type": "root", "type_id": 11, "children": [-6]},
+          {"id": -6, "name": "storage-001", "type": "host", "type_id": 1, "children": [1, 2, 3]},
+          {"id": 1, "name": "osd.1", "type": "osd", "type_id": 0, "device_class": "hdd"},
+          {"id": 2, "name": "osd.2", "type": "osd", "type_id": 0, "device_class": "hdd"},
+          {"id": 3, "name": "osd.3", "type": "osd", "type_id": 0, "device_class": "nvme"}
+        ],
+        "stray": []
+      }
+  copy-from-original:
+    - sos_commands/date/date
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+raised-issues:
+  CephMgrError: >-
+    Overlapping CRUSH roots detected via ceph osd crush tree
+    --show-shadow. This will prevent PG autoscaler from scaling
+    those pools. This happens when a pool uses a crush rule that
+    doesn't distinguish between OSD device classes. Any pool
+    using that crush rule would use OSDs from multiple device
+    classes. Identify those pools (ceph osd crush tree
+    --show-shadow) and change their crush rule to use only one
+    of the device classes.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots_microceph.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mgr/autoscaler_overlap_roots_microceph.yaml
@@ -10,10 +10,11 @@ data-root:
     - sos_commands/systemd/systemctl_list-unit-files
 raised-issues:
   CephMgrError: >-
-    PG autoscaler found overlapping roots for pools: 14, 4. As a
-    result, PG autoscaler won't scale those pools. This happens
-    when a pool uses a crush rule that doesn't distinguish
-    between OSD device classes. Any pool using that crush rule
-    would use OSDs from multiple device classes. Identify those
-    pools (ceph osd crush tree --show-shadow) and change their
-    crush rule to use only one of the device classes.
+    PG autoscaler found overlapping roots for pools: 14, 4.
+    This will prevent PG autoscaler from scaling those pools.
+    This happens when a pool uses a crush rule that doesn't
+    distinguish between OSD device classes. Any pool using that
+    crush rule would use OSDs from multiple device classes.
+    Identify those pools (ceph osd crush tree --show-shadow)
+    and change their crush rule to use only one of the device
+    classes.

--- a/tests/unit/host_helpers/test_cli.py
+++ b/tests/unit/host_helpers/test_cli.py
@@ -329,6 +329,7 @@ class TestCommandAffinity(utils.BaseTestCase):
                         'ceph_status_json_decoded',
                         'ceph_daemon_osd_dump_mempools',
                         'ceph_osd_crush_dump_json_decoded',
+                        'ceph_osd_crush_tree_json_decoded',
                         'ceph_versions',
                         'ceph_mon_dump_json_decoded',
                         'ceph_osd_dump_json_decoded',


### PR DESCRIPTION
The ceph-mgr log may not always contain the relevant errors or may have been rotated out. crush tree provides the more accurate view of the 'overlapping roots' issue as one or more OSDs being part of different trees can be seen directly.

Fixes #SET-2289.