### PR TITLE
Update pypi publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@
 name: Python package
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -29,11 +30,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install build
           python -m build
-      - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'push' && github.ref_name == 'main' && matrix.python-version == '3.8'
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Upload Python package as CI artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,0 +1,36 @@
+# This is a templated file and must be kept up-to-date with the original
+# from upstream at https://github.com/canonical/se-tooling-ci-common.
+name: Publish to pypi.org
+
+on:
+  workflow_run:
+    workflows: [Python Package]
+    types:
+      - completed
+
+jobs:
+  build:
+    # Include the build workflow.
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iduses
+    uses: ./.github/workflows/build.yaml
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Get package build
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Prepare build artifact
+        run: |
+            ls -R dist
+            mv dist/*/*.whl dist/
+
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.14.0
+        if: github.event_name == 'push' && github.ref_name == 'main' && matrix.python-version == '3.8'
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
  * splits publish from build
  * use se-tooling-ci-common template
  * upgrade to pypa/gh-action-pypi-publish/releases/tag/v1.14.0
  * constrain push event to main branch