### PR TITLE
Catch kubectl error when kube config is missing

### DIFF
--- a/hotsos/core/plugins/openstack/sunbeam.py
+++ b/hotsos/core/plugins/openstack/sunbeam.py
@@ -13,20 +13,39 @@ class SunbeamInfo():
     def is_controller(self):
         return 'openstack' in SnapPackageHelper(core_snaps=['openstack']).core
 
+    @staticmethod
+    def _kubectl_get(opt):
+        """ Run kubectl get for the given resource and return its items.
+
+        On a controller ~/.kube/config is expected to exist so if kubectl
+        fails (e.g. missing/invalid config) the output will be empty. We catch
+        that here and warn rather than silently returning nothing so that the
+        reason is not hidden from the user.
+
+        @param opt: resource to query e.g. 'pods' or 'statefulsets'.
+        @return: list of items (possibly empty).
+        """
+        out = CLIHelper().kubectl_get(namespace='openstack', opt=opt,
+                                      subopts='')
+        if not out or 'items' not in out:
+            log.warning("no sunbeam %s found - kubectl returned no data "
+                        "(does ~/.kube/config exist?)", opt)
+            return []
+
+        return out['items']
+
     @cached_property
     def pods(self):
         """ Return dictionary of pods keyed by their status e.g. Running. """
         if not self.is_controller:
             return {}
 
-        cli = CLIHelper()
-        out = cli.kubectl_get(namespace='openstack', opt='pods', subopts='')
-        if 'items' not in out:
-            log.info('no sunbeam pods found')
+        items = self._kubectl_get('pods')
+        if not items:
             return {}
 
         pods = defaultdict(list)
-        for pod in out['items']:
+        for pod in items:
             phase = pod['status']['phase']
             pods[phase].append(pod['metadata']['name'])
 
@@ -41,17 +60,13 @@ class SunbeamInfo():
         if not self.is_controller:
             return {}
 
-        cli = CLIHelper()
-        out = cli.kubectl_get(namespace='openstack', opt='statefulsets',
-                              subopts='')
-
-        ss = {'complete': [], 'incomplete': []}
-        if 'items' not in out:
-            log.info('no sunbeam statefulsets found')
+        items = self._kubectl_get('statefulsets')
+        if not items:
             return {}
 
+        ss = {'complete': [], 'incomplete': []}
         metadata_fails = 0
-        for i in out['items']:
+        for i in items:
             try:
                 name = i['metadata']['name']
             except KeyError:

--- a/hotsos/plugin_extensions/openstack/sunbeam.py
+++ b/hotsos/plugin_extensions/openstack/sunbeam.py
@@ -1,3 +1,4 @@
+from hotsos.core.issues import IssuesManager, OpenstackWarning
 from hotsos.core.plugins.openstack.common import (
     OpenstackBase,
     OpenStackChecks,
@@ -20,5 +21,11 @@ class SunbeamStatus(OpenstackBase, OpenStackChecks):
         if sunbeam.pods:
             return {'pods': sunbeam.pods,
                     'statefulsets': sunbeam.statefulsets}
+
+        if sunbeam.is_controller:
+            IssuesManager().add(OpenstackWarning(
+                "this host is a sunbeam controller but no kubernetes data "
+                "was found - kubectl may have failed (does ~/.kube/config "
+                "exist?)"))
 
         return None

--- a/tests/unit/openstack/test_sunbeam.py
+++ b/tests/unit/openstack/test_sunbeam.py
@@ -4,7 +4,9 @@ from unittest import mock
 from hotsos.core.config import HotSOSConfig
 import hotsos.core.plugins.openstack as openstack_core
 from hotsos.core.plugins.openstack import sunbeam
+from hotsos.core.issues import IssuesManager
 from hotsos.plugin_extensions.openstack import agent
+from hotsos.plugin_extensions.openstack import sunbeam as sunbeam_ext
 from hotsos.core.ycheck.common import GlobalSearcher
 from tests.unit import utils
 from tests.unit.openstack.test_openstack import TestOpenstackBase
@@ -142,6 +144,37 @@ class TestOpenstackSunbeam(TestOpenstackSunbeamBase):
             expected = {'complete': [],
                         'incomplete': ['traefik-public']}
             self.assertDictEqual(sunbeaminfo.statefulsets, expected)
+
+    def test_pods_kubectl_error(self):
+        sunbeaminfo = sunbeam.SunbeamInfo()
+        with mock.patch.object(sunbeam.SunbeamInfo, 'is_controller', True), \
+                mock.patch.object(sunbeam, 'CLIHelper') as mock_helper:
+            mock_helper.return_value.kubectl_get.return_value = {}
+            self.assertDictEqual(sunbeaminfo.pods, {})
+            self.assertDictEqual(sunbeaminfo.statefulsets, {})
+
+    def test_pods_kubectl_no_output(self):
+        sunbeaminfo = sunbeam.SunbeamInfo()
+        with mock.patch.object(sunbeam.SunbeamInfo, 'is_controller', True), \
+                mock.patch.object(sunbeam, 'CLIHelper') as mock_helper:
+            mock_helper.return_value.kubectl_get.return_value = None
+            self.assertDictEqual(sunbeaminfo.pods, {})
+            self.assertDictEqual(sunbeaminfo.statefulsets, {})
+
+    def test_summary_controller_no_kubectl_data_raises_issue(self):
+        with mock.patch.object(sunbeam.SunbeamInfo, 'is_controller', True), \
+                mock.patch.object(sunbeam, 'CLIHelper') as mock_helper:
+            mock_helper.return_value.kubectl_get.return_value = {}
+            inst = sunbeam_ext.SunbeamStatus()
+            self.part_output_to_actual(inst.output)
+            issues = {'potential-issues': [{
+                        'message': ('this host is a sunbeam controller but no '
+                                    'kubernetes data was found - kubectl may '
+                                    'have failed (does ~/.kube/config '
+                                    'exist?)'),
+                        'origin': 'openstack.testpart',
+                        'type': 'OpenstackWarning'}]}
+            self.assertEqual(IssuesManager().load_issues(), issues)
 
 
 class TestOpenstackSunbeamPluginCore(TestOpenstackSunbeamBase):


### PR DESCRIPTION
When sunbeam is a controller, ~/.kube/config is expected to exist.

If kubectl fails because the config is missing or invalid, the output is empty.

Handle empty/None output safely, log a warning, and raise an issue in the report so an incomplete sosreport is not missed instead of failing silently.