### PR TITLE
fix: correct occured typo in unpack log message

### DIFF
--- a/hotsos/core/root_manager.py
+++ b/hotsos/core/root_manager.py
@@ -85,7 +85,7 @@ class DataRootManager():
                     # We really do want to catch all here since we don't care
                     # why it failed but don't want to fail hard if it does.
                     except Exception:  # pylint: disable=W0718
-                        log.exception("error occured while unpacking "
+                        log.exception("error occurred while unpacking "
                                       "sosreport:")
                         # some members might fail to extract e.g. permission
                         # denied but we dont want that to cause the whole run


### PR DESCRIPTION
Fixes "error occured" -> "error occurred" in the sosreport unpack failure log message in `hotsos/core/root_manager.py`.