### PR TITLE
Detect MDS balancer issue

### DIFF
--- a/hotsos/core/host_helpers/cli/catalog.py
+++ b/hotsos/core/host_helpers/cli/catalog.py
@@ -81,6 +81,7 @@ class CommandCatalog(UserDict):
             'ceph_versions': ceph.CephVersionsCommands(),
             'ceph_volume_lvm_list': ceph.CephVolumeLVMListCommands(),
             'ceph_report_json_decoded': ceph.CephReportCommands(),
+            'ceph_config_dump_json_decoded': ceph.CephConfigDumpCommands(),
             'ceph_mgr_module_ls': ceph.CephMgrModuleLsCommands(),
             'date':
                 [DateBinCmd('date', singleline=True),

--- a/hotsos/core/host_helpers/cli/commands/ceph.py
+++ b/hotsos/core/host_helpers/cli/commands/ceph.py
@@ -317,6 +317,22 @@ class CephReportCommands(UserList):
         super().__init__(cmds)
 
 
+class CephConfigDumpCommands(UserList):
+    """ Generate ceph config dump command variants. """
+
+    def __init__(self):
+        prefixes = [""] + CEPH_ALIASES
+        # binary
+        cmds = [CephJSONBinCmd(f'{prefix}ceph config dump --format '
+                               'json-pretty') for prefix in prefixes]
+        # file-based
+        cmds.extend([CephJSONFileCmd('sos_commands/ceph_mon/json_output/'
+                                     f'{prefix}ceph_config_dump_'
+                                     '--format_json-pretty')
+                     for prefix in prefixes])
+        super().__init__(cmds)
+
+
 class CephMgrModuleLsCommands(UserList):
     """ Generate ceph XXX command variants. """
 

--- a/hotsos/core/plugins/storage/ceph/cluster.py
+++ b/hotsos/core/plugins/storage/ceph/cluster.py
@@ -297,6 +297,10 @@ class CephCluster():  # pylint: disable=too-many-public-methods
         self.crush_map = CephCrushMap()
 
     @cached_property
+    def ceph_config_dump(self):
+        return CLIHelper().ceph_config_dump_json_decoded() or []
+
+    @cached_property
     def _osd_daemon_config(self):
         """
         Try to get daemon config from any local OSD. Returns a dict of config

--- a/hotsos/core/plugins/storage/ceph/common.py
+++ b/hotsos/core/plugins/storage/ceph/common.py
@@ -345,6 +345,72 @@ class CephChecks(StorageBase):
     def local_osds_devtypes(self):
         return [osd.devtype for osd in self.local_osds]
 
+    @staticmethod
+    def _is_zero_config_value(value):
+        try:
+            return int(value) == 0
+        except (TypeError, ValueError):
+            return False
+
+    @cached_property
+    def _mds_bal_interval_is_zero(self):
+        """
+        Returns True if mds_bal_interval is explicitly set to 0, which
+        disables the balancer on all releases.
+        """
+        mds_values = []
+        global_values = []
+        for item in self.cluster.ceph_config_dump:
+            if item.get('name') != 'mds_bal_interval':
+                continue
+
+            section = item.get('section')
+            if section == 'mds':
+                mds_values.append(item.get('value'))
+            elif section == 'global':
+                global_values.append(item.get('value'))
+
+        values = mds_values or global_values
+        if values:
+            return all(self._is_zero_config_value(value) for value in values)
+
+        conf_value = self.ceph_config.get('mds_bal_interval')
+        if conf_value is not None:
+            return self._is_zero_config_value(conf_value)
+
+        return False
+
+    @staticmethod
+    def _fs_balance_automate(filesystem):
+        """
+        Returns the balance_automate flag for a filesystem, or None if the
+        flag is not present (releases before reef do not expose it).
+        """
+        flags_state = (filesystem or {}).get('mdsmap', {}).get('flags_state',
+                                                               {})
+        return flags_state.get('balance_automate')
+
+    @cached_property
+    def mds_balancer_disabled(self):
+        """
+        Returns True if the CephFS MDS balancer is disabled.
+
+        The balancer can be turned off cluster-wide by setting
+        mds_bal_interval to 0 (all releases), or per-filesystem via the
+        balance_automate flag which reef and later expose and disable by
+        default.
+        """
+        if self._mds_bal_interval_is_zero:
+            return True
+
+        report = self.cluster.crush_map.ceph_report
+        filesystems = report.get('fsmap', {}).get('filesystems') or []
+        automate = [self._fs_balance_automate(fs) for fs in filesystems]
+        if automate and all(state is False for state in automate):
+            return True
+
+        return False
+
     @cached_property
     def local_osds_with_oversized_bluefs_log(self):
         """

--- a/hotsos/defs/scenarios/storage/ceph/ceph-mon/mds_balancer.yaml
+++ b/hotsos/defs/scenarios/storage/ceph/ceph-mon/mds_balancer.yaml
@@ -1,0 +1,38 @@
+vars:
+  ceph_report: '@hotsos.core.plugins.storage.ceph.CephCrushMap.ceph_report'
+  msg_main: >-
+    This Ceph cluster has CephFS configured and the MDS balancer does not
+    appear to be disabled. The MDS balancer can introduce performance and
+    stability issues. Disable it with 'sudo ceph config set mds
+    mds_bal_interval 0' (reef and later also support 'sudo ceph fs set
+    <fs_name> balance_automate false'). This change takes effect immediately
+    and does not require service restarts.
+checks:
+  ceph_report_has_fsmap:
+    varops: [[$ceph_report], [contains, fsmap]]
+  ceph_fsmap_has_filesystems:
+    varops: [[$ceph_report], [getitem, fsmap], [contains, filesystems]]
+  cephfs_configured:
+    varops:
+      - [$ceph_report]
+      - [getitem, fsmap]
+      - [getitem, filesystems]
+      - [length_hint]
+  mds_balancer_not_disabled:
+    property:
+      path: hotsos.core.plugins.storage.ceph.CephChecks.mds_balancer_disabled
+      ops: [[eq, false]]
+conclusions:
+  cephtracker61378_mds_balancer_not_disabled:
+    decision:
+      - ceph_report_has_fsmap
+      - ceph_fsmap_has_filesystems
+      - cephfs_configured
+      - mds_balancer_not_disabled
+    raises:
+      type: CephTrackerBug
+      bug-id: 61378
+      message: >-
+        {msg_main}
+      format-dict:
+        msg_main: $msg_main

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_balance_automate_disabled.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_balance_automate_disabled.yaml
@@ -1,0 +1,19 @@
+target-name: mds_balancer.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/ceph_report: |
+      {
+        "fsmap": {
+          "filesystems": [
+            {
+              "id": 1,
+              "mdsmap": {
+                "flags_state": {
+                  "balance_automate": false
+                }
+              }
+            }
+          ]
+        }
+      }
+raised-bugs:  # none expected

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_balance_automate_enabled.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_balance_automate_enabled.yaml
@@ -1,0 +1,26 @@
+target-name: mds_balancer.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/ceph_report: |
+      {
+        "fsmap": {
+          "filesystems": [
+            {
+              "id": 1,
+              "mdsmap": {
+                "flags_state": {
+                  "balance_automate": true
+                }
+              }
+            }
+          ]
+        }
+      }
+raised-bugs:
+  https://tracker.ceph.com/issues/61378: >-
+    This Ceph cluster has CephFS configured and the MDS balancer does not
+    appear to be disabled. The MDS balancer can introduce performance and
+    stability issues. Disable it with 'sudo ceph config set mds
+    mds_bal_interval 0' (reef and later also support 'sudo ceph fs set
+    <fs_name> balance_automate false'). This change takes effect immediately
+    and does not require service restarts.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_balance_automate_partial.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_balance_automate_partial.yaml
@@ -1,0 +1,29 @@
+target-name: mds_balancer.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/ceph_report: |
+      {
+        "fsmap": {
+          "filesystems": [
+            {
+              "id": 1,
+              "mdsmap": {
+                "flags_state": {
+                  "balance_automate": false
+                }
+              }
+            },
+            {
+              "id": 2
+            }
+          ]
+        }
+      }
+raised-bugs:
+  https://tracker.ceph.com/issues/61378: >-
+    This Ceph cluster has CephFS configured and the MDS balancer does not
+    appear to be disabled. The MDS balancer can introduce performance and
+    stability issues. Disable it with 'sudo ceph config set mds
+    mds_bal_interval 0' (reef and later also support 'sudo ceph fs set
+    <fs_name> balance_automate false'). This change takes effect immediately
+    and does not require service restarts.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_config_dump_preferred.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_config_dump_preferred.yaml
@@ -1,0 +1,27 @@
+target-name: mds_balancer.yaml
+data-root:
+  files:
+    etc/ceph/ceph.conf: |
+      [global]
+      mds_bal_interval = 10
+    sos_commands/ceph_mon/json_output/ceph_config_dump_--format_json-pretty: |
+      [
+        {
+          "section": "mds",
+          "mask": "",
+          "name": "mds_bal_interval",
+          "value": "0",
+          "level": "advanced",
+          "can_update_at_runtime": true,
+          "flags": []
+        }
+      ]
+mock:
+  patch:
+    hotsos.core.plugins.storage.ceph.CephCrushMap.ceph_report:
+      kwargs:
+        new:
+          fsmap:
+            filesystems:
+              - id: 1
+raised-bugs:  # none expected

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_default.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_default.yaml
@@ -1,0 +1,21 @@
+target-name: mds_balancer.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/json_output/ceph_config_dump_--format_json-pretty: |
+      []
+mock:
+  patch:
+    hotsos.core.plugins.storage.ceph.CephCrushMap.ceph_report:
+      kwargs:
+        new:
+          fsmap:
+            filesystems:
+              - id: 1
+raised-bugs:
+  https://tracker.ceph.com/issues/61378: >-
+    This Ceph cluster has CephFS configured and the MDS balancer does not
+    appear to be disabled. The MDS balancer can introduce performance and
+    stability issues. Disable it with 'sudo ceph config set mds
+    mds_bal_interval 0' (reef and later also support 'sudo ceph fs set
+    <fs_name> balance_automate false'). This change takes effect immediately
+    and does not require service restarts.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_disabled.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_disabled.yaml
@@ -1,0 +1,24 @@
+target-name: mds_balancer.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/json_output/ceph_config_dump_--format_json-pretty: |
+      [
+        {
+          "section": "mds",
+          "mask": "",
+          "name": "mds_bal_interval",
+          "value": "0",
+          "level": "advanced",
+          "can_update_at_runtime": true,
+          "flags": []
+        }
+      ]
+mock:
+  patch:
+    hotsos.core.plugins.storage.ceph.CephCrushMap.ceph_report:
+      kwargs:
+        new:
+          fsmap:
+            filesystems:
+              - id: 1
+raised-bugs:  # none expected

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_enabled.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_enabled.yaml
@@ -1,0 +1,33 @@
+target-name: mds_balancer.yaml
+data-root:
+  files:
+    sos_commands/ceph_mon/ceph_report: |
+      {
+        "fsmap": {
+          "filesystems": [
+            {
+              "id": 1
+            }
+          ]
+        }
+      }
+    sos_commands/ceph_mon/json_output/ceph_config_dump_--format_json-pretty: |
+      [
+        {
+          "section": "mds",
+          "mask": "",
+          "name": "mds_bal_interval",
+          "value": "10",
+          "level": "advanced",
+          "can_update_at_runtime": true,
+          "flags": []
+        }
+      ]
+raised-bugs:
+  https://tracker.ceph.com/issues/61378: >-
+    This Ceph cluster has CephFS configured and the MDS balancer does not
+    appear to be disabled. The MDS balancer can introduce performance and
+    stability issues. Disable it with 'sudo ceph config set mds
+    mds_bal_interval 0' (reef and later also support 'sudo ceph fs set
+    <fs_name> balance_automate false'). This change takes effect immediately
+    and does not require service restarts.

--- a/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_no_ceph_report.yaml
+++ b/hotsos/defs/tests/scenarios/storage/ceph/ceph-mon/mds_balancer_no_ceph_report.yaml
@@ -1,0 +1,7 @@
+target-name: mds_balancer.yaml
+mock:
+  patch:
+    hotsos.core.plugins.storage.ceph.CephCrushMap.ceph_report:
+      kwargs:
+        new: {}
+raised-bugs:  # none expected

--- a/tests/unit/host_helpers/test_cli.py
+++ b/tests/unit/host_helpers/test_cli.py
@@ -315,6 +315,7 @@ class TestCommandAffinity(utils.BaseTestCase):
                         'pebble_services',
                         'sunbeam_cluster_list_yaml_decoded',
                         'ceph_daemon_osd_config_show',
+                        'ceph_config_dump_json_decoded',
                         'ceph_report_json_decoded',
                         'ps_axo_flags',
                         'docker_images',

--- a/tests/unit/storage/test_ceph_common.py
+++ b/tests/unit/storage/test_ceph_common.py
@@ -97,6 +97,57 @@ class TestCephPluginDeps(CephCommonTestsBase):
         self.assertEqual(ceph.common.CephChecks().release_name, 'reef')
 
 
+class TestCephChecks(CephCommonTestsBase):
+    """ Unit tests for ceph checks. """
+    def test_mds_balancer_disabled_by_interval(self):
+        cases = [
+            ('mds config dump',
+             [{'name': 'mds_bal_interval',
+               'section': 'mds',
+               'value': '0'}], {}, True),
+            ('global config dump',
+             [{'name': 'mds_bal_interval',
+               'section': 'global',
+               'value': '0'}], {}, True),
+            ('mds overrides global',
+             [{'name': 'mds_bal_interval',
+               'section': 'global',
+               'value': '0'},
+              {'name': 'mds_bal_interval',
+               'section': 'mds',
+               'value': '10'}], {}, False),
+            ('ceph config fallback', [], {'mds_bal_interval': '0'}, True),
+        ]
+        for name, config_dump, ceph_config, expected in cases:
+            with self.subTest(name=name):
+                checks = ceph.common.CephChecks()
+                checks.cluster.ceph_config_dump = config_dump
+                checks.cluster.crush_map.ceph_report = {}
+                checks.ceph_config = ceph_config
+                self.assertEqual(checks.mds_balancer_disabled, expected)
+
+    def test_mds_balancer_disabled_by_balance_automate(self):
+        cases = [
+            ('disabled for all filesystems',
+             [{'mdsmap': {'flags_state': {'balance_automate': False}}},
+              {'mdsmap': {'flags_state': {'balance_automate': False}}}],
+             True),
+            ('enabled for one filesystem',
+             [{'mdsmap': {'flags_state': {'balance_automate': False}}},
+              {'mdsmap': {'flags_state': {'balance_automate': True}}}],
+             False),
+            ('flag unavailable', [{'mdsmap': {}}], False),
+        ]
+        for name, filesystems, expected in cases:
+            with self.subTest(name=name):
+                checks = ceph.common.CephChecks()
+                checks.cluster.ceph_config_dump = []
+                checks.cluster.crush_map.ceph_report = {
+                    'fsmap': {'filesystems': filesystems}}
+                checks.ceph_config = {}
+                self.assertEqual(checks.mds_balancer_disabled, expected)
+
+
 @utils.load_templated_tests('scenarios/storage/ceph/common')
 class TestCephCommonScenarios(CephCommonTestsBase):
     """


### PR DESCRIPTION
Fixes #1079.

Detect Ceph clusters with CephFS configured where the MDS balancer does not appear to be disabled, and raise Ceph tracker bug 61378 with the recommended mitigation.