### PR TITLE
Detect manual pg-upmap items that break the crush failure domain

### DIFF
--- a/hotsos/core/plugins/storage/ceph/cluster.py
+++ b/hotsos/core/plugins/storage/ceph/cluster.py
@@ -705,3 +705,163 @@ class CephCluster():  # pylint: disable=too-many-public-methods
                     f"'{device_class}' ({min_tb} TiB - {max_tb} TiB)")
 
         return results
+
+    @staticmethod
+    def _rule_root_and_failure_domain(rule):
+        """Extract the (root_item_id, failure_domain_type) from a crush rule.
+
+        A rule selects a starting bucket with a 'take' step then chooses
+        leaves at a bucket type (the failure domain) with a 'choose' step.
+        Returns None if the rule has no such pair of steps.
+        """
+        root = None
+        for step in rule.get('steps', []):
+            op = step.get('op', '')
+            if op == 'take':
+                root = step.get('item')
+            elif 'choose' in op and 'type' in step and root is not None:
+                return (root, step['type'])
+
+        return None
+
+    @staticmethod
+    def _map_osds_to_failure_domain(root_id, fd_type, buckets_by_id):
+        """Map each OSD under a crush tree to its failure domain bucket.
+
+        Walks the subtree rooted at root_id (the tree selected by a rule's
+        'take' step) returning {osd_id: fd_bucket_id} where fd_bucket_id is
+        the ancestor bucket of type fd_type. Restricting the walk to the
+        rule's root means shadow trees (e.g. 'default~ssd') that share the
+        same OSDs do not interfere.
+        """
+        mapping = {}
+        # (node_id, enclosing failure-domain bucket id or None)
+        stack = [(root_id, None)]
+        while stack:
+            node_id, fd_bucket = stack.pop()
+            bucket = buckets_by_id.get(node_id)
+            if bucket is None:
+                continue
+            cur_fd = node_id if bucket['type_name'] == fd_type else fd_bucket
+            for item in bucket.get('items', []):
+                iid = item['id']
+                if iid < 0:
+                    stack.append((iid, cur_fd))
+                # OSD leaf - only meaningful inside a failure-domain bucket.
+                elif cur_fd is not None:
+                    mapping[iid] = cur_fd
+
+        return mapping
+
+    def _manual_upmap_placements(self, osd_dump, upmap_pgids):
+        """Return {pgid: [osd, ...]} placement for each manually-upmapped PG.
+
+        'ceph osd dump' carries the full override OSD list for pg_upmap
+        entries; for pg_upmap_items (pairwise from->to) we use the resulting
+        up set which is authoritative in 'ceph pg dump'.
+        """
+        placements = {e['pgid']: list(e.get('osds', []))
+                      for e in osd_dump.get('pg_upmap', [])}
+        if self.pg_dump:
+            for pg in self.pg_dump['pg_map']['pg_stats']:
+                if pg['pgid'] in upmap_pgids:
+                    placements[pg['pgid']] = pg.get('up', [])
+
+        return placements
+
+    @staticmethod
+    def _failure_domain_collisions(osds, osd_fd, buckets_by_id):
+        """Return {bucket_name: [osds]} for failure domains holding >1 OSD."""
+        buckets_seen = {}
+        for osd_id in osds:
+            fd_bucket = osd_fd.get(osd_id)
+            if fd_bucket is None:
+                continue
+            buckets_seen.setdefault(fd_bucket, []).append(osd_id)
+
+        return {buckets_by_id[fd_bucket]['name']: sorted(ids)
+                for fd_bucket, ids in buckets_seen.items() if len(ids) > 1}
+
+    @cached_property
+    def manual_upmaps_disrespecting_failure_domain(self):
+        """Detect manual pg-upmap placements that break the failure domain.
+
+        Operators can use 'ceph osd pg-upmap' or 'ceph osd pg-upmap-items' to
+        override where a PG is placed. Because these overrides bypass the
+        crush rule, they can put two or more shards/replicas of a PG into the
+        same failure domain (e.g. two OSDs on the same host when the rule
+        requires host-level separation). This silently defeats the
+        redundancy guarantee and can lead to data loss if that domain fails.
+
+        Returns a dict keyed by pgid with the offending failure domain type
+        and the buckets that hold more than one OSD of the PG, e.g.
+
+            {'3.326': {'failure_domain': 'host',
+                       'shared': {'compute4': [6, 18]}}}
+        """
+        osd_dump = self._osd_dump
+        crush_dump = self.crush_map.osd_crush_dump
+        if not osd_dump or not crush_dump:
+            return {}
+
+        # PGs that have a manual upmap of either kind.
+        upmap_pgids = {e['pgid'] for e in osd_dump.get('pg_upmap', [])}
+        upmap_pgids |= {e['pgid'] for e in osd_dump.get('pg_upmap_items', [])}
+        if not upmap_pgids:
+            return {}
+
+        buckets_by_id = {b['id']: b for b in crush_dump.get('buckets', [])}
+        rules_by_id = {r['rule_id']: r for r in crush_dump.get('rules', [])}
+        pool_rule = {p['pool']: p['crush_rule']
+                     for p in osd_dump.get('pools', [])}
+        placements = self._manual_upmap_placements(osd_dump, upmap_pgids)
+
+        # Cache osd->failure-domain maps keyed by (root, fd_type).
+        fd_cache = {}
+        violations = {}
+        for pgid in sorted(upmap_pgids):
+            osds = placements.get(pgid)
+            info = self._pg_rule_failure_domain(pgid, pool_rule, rules_by_id)
+            if not osds or info is None:
+                continue
+
+            if info not in fd_cache:
+                fd_cache[info] = self._map_osds_to_failure_domain(
+                    info[0], info[1], buckets_by_id)
+
+            shared = self._failure_domain_collisions(
+                osds, fd_cache[info], buckets_by_id)
+            if shared:
+                violations[pgid] = {'failure_domain': info[1],
+                                    'shared': shared}
+
+        return violations
+
+    def _pg_rule_failure_domain(self, pgid, pool_rule, rules_by_id):
+        """Return (root_id, failure_domain_type) for the PG's crush rule."""
+        try:
+            pool_id = int(pgid.split('.')[0])
+        except (ValueError, IndexError):
+            return None
+
+        rule = rules_by_id.get(pool_rule.get(pool_id))
+        if rule is None:
+            return None
+
+        return self._rule_root_and_failure_domain(rule)
+
+    @cached_property
+    def manual_upmaps_disrespecting_failure_domain_str(self):
+        """Human-readable summary of failure-domain-breaking pg-upmaps."""
+        violations = self.manual_upmaps_disrespecting_failure_domain
+        if not violations:
+            return None
+
+        parts = []
+        for pgid, info in violations.items():
+            groups = ', '.join(f"{bucket}={ids}"
+                               for bucket, ids in info['shared'].items())
+            parts.append(f"{pgid} (failure domain '{info['failure_domain']}'"
+                         f": {groups})")
+
+        return '; '.join(parts)

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/manual_upmap_failure_domain.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/manual_upmap_failure_domain.yaml
@@ -1,0 +1,22 @@
+checks:
+  upmaps_disrespect_failure_domain:
+    property:
+      path: hotsos.core.plugins.storage.ceph.CephCluster.manual_upmaps_disrespecting_failure_domain
+      ops: [[length_hint], [gt, 0]]
+conclusions:
+  manual-upmaps-disrespect-failure-domain:
+    decision: upmaps_disrespect_failure_domain
+    raises:
+      type: CephCrushWarning
+      message: >-
+        Found manually-set pg-upmap placement(s) that do not honour the crush
+        rule's failure domain: {upmaps}. Commands such as
+        'ceph osd pg-upmap <pgid> <osd> ...' or 'ceph osd pg-upmap-items'
+        override a PG's placement and can put more than one OSD of the PG in
+        the same failure domain (e.g. two OSDs on the same host). This defeats
+        the redundancy the crush rule is meant to provide and can lead to data
+        loss if that domain fails. Review these mappings and remove them with
+        'ceph osd rm-pg-upmap[-items] <pgid>' so that placement follows the
+        crush rule, or let the balancer manage upmaps.
+      format-dict:
+        upmaps: hotsos.core.plugins.storage.ceph.CephCluster.manual_upmaps_disrespecting_failure_domain_str

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/manual_upmap_failure_domain.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/manual_upmap_failure_domain.yaml
@@ -1,0 +1,23 @@
+mock:
+  patch:
+    hotsos.core.plugins.storage.ceph.CephCluster.manual_upmaps_disrespecting_failure_domain:
+      kwargs:
+        new:
+          '3.326':
+            failure_domain: host
+            shared:
+              compute4: [6, 18]
+    hotsos.core.plugins.storage.ceph.CephCluster.manual_upmaps_disrespecting_failure_domain_str:
+      kwargs:
+        new: "3.326 (failure domain 'host': compute4=[6, 18])"
+raised-issues:
+  CephCrushWarning: >-
+    Found manually-set pg-upmap placement(s) that do not honour the crush
+    rule's failure domain: 3.326 (failure domain 'host': compute4=[6, 18]).
+    Commands such as 'ceph osd pg-upmap <pgid> <osd> ...' or
+    'ceph osd pg-upmap-items' override a PG's placement and can put more than
+    one OSD of the PG in the same failure domain (e.g. two OSDs on the same
+    host). This defeats the redundancy the crush rule is meant to provide and
+    can lead to data loss if that domain fails. Review these mappings and
+    remove them with 'ceph osd rm-pg-upmap[-items] <pgid>' so that placement
+    follows the crush rule, or let the balancer manage upmaps.

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -407,6 +407,86 @@ class TestCoreCephCluster(  # pylint: disable=too-many-public-methods
         cluster = ceph.CephCluster()
         self.assertEqual(cluster.mixed_size_osd_device_classes, [])
 
+    # root 'default' -> host0 (osd 0,1), host1 (osd 2), host2 (osd 3)
+    UPMAP_CRUSH_DUMP = {
+        "buckets": [
+            {"id": -1, "name": "default", "type_id": 11, "type_name": "root",
+             "items": [{"id": -3, "weight": 1}, {"id": -5, "weight": 1},
+                       {"id": -7, "weight": 1}]},
+            {"id": -3, "name": "host0", "type_id": 1, "type_name": "host",
+             "items": [{"id": 0, "weight": 1}, {"id": 1, "weight": 1}]},
+            {"id": -5, "name": "host1", "type_id": 1, "type_name": "host",
+             "items": [{"id": 2, "weight": 1}]},
+            {"id": -7, "name": "host2", "type_id": 1, "type_name": "host",
+             "items": [{"id": 3, "weight": 1}]},
+        ],
+        "rules": [{"rule_id": 0, "rule_name": "replicated_rule", "steps": [
+            {"op": "take", "item": -1, "item_name": "default"},
+            {"op": "chooseleaf_firstn", "num": 0, "type": "host"},
+            {"op": "emit"}]}],
+    }
+
+    def test_manual_upmaps_disrespecting_failure_domain(self):
+        # pg 3.326 fully overridden onto osds 0 and 1 (both on host0) plus
+        # osd 2 - this violates the host failure domain. pg 3.10 uses
+        # pg-upmap-items, resulting up set [0, 1, 3] (0 and 1 on host0).
+        osd_dump = {
+            "pools": [{"pool": 3, "pool_name": "cinder", "crush_rule": 0}],
+            "pg_upmap": [{"pgid": "3.326", "osds": [0, 1, 2]}],
+            "pg_upmap_items": [{"pgid": "3.10",
+                                "mappings": [{"from": 2, "to": 1}]}],
+        }
+        pg_dump = {"pg_map": {"pg_stats": [
+            {"pgid": "3.326", "up": [0, 1, 2]},
+            {"pgid": "3.10", "up": [0, 1, 3]},
+        ]}}
+
+        cluster = ceph.CephCluster()
+        with mock.patch.object(type(cluster.crush_map), 'osd_crush_dump',
+                               new=self.UPMAP_CRUSH_DUMP), \
+                mock.patch.object(ceph.CephCluster, '_osd_dump',
+                                  new=osd_dump), \
+                mock.patch.object(ceph.CephCluster, 'pg_dump', new=pg_dump):
+            result = cluster.manual_upmaps_disrespecting_failure_domain
+            self.assertEqual(result, {
+                '3.10': {'failure_domain': 'host',
+                         'shared': {'host0': [0, 1]}},
+                '3.326': {'failure_domain': 'host',
+                          'shared': {'host0': [0, 1]}},
+            })
+            self.assertEqual(
+                cluster.manual_upmaps_disrespecting_failure_domain_str,
+                "3.10 (failure domain 'host': host0=[0, 1]); "
+                "3.326 (failure domain 'host': host0=[0, 1])")
+
+    def test_manual_upmaps_respecting_failure_domain(self):
+        # pg 3.326 overridden onto osds on three distinct hosts - no
+        # violation.
+        osd_dump = {
+            "pools": [{"pool": 3, "pool_name": "cinder", "crush_rule": 0}],
+            "pg_upmap": [{"pgid": "3.326", "osds": [0, 2, 3]}],
+            "pg_upmap_items": [],
+        }
+        pg_dump = {"pg_map": {"pg_stats": [
+            {"pgid": "3.326", "up": [0, 2, 3]},
+        ]}}
+
+        cluster = ceph.CephCluster()
+        with mock.patch.object(type(cluster.crush_map), 'osd_crush_dump',
+                               new=self.UPMAP_CRUSH_DUMP), \
+                mock.patch.object(ceph.CephCluster, '_osd_dump',
+                                  new=osd_dump), \
+                mock.patch.object(ceph.CephCluster, 'pg_dump', new=pg_dump):
+            self.assertEqual(
+                cluster.manual_upmaps_disrespecting_failure_domain, {})
+            self.assertIsNone(
+                cluster.manual_upmaps_disrespecting_failure_domain_str)
+
+    def test_manual_upmaps_no_upmaps(self):
+        cluster = ceph.CephCluster()
+        self.assertEqual(
+            cluster.manual_upmaps_disrespecting_failure_domain, {})
+
     def test_mgr_modules(self):
         cluster = ceph.CephCluster()
         expected = ['balancer',


### PR DESCRIPTION
## Problem

Operators can run commands such as `ceph osd pg-upmap 3.326 6 18 74 100` or `ceph osd pg-upmap-items ...` to fully override a PG's placement. Because these overrides bypass the crush rule, they can place two or more OSDs of a PG into the **same failure domain** (e.g. two OSDs on the same host when the rule requires host-level separation). This silently defeats the redundancy the crush rule is meant to provide and can lead to data loss if that domain fails.

## Change

Add a `CephCluster.manual_upmaps_disrespecting_failure_domain` property that, for every PG carrying a manual upmap (`pg_upmap` full override or `pg_upmap_items` pairwise):

1. Resolves the PG's pool → crush rule → failure domain type (the `type` of the rule's `choose`/`chooseleaf` step) and root tree (the `take` step).
2. Maps each OSD to its failure-domain bucket by walking only the rule's subtree, so shadow trees (e.g. `default~ssd`) that share OSDs do not interfere.
3. Reads the PG's actual placement — the override `osds` list from `ceph osd dump` for full overrides, and the authoritative resulting `up` set from `ceph pg dump` for pairwise items.
4. Flags the PG if any failure-domain bucket holds more than one of its OSDs.

A new `ceph-mon` scenario raises a `CephCrushWarning` listing the offending PGs and buckets, with guidance to remove the mappings via `ceph osd rm-pg-upmap[-items]`.

## Tests

- Unit tests covering a full-override violation, a `pg-upmap-items` violation (via the resulting `up` set), a valid placement across distinct hosts, and the no-upmaps case.
- Scenario test stub validating the raised warning.

All new tests pass; `flake8`, `yamllint` and `pylint` (10.00/10) are clean on the changed files.