### PR TITLE
ceph: compute PG/OSD warning threshold from cluster config

### DIFF
--- a/hotsos/core/plugins/storage/ceph/cluster.py
+++ b/hotsos/core/plugins/storage/ceph/cluster.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from functools import cached_property
 
@@ -15,6 +16,8 @@ from hotsos.core.plugins.storage.ceph.daemon import (
     CephOSD,
 )
 from hotsos.core.utils import sorted_dict
+
+log = logging.getLogger()
 
 CEPH_POOL_TYPE = {1: 'replicated', 3: 'erasure-coded'}
 
@@ -277,7 +280,11 @@ class CephCluster():  # pylint: disable=too-many-public-methods
           nature this is going to have a large number of public methods.
     """
     OSD_META_LIMIT_PERCENT = 5
-    OSD_PG_MAX_LIMIT = 500
+    # Ceph defaults for PG overdose protection
+    MON_MAX_PG_PER_OSD_DEFAULT = 250
+    OSD_MAX_PG_PER_OSD_HARD_RATIO_DEFAULT = 3.0
+    # Fraction of the hard limit at which we warn
+    OSD_PG_MAX_LIMIT_FRACTION = 2.0 / 3.0
     # min cluster utilisation required to trigger this warning
     OSD_PG_OPTIMAL_MIN_UTIL = 10
     OSD_PG_OPTIMAL_NUM_MAX = 200
@@ -288,6 +295,52 @@ class CephCluster():  # pylint: disable=too-many-public-methods
 
     def __init__(self):
         self.crush_map = CephCrushMap()
+
+    @cached_property
+    def _osd_daemon_config(self):
+        """
+        Try to get daemon config from any local OSD. Returns a dict of config
+        values or empty dict if unavailable.
+        """
+        cli = CLIHelper()
+        for osd in self.osds:
+            config = cli.ceph_daemon_osd_config_show(osd_id=osd.id)
+            if config:
+                return config
+
+        return {}
+
+    @cached_property
+    def osd_pg_max_limit(self):
+        """
+        Compute the PG-per-OSD warning threshold dynamically based on the
+        configured mon_max_pg_per_osd and osd_max_pg_per_osd_hard_ratio.
+
+        The hard limit (at which Ceph refuses to create PGs) is:
+            mon_max_pg_per_osd * osd_max_pg_per_osd_hard_ratio
+
+        We warn at 2/3 of the hard limit to give operators time to act.
+        """
+        config = self._osd_daemon_config
+        try:
+            mon_max = int(config.get('mon_max_pg_per_osd',
+                                     self.MON_MAX_PG_PER_OSD_DEFAULT))
+        except (TypeError, ValueError):
+            mon_max = self.MON_MAX_PG_PER_OSD_DEFAULT
+
+        try:
+            hard_ratio = float(config.get(
+                'osd_max_pg_per_osd_hard_ratio',
+                self.OSD_MAX_PG_PER_OSD_HARD_RATIO_DEFAULT))
+        except (TypeError, ValueError):
+            hard_ratio = self.OSD_MAX_PG_PER_OSD_HARD_RATIO_DEFAULT
+
+        hard_limit = mon_max * hard_ratio
+        limit = int(hard_limit * self.OSD_PG_MAX_LIMIT_FRACTION)
+        log.debug("OSD PG max limit computed as %d (mon_max_pg_per_osd=%d, "
+                  "osd_max_pg_per_osd_hard_ratio=%.2f, hard_limit=%d)",
+                  limit, mon_max, hard_ratio, int(hard_limit))
+        return limit
 
     @cached_property
     def health_status(self):
@@ -734,7 +787,7 @@ class CephCluster():  # pylint: disable=too-many-public-methods
     def osds_pgs_above_max(self):
         _osds_pgs = {}
         for osd, num_pgs in self.osds_pgs.items():
-            if num_pgs > self.OSD_PG_MAX_LIMIT:
+            if num_pgs > self.osd_pg_max_limit:
                 _osds_pgs[osd] = num_pgs
 
         return sorted_dict(_osds_pgs, key=lambda e: e[1], reverse=True)

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/pg_imbalance.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/pg_imbalance.yaml
@@ -24,7 +24,7 @@ conclusions:
         limit at which point they will stop creating pgs and fail - please
         investigate.
       format-dict:
-        limit: hotsos.core.plugins.storage.ceph.CephCluster.OSD_PG_MAX_LIMIT
+        limit: hotsos.core.plugins.storage.ceph.CephCluster.osd_pg_max_limit
   cluster-osds-with-suboptimal-pgs:
     decision:
       - cluster_has_osds_with_suboptimal_pgs

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/pg_imbalance_p3.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/pg_imbalance_p3.yaml
@@ -1,0 +1,42 @@
+target-name: pg_imbalance.yaml
+# Test that when mon_max_pg_per_osd is configured higher than default,
+# the PG warning threshold adapts accordingly and does not produce
+# false positives (see https://github.com/canonical/hotsos/issues/753).
+data-root:
+  files:
+    sos_commands/ceph_mon/json_output/ceph_osd_df_tree_--format_json-pretty: |
+      {"nodes": [{"id": 0, "pgs": 295, "name": "osd.0"},
+                 {"id": 1, "pgs": 501, "name": "osd.1"},
+                 {"id": 2, "pgs": 200, "name": "osd.2"}],
+       "summary": {"average_utilization": 20.00}}
+    sos_commands/ceph_mon/json_output/ceph_osd_dump_--format_json-pretty: |
+      {"epoch": 1, "osds": [
+        {"osd": 0, "uuid": "aaa"},
+        {"osd": 1, "uuid": "bbb"},
+        {"osd": 2, "uuid": "ccc"}]}
+    sos_commands/ceph_osd/ceph_daemon_osd.0_config_show: |
+      {"mon_max_pg_per_osd": "500",
+       "osd_max_pg_per_osd_hard_ratio": "3.000000"}
+  copy-from-original:
+    - sos_commands/date/date
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+mock:
+  patch:
+    hotsos.core.plugins.storage.ceph.CephCrushMap.ceph_report:
+      kwargs:
+        new:
+          osdmap:
+            pools:
+              - pool: 1
+              - pg_autoscale_mode: 'off'
+              - pool: 2
+              - pg_autoscale_mode: 'on'
+    hotsos.core.plugins.storage.ceph.CephCluster.cluster_has_non_empty_pools:
+      kwargs:
+        new: true
+raised-issues:
+  CephCrushWarning: >-
+    Found some Ceph osd(s) whose pg count is > 30% outside the optimal range
+    of 50-200 pgs. This could indicate poor data distribution across the
+    cluster and result in performance degradation.

--- a/tests/unit/storage/test_ceph_mon.py
+++ b/tests/unit/storage/test_ceph_mon.py
@@ -238,8 +238,9 @@ class CephMonTestsBase(utils.BaseTestCase):
                      'osd.1': 501}}
 
 
-class TestCoreCephCluster(CephMonTestsBase):
-    """ Unit tests for ceph cluster code. """
+class TestCoreCephCluster(  # pylint: disable=too-many-public-methods
+        CephMonTestsBase):
+    """Unit tests for ceph cluster code."""
     def test_cluster_mons(self):
         cluster_mons = ceph.CephCluster().mons
         self.assertEqual([ceph.daemon.CephMon],
@@ -281,6 +282,25 @@ class TestCoreCephCluster(CephMonTestsBase):
     def test_cluster_osd_ids(self):
         cluster = ceph.CephCluster()
         self.assertEqual([osd.id for osd in cluster.osds], [0, 1, 2])
+
+    def test_osd_pg_max_limit_default(self):
+        """When no OSD daemon config is available, use default threshold."""
+        cluster = ceph.CephCluster()
+        # Default: 250 * 3.0 * 2/3 = 500
+        self.assertEqual(cluster.osd_pg_max_limit, 500)
+
+    @utils.create_data_root(
+        {'sos_commands/ceph_osd/ceph_daemon_osd.0_config_show':
+         json.dumps({"mon_max_pg_per_osd": "500",
+                     "osd_max_pg_per_osd_hard_ratio": "3.000000"})},
+        copy_from_original=[
+            'sos_commands/ceph_mon/json_output/'
+            'ceph_osd_dump_--format_json-pretty'])
+    def test_osd_pg_max_limit_custom_config(self):
+        """When mon_max_pg_per_osd is configured higher, threshold adapts."""
+        cluster = ceph.CephCluster()
+        # Custom: 500 * 3.0 * 2/3 = 1000
+        self.assertEqual(cluster.osd_pg_max_limit, 1000)
 
     def test_crush_rules(self):
         cluster = ceph.CephCluster()


### PR DESCRIPTION
The CephCrushError warning for OSDs approaching the PG hard limit previously used a hardcoded threshold of 500. This can cause false positives when operators configured mon_max_pg_per_osd and/or osd_max_pg_per_osd_hard_ratio to values above the defaults.

Replace the static OSD_PG_MAX_LIMIT class constant with a cached_property that reads the actual values from `ceph daemon config show` and computes the threshold as 2/3 of the hard limit (mon_max_pg_per_osd * osd_max_pg_per_osd_hard_ratio).

Falls back to upstream defaults when daemon config is unavailable.

Fixes #753.

Fixes #SET-2198.