### PR TITLE
[cpu] Issue a warning if cpu scaling governor isn't enabled in BIOS

### DIFF
--- a/examples/hotsos-example-openstack.short.summary.yaml
+++ b/examples/hotsos-example-openstack.short.summary.yaml
@@ -4,6 +4,15 @@ potential-issues:
       - Unattended upgrades are enabled which can lead to uncontrolled changes to
         this environment. If maintenance windows are required please consider disabling
         unattended upgrades.
+  openstack:
+    OpenstackWarnings:
+      - This node is used as an Openstack hypervisor but is not using cpufreq scaling_governor
+        in "performance" mode (actual=unknown). The cpufreq scaling governor could
+        not be determined which typically means frequency scaling is disabled in the
+        BIOS. Please check that the BIOS power management is set to "OS Control" or
+        equivalent and reboot. If already set correctly, install cpufrequtils, set
+        "GOVERNOR=performance" in /etc/default/cpufrequtils and run systemctl restart
+        cpufrequtils.
 bugs-detected:
   openstack:
     https://bugs.launchpad.net/bugs/2029952: This host is running neutron agents that

--- a/examples/hotsos-example-openstack.summary.yaml
+++ b/examples/hotsos-example-openstack.summary.yaml
@@ -295,3 +295,12 @@ openstack:
       a malicious QCOW2 image with an external data file allows an authenticated user
       to read arbitrary files from the host. There is a fix available in the Ubuntu
       archives and upgrading is recommended.
+  potential-issues:
+    OpenstackWarnings:
+      - This node is used as an Openstack hypervisor but is not using cpufreq scaling_governor
+        in "performance" mode (actual=unknown). The cpufreq scaling governor could
+        not be determined which typically means frequency scaling is disabled in the
+        BIOS. Please check that the BIOS power management is set to "OS Control" or
+        equivalent and reboot. If already set correctly, install cpufrequtils, set
+        "GOVERNOR=performance" in /etc/default/cpufrequtils and run systemctl restart
+        cpufrequtils.

--- a/hotsos/defs/scenarios/kubernetes/system_cpufreq_mode.yaml
+++ b/hotsos/defs/scenarios/kubernetes/system_cpufreq_mode.yaml
@@ -9,6 +9,12 @@ vars:
   message_ondemand: >-
     You will also need to stop and disable the ondemand systemd service in
     order for changes to persist.
+  message_unknown: >-
+    The cpufreq scaling governor could not be determined which typically means
+    frequency scaling is disabled in the BIOS. Please check that the BIOS
+    power management is set to "OS Control" or equivalent and reboot. If
+    already set correctly, install cpufrequtils, set "GOVERNOR=performance"
+    in /etc/default/cpufrequtils and run systemctl restart cpufrequtils.
   scaling_governor: '@hotsos.core.plugins.kernel.sysfs.CPU.cpufreq_scaling_governor_all'
 checks:
   cpufreq_governor_not_performance:
@@ -16,6 +22,8 @@ checks:
     - varops: [[$scaling_governor], [ne, unknown]]
     # does it have the expected value
     - varops: [[$scaling_governor], [ne, performance]]
+  cpufreq_governor_unknown:
+    varops: [[$scaling_governor], [eq, unknown]]
   kubernetes_installed_metal:
     # ignore if not running on metal
     - property:
@@ -25,6 +33,19 @@ checks:
     systemd:
       ondemand: enabled
 conclusions:
+  cpufreq-unknown:
+    priority: 3
+    decision:
+      - cpufreq_governor_unknown
+      - kubernetes_installed_metal
+    raises:
+      type: KubernetesWarning
+      message: >-
+        {msg_pt1} (actual={governor}). {msg_unknown}
+      format-dict:
+        msg_pt1: $message_pt1
+        msg_unknown: $message_unknown
+        governor: $scaling_governor
   cpufreq-not-performance:
     priority: 1
     decision:

--- a/hotsos/defs/scenarios/openstack/system_cpufreq_mode.yaml
+++ b/hotsos/defs/scenarios/openstack/system_cpufreq_mode.yaml
@@ -12,6 +12,12 @@ vars:
   msg_ondemand: >-
     You will also need to stop and disable the ondemand systemd service in
     order for changes to persist.
+  message_unknown: >-
+    The cpufreq scaling governor could not be determined which typically means
+    frequency scaling is disabled in the BIOS. Please check that the BIOS
+    power management is set to "OS Control" or equivalent and reboot. If
+    already set correctly, install cpufrequtils, set "GOVERNOR=performance"
+    in /etc/default/cpufrequtils and run systemctl restart cpufrequtils.
   scaling_governor: '@hotsos.core.plugins.kernel.sysfs.CPU.cpufreq_scaling_governor_all'
 checks:
   cpufreq_governor_not_performance:
@@ -19,6 +25,8 @@ checks:
     - varops: [[$scaling_governor], [ne, unknown]]
     # does it have the expected value
     - varops: [[$scaling_governor], [ne, performance]]
+  cpufreq_governor_unknown:
+    varops: [[$scaling_governor], [eq, unknown]]
   is_neutron_gateway:
     # i.e. neutron-l3-agent but no nova == neutron gateway
     - not:
@@ -30,6 +38,32 @@ checks:
     systemd:
       ondemand: enabled
 conclusions:
