### PR TITLE
[ceph] report high latencies observed

### DIFF
--- a/hotsos/defs/events/storage/ceph/osd/osdlogs.yaml
+++ b/hotsos/defs/events/storage/ceph/osd/osdlogs.yaml
@@ -3,6 +3,9 @@ input:
   path: ['var/log/ceph/ceph-osd*.log', 'var/snap/microceph/common/logs/ceph-osd*.log']
 slow-requests:
   expr: '([\d-]+)[T ]([\d:]+)\S+ .+ ([0-9]+) slow requests are blocked .+ \(REQUEST_SLOW\)'
+osd-latency:
+  expr: '([\d-]+)[T ]([\d:]+)\S+ .+ log_latency\S* slow operation observed .+'
+  hint: 'slow operation observed'
 crc-err-bluestore:
   expr: '([\d-]+)[T ]([\d:]+)\S+ .+ _verify_csum bad .+'
 crc-err-rocksdb:

--- a/hotsos/plugin_extensions/storage/ceph_event_checks.py
+++ b/hotsos/plugin_extensions/storage/ceph_event_checks.py
@@ -97,6 +97,28 @@ class EventCallbackCRCErrors(CephEventCallbackBase):
         return ret
 
 
+class EventCallbackOSDLatency(CephEventCallbackBase):
+    """ Events callback for Ceph OSD Latency events """
+    event_group = 'ceph'
+    event_names = ['osd-latency']
+
+    def __call__(self, event):
+        c_expr = re.compile(CEPH_ID_FROM_LOG_PATH_EXPR)
+        results = []
+        for r in event.results:
+            ret = c_expr.match(event.searcher.resolve_source_id(r.source_id))
+            if ret:
+                key = f"osd.{ret.group(1)}"
+            else:
+                key = None
+
+            results.append({'date': r.get(1), 'key': key})
+
+        options = self.EventProcessingOptions(squash_if_none_keys=True,
+                                              key_by_date=False)
+        return self.categorise_events(event, results=results, options=options)
+
+
 class EventCallbackHeartbeatPings(CephEventCallbackBase):
     """ Events callback for Ceph Heartbeat events """
     event_group = 'ceph'

--- a/tests/unit/storage/test_ceph_osd.py
+++ b/tests/unit/storage/test_ceph_osd.py
@@ -263,6 +263,33 @@ class TestCephOSDEvents(StorageCephOSDTestsBase):
             for key, value in result.items():
                 self.assertEqual(actual[key], value)
 
+    @utils.create_data_root(
+        {'var/log/ceph/ceph-osd.0.log': (
+            '2022-02-10T16:20:23.226+0000 7fc33ca06700  0 '
+            'bluestore(/var/lib/ceph/osd/ceph-0) log_latency slow operation '
+            'observed for submit_transact, latency = 6.402924154s\n'
+            '2022-02-10T16:20:23.310+0000 7fc34e229700  0 '
+            'bluestore(/var/lib/ceph/osd/ceph-0) log_latency_fn slow '
+            'operation observed for _txc_committed_kv, latency = '
+            '6.485089964s, txc = 0x55d96303af00\n'
+            '2022-02-10T16:20:31.998+0000 7fc33ea0a700  0 '
+            'bluestore(/var/lib/ceph/osd/ceph-0) log_latency slow operation '
+            'observed for submit_transact, latency = 5.894541264s\n')})
+    @mock.patch('hotsos.core.ycheck.engine.YDefsLoader._is_def',
+                new=utils.is_def_filter('osd/osdlogs.yaml',
+                                        'events/storage/ceph'))
+    @mock.patch('hotsos.core.search.CLIHelper')
+    def test_ceph_daemon_osd_latency(self, mock_cli):
+        mock_cli.return_value = mock.MagicMock()
+        mock_cli.return_value.date.return_value = "2021-01-01 00:00:00"
+        result = {'osd-latency': {'osd.0': {'2022-02-10': 3}}}
+
+        with GlobalSearcher() as global_searcher:
+            inst = ceph_event_checks.CephEventHandler(global_searcher)
+            actual = self.part_output_to_actual(inst.output)
+            for key, value in result.items():
+                self.assertEqual(actual[key], value)
+
 
 @utils.load_templated_tests('scenarios/storage/ceph/ceph-osd')
 class TestCephOSDScenarios(StorageCephOSDTestsBase):


### PR DESCRIPTION
Ceph logs if the latency of ops is >=5s. This is almost always an issue, typically caused by high load on OSDs, network issue, dying disk, etc.

Fixes #1007.

Fixes #SET-2412.