### PR TITLE
[ceph] detect and use running versions of OSDs

### DIFF
--- a/hotsos/core/host_helpers/cli/catalog.py
+++ b/hotsos/core/host_helpers/cli/catalog.py
@@ -46,6 +46,17 @@ class CommandCatalog(UserDict):
             'apparmor_status':
                 [BinCmd('apparmor_status'),
                  FileCmd('sos_commands/apparmor/apparmor_status')],
+            'ceph_daemon_osd_version':
+                [BinCmd('ceph daemon osd.{osd_id} version',
+                        json_decode=True),
+                 FileCmd('sos_commands/ceph_osd/'
+                         'ceph_daemon_.var.run.ceph.'
+                         'ceph-osd.{osd_id}.asok_version',
+                         json_decode=True),
+                 FileCmd('sos_commands/ceph_osd/'
+                         'ceph_daemon_.var.snap.microceph.current.run.'
+                         'ceph-osd.{osd_id}.asok_version',
+                         json_decode=True)],
             'ceph_daemon_osd_config_show':
                 [BinCmd('ceph daemon osd.{osd_id} config show',
                         json_decode=True),

--- a/hotsos/core/plugins/storage/ceph/common.py
+++ b/hotsos/core/plugins/storage/ceph/common.py
@@ -532,6 +532,74 @@ class CephDaemonConfigShow():
         return getattr(self.cmd, name)
 
 
+class CephDaemonVersion():
+    """ Interface to ceph daemon osd version command. """
+    def __init__(self, osd_id):
+        self.cmd = CephDaemonCommand('ceph_daemon_osd_version',
+                                     osd_id=osd_id)
+
+    @property
+    def version(self):
+        """
+        Parses the version string from ceph daemon osd version output.
+        The output format is:
+        {"version":"ceph version <ver> (<hash>) <release> (<stability>)"}
+        Returns the version part e.g. "15.2.14".
+        """
+        try:
+            raw = getattr(self.cmd, 'version')
+        except AttributeError:
+            return None
+
+        if raw:
+            match = re.match(r'ceph version (\S+)', raw)
+            if match:
+                return match.group(1)
+
+        return None
+
+
+class CephOSDDaemonVersionInterface():
+    """ Handler for the binary check type to verify OSD daemon versions. """
+
+    @cached_property
+    def _local_osd_ids(self):
+        osd_ids = []
+        s = FileSearcher()
+        sd = SequenceSearchDef(
+            start=SearchDef(r"^=+\s+osd\.(\d+)\s+=+.*"),
+            body=SearchDef([r"\s+osd\s+(fsid)\s+(\S+)\s*",
+                            r"\s+(devices)\s+([\S]+)\s*"]),
+            tag="ceph-lvm")
+        with CLIHelperFile() as cli:
+            fout = cli.ceph_volume_lvm_list()
+            s.add(sd, path=fout)
+            for results in s.run().find_sequence_sections(sd).values():
+                for result in results:
+                    if result.tag == sd.start_tag:
+                        osd_ids.append(int(result.get(1)))
+        return osd_ids
+
+    @cached_property
+    def _daemon_version(self):
+        for osd_id in self._local_osd_ids:
+            try:
+                ver = CephDaemonVersion(osd_id=osd_id).version
+            except Exception:  # pylint: disable=broad-except
+                continue
+            if ver:
+                return ver
+        return None
+
+    def is_installed(self, _name):
+        """Return True if the daemon version is available."""
+        return self._daemon_version is not None
+
+    def get_version(self, _name):
+        """Return the daemon version string."""
+        return self._daemon_version
+
+
 class CephDaemonDumpMemPools():
     """ Interface to ceph daemon osd dump mempools. """
     def __init__(self, osd_id):

--- a/hotsos/defs/scenarios/storage/ceph/ceph-osd/bugs/lp1936136.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-osd/bugs/lp1936136.yaml
@@ -1,20 +1,34 @@
 vars:
   cache_available_percent: '@hotsos.core.plugins.storage.bcache.CachesetsInfo.cache_available_percent'
 checks:
-  node_is_ceph_osd_and_has_version:
-    # Get version of osd based on package installed. This is prone to
-    # inaccuracy since the daemon many not have been restarted after
-    # package update.
+  osd_daemon_has_vulnerable_version:
+    # Get version of osd based on running daemon version. This is more
+    # accurate than checking the apt package version since the daemon
+    # may not have been restarted after a package update.
+    binary:
+      handler: hotsos.core.plugins.storage.ceph.common.CephOSDDaemonVersionInterface
+      ceph-osd:
+        - min: '13.0.2'
+          max: '14.2.9'
+        - min: '14.2.22'
+          max: '15.2.1'
+        - min: '15.2.13'
+          max: '16.1.0'
+        - min: '17.0.0'
+          max: '17.0.0'
+  osd_apt_has_vulnerable_version:
+    # Fallback to apt package version for sosreports where the daemon
+    # binary is not available.
     apt:
       ceph-osd:
-        - min: 13.0.2
-          max: 14.2.9
-        - min: 14.2.22
-          max: 15.2.1
-        - min: 15.2.13
-          max: 16.1.0
-        - min: 17.0.0
-          max: 17.0.0
+        - min: '13.0.2'
+          max: '14.2.9'
+        - min: '14.2.22'
+          max: '15.2.1'
+        - min: '15.2.13'
+          max: '16.1.0'
+        - min: '17.0.0'
+          max: '17.0.0'
   node_has_osds_using_bcache:
     property: hotsos.core.plugins.storage.ceph.CephChecks.local_osds_use_bcache
   kernel_version_check:
@@ -33,7 +47,9 @@ checks:
 conclusions:
   node_affected_by_bug_1936136:
     decision:
-      - node_is_ceph_osd_and_has_version
+      - or:
+          - osd_daemon_has_vulnerable_version
+          - osd_apt_has_vulnerable_version
       - node_has_osds_using_bcache
       - kernel_version_check
       - bluefs_buffered_io_enabled

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-osd/bugs/lp1936136.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-osd/bugs/lp1936136.yaml
@@ -11,6 +11,12 @@ data-root:
     - sos_commands/systemd/systemctl_list-unit-files
 mock:
   patch:
+    hotsos.core.plugins.storage.ceph.common.CephOSDDaemonVersionInterface.is_installed:
+      kwargs:
+        return_value: true
+    hotsos.core.plugins.storage.ceph.common.CephOSDDaemonVersionInterface.get_version:
+      kwargs:
+        return_value: '14.2.22'
     hotsos.core.plugins.storage.ceph.CephChecks.local_osds_use_bcache:
       kwargs:
         new: true

--- a/tests/unit/host_helpers/test_cli.py
+++ b/tests/unit/host_helpers/test_cli.py
@@ -338,6 +338,7 @@ class TestCommandAffinity(utils.BaseTestCase):
                         'sunbeam_cluster_list_yaml_decoded',
                         'ceph_daemon_osd_config_show',
                         'ceph_config_dump_json_decoded',
+                        'ceph_daemon_osd_version',
                         'ceph_report_json_decoded',
                         'ps_axo_flags',
                         'docker_images',


### PR DESCRIPTION
We currently used apt to check whether the OSDs are affected by lp1936136. Running versions are a more accurate method to check instead of the installed versions.

Fixes #283.

Fixes #SET-2220.