+  cpufreq-unknown-n-cpu:
+    priority: 3
+    decision:
+      - cpufreq_governor_unknown
+      - is_nova_compute
+    raises:
+      type: OpenstackWarning
+      message: >-
+        {msg_pt1} (actual={governor}). {msg_unknown}
+      format-dict:
+        msg_pt1: $message_pt1_nova_compute
+        msg_unknown: $message_unknown
+        governor: $scaling_governor
+  cpufreq-unknown-n-gw:
+    priority: 3
+    decision:
+      - cpufreq_governor_unknown
+      - is_neutron_gateway
+    raises:
+      type: OpenstackWarning
+      message: >-
+        {msg_pt1} (actual={governor}). {msg_unknown}
+      format-dict:
+        msg_pt1: $message_pt1_neutron_gateway
+        msg_unknown: $message_unknown
+        governor: $scaling_governor
   cpufreq-not-performance-n-cpu:
     priority: 1
     decision:

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/system_cpufreq_mode.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/system_cpufreq_mode.yaml
@@ -9,6 +9,12 @@ vars:
   message_ondemand: >-
     You will also need to stop and disable the ondemand systemd service in
     order for changes to persist.
+  message_unknown: >-
+    The cpufreq scaling governor could not be determined which typically means
+    frequency scaling is disabled in the BIOS. Please check that the BIOS
+    power management is set to "OS Control" or equivalent and reboot. If
+    already set correctly, install cpufrequtils, set "GOVERNOR=performance"
+    in /etc/default/cpufrequtils and run systemctl restart cpufrequtils.
   scaling_governor: '@hotsos.core.plugins.kernel.sysfs.CPU.cpufreq_scaling_governor_all'
 checks:
   cpufreq_governor_not_performance:
@@ -16,10 +22,23 @@ checks:
     - varops: [[$scaling_governor], [ne, unknown]]
     # does it have the expected value
     - varops: [[$scaling_governor], [ne, performance]]
+  cpufreq_governor_unknown:
+    varops: [[$scaling_governor], [eq, unknown]]
   ondemand_installed_and_enabled:
     systemd:
       ondemand: enabled
 conclusions:
+  cpufreq-unknown:
+    priority: 3
+    decision: cpufreq_governor_unknown
+    raises:
+      type: CephWarning
+      message: >-
+        {msg_pt1} (actual={governor}). {msg_unknown}
+      format-dict:
+        msg_pt1: $message_pt1
+        msg_unknown: $message_unknown
+        governor: $scaling_governor
   cpufreq-not-performance:
     priority: 1
     decision: cpufreq_governor_not_performance

--- a/hotsos/defs/tests/scenarios/kubernetes/system_cpufreq_mode_unknown.yaml
+++ b/hotsos/defs/tests/scenarios/kubernetes/system_cpufreq_mode_unknown.yaml
@@ -1,0 +1,29 @@
+target-name: system_cpufreq_mode.yaml
+data-root:
+  files:
+    sos_commands/snap/snap_list_--all: |
+      Name                     Version    Rev    Tracking       Publisher   Notes
+      kubelet                  1.2.3      123    latest/stable  canonical   core
+  copy-from-original:
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+mock:
+  patch:
+    hotsos.core.plugins.kernel.sysfs.CPU.cpufreq_scaling_governor_all:
+      kwargs:
+        new: unknown
+    hotsos.core.plugins.system.system.SystemBase.virtualisation_type:
+      kwargs:
+        new: null
+    hotsos.core.plugins.kubernetes.KubernetesChecks.is_runnable:
+      kwargs:
+        new: true
+raised-issues:
+  KubernetesWarning: >-
+    This node is used for Kubernetes but is not using cpufreq scaling_governor
+    in "performance" mode (actual=unknown). The cpufreq scaling governor
+    could not be determined which typically means frequency scaling is
+    disabled in the BIOS. Please check that the BIOS power management is set
+    to "OS Control" or equivalent and reboot. If already set correctly,
+    install cpufrequtils, set "GOVERNOR=performance" in
+    /etc/default/cpufrequtils and run systemctl restart cpufrequtils.

--- a/hotsos/defs/tests/scenarios/openstack/system_cpufreq_mode_unknown.yaml
+++ b/hotsos/defs/tests/scenarios/openstack/system_cpufreq_mode_unknown.yaml
@@ -1,0 +1,16 @@
+target-name: system_cpufreq_mode.yaml
+mock:
+  patch:
+    hotsos.core.plugins.kernel.sysfs.CPU.cpufreq_scaling_governor_all:
+      kwargs:
+        new: unknown
+raised-issues:
+  OpenstackWarning: >-
+    This node is used as an Openstack hypervisor but is not using
+    cpufreq scaling_governor in "performance" mode (actual=unknown).
+    The cpufreq scaling governor could not be determined which
+    typically means frequency scaling is disabled in the BIOS.
+    Please check that the BIOS power management is set to "OS
+    Control" or equivalent and reboot. If already set correctly,
+    install cpufrequtils, set "GOVERNOR=performance" in
+    /etc/default/cpufrequtils and run systemctl restart cpufrequtils.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-osd/system_cpufreq_mode_unknown.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-osd/system_cpufreq_mode_unknown.yaml
@@ -1,0 +1,16 @@
+target-name: system_cpufreq_mode.yaml
+mock:
+  patch:
+    hotsos.core.plugins.kernel.sysfs.CPU.cpufreq_scaling_governor_all:
+      kwargs:
+        new: unknown
+raised-issues:
+  CephWarning: >-
+    This node has Ceph OSDs running on it but is not using cpufreq
+    scaling_governor in "performance" mode (actual=unknown). The
+    cpufreq scaling governor could not be determined which typically
+    means frequency scaling is disabled in the BIOS. Please check
+    that the BIOS power management is set to "OS Control" or
+    equivalent and reboot. If already set correctly, install
+    cpufrequtils, set "GOVERNOR=performance" in
+    /etc/default/cpufrequtils and run systemctl restart cpufrequtils.


### PR DESCRIPTION
Fixes #458.

Fixes #SET-2208.