### PR TITLE
[ceph] warn when size == min_size for replicated pools.

### DIFF
--- a/hotsos/core/plugins/storage/ceph/cluster.py
+++ b/hotsos/core/plugins/storage/ceph/cluster.py
@@ -635,6 +635,27 @@ class CephCluster():  # pylint: disable=too-many-public-methods
                 return True
         return False
 
+    @cached_property
+    def pools_with_size_equal_min_size(self):
+        """
+        Returns a list of pool names where size == min_size. This is a risky
+        configuration because it means the pool cannot tolerate any OSD
+        failures without becoming unavailable.
+        """
+        bad_pools = []
+        ceph_report = self.crush_map.ceph_report
+        if not ceph_report:
+            return bad_pools
+
+        pools = ceph_report.get('osdmap', {}).get('pools', [])
+        for pool in pools:
+            size = pool.get('size', 0)
+            min_size = pool.get('min_size', 0)
+            if 0 < size <= min_size:
+                bad_pools.append(pool['pool_name'])
+
+        return bad_pools
+
     @staticmethod
     def version_as_a_tuple(ver):
         """

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/pool_size_min_size.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/pool_size_min_size.yaml
@@ -1,0 +1,17 @@
+checks:
+  pools_with_size_equal_min_size:
+    property:
+      path: hotsos.core.plugins.storage.ceph.CephCluster.pools_with_size_equal_min_size
+      ops: [[length_hint], [gt, 0]]
+conclusions:
+  pools-size-equal-min-size:
+    decision: pools_with_size_equal_min_size
+    raises:
+      type: CephWarning
+      message: >-
+        Found pool(s) '{pools}' where size == min_size. This means
+        the pool cannot tolerate any OSD failure without losing availability.
+        It is recommended to set min_size < size (e.g. size: 3, min_size: 2)
+        to allow degraded I/O to continue when an OSD is lost.
+      format-dict:
+        pools: '@checks.pools_with_size_equal_min_size.requires.value_actual:comma_join'

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/pool_size_min_size.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/pool_size_min_size.yaml
@@ -1,0 +1,49 @@
+target-name: pool_size_min_size.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/ceph_report: |
+      {
+        "osdmap": {
+          "pools": [
+            {
+              "pool": 1,
+              "pool_name": "device_health_metrics",
+              "type": 1,
+              "size": 3,
+              "min_size": 2,
+              "crush_rule": 0,
+              "pg_autoscale_mode": "on"
+            },
+            {
+              "pool": 2,
+              "pool_name": "cinder-ceph",
+              "type": 1,
+              "size": 3,
+              "min_size": 3,
+              "crush_rule": 0,
+              "pg_autoscale_mode": "on"
+            },
+            {
+              "pool": 3,
+              "pool_name": "nova",
+              "type": 1,
+              "size": 3,
+              "min_size": 3,
+              "crush_rule": 0,
+              "pg_autoscale_mode": "on"
+            }
+          ]
+        }
+      }
+      report 1234567890
+  copy-from-original:
+    - sos_commands/systemd/systemctl_list-units
+    - sos_commands/systemd/systemctl_list-unit-files
+    - sos_commands/dpkg/dpkg_-l
+raised-issues:
+  CephWarning:
+    - >-
+      Found pool(s) 'cinder-ceph, nova' where size == min_size.
+      This means the pool cannot tolerate any OSD failure without losing
+      availability. It is recommended to set min_size < size (e.g. size: 3,
+      min_size: 2) to allow degraded I/O to continue when an OSD is lost.


### PR DESCRIPTION
This is never recommended except in rare situations where as a temporary recovery mechanism.

Fixes #998.

Fixes #SET-2193.