### PR TITLE
[kernel] Add SCSI error detections

### DIFF
--- a/hotsos/defs/scenarios/kernel/scsi_error.yaml
+++ b/hotsos/defs/scenarios/kernel/scsi_error.yaml
@@ -1,0 +1,70 @@
+checks:
+  scsi_failed_result:
+    input:
+      path: 'var/log/kern.log'
+    # Matches SCSI command failures from scsi_print_result() e.g.:
+    # sd 0:0:11:0: [sdh] tag#2712 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE
+    expr: '.* kernel: \[.*\] sd \S+: \[([^\]]+)\] \S+ FAILED Result: hostbyte=(\S+) driverbyte=(\S+)'
+  scsi_device_offlined:
+    input:
+      path: 'var/log/kern.log'
+    # Matches device offline from scsi_eh_offline_sdevs() in scsi_error.c e.g.:
+    # sd 0:0:11:0: Device offlined - not ready after error recovery
+    expr: '.* kernel: \[.*\] sd (\S+): Device offlined - not ready after error recovery'
+  scsi_medium_error:
+    input:
+      path: 'var/log/kern.log'
+    # Matches SCSI Medium Error sense key from scsi_log_print_sense_hdr() e.g.:
+    # sd 0:0:11:0: [sdh] tag#2712 Sense Key : Medium Error [current]
+    expr: '.* kernel: \[.*\] sd \S+: \[([^\]]+)\] \S+ Sense Key : Medium Error \[current\]'
+  scsi_hardware_error:
+    input:
+      path: 'var/log/kern.log'
+    # Matches SCSI Hardware Error sense key from scsi_log_print_sense_hdr() e.g.:
+    # sd 0:0:11:0: [sdh] tag#2712 Sense Key : Hardware Error [current]
+    expr: '.* kernel: \[.*\] sd \S+: \[([^\]]+)\] \S+ Sense Key : Hardware Error \[current\]'
+conclusions:
+  scsi_device_offline:
+    priority: 3
+    decision: scsi_device_offlined
+    raises:
+      type: KernelError
+      message: >-
+        SCSI device {dev} has been offlined after error recovery failed.
+        The device is no longer accessible and may need replacement or
+        manual intervention.
+      format-dict:
+        dev: '@checks.scsi_device_offlined.search.results_group_1:unique_comma_join'
+  scsi_medium_err:
+    priority: 2
+    decision: scsi_medium_error
+    raises:
+      type: KernelWarning
+      message: >-
+        SCSI Medium Error detected for device {dev}. This typically
+        indicates disk surface or media issues.
+      format-dict:
+        dev: '@checks.scsi_medium_error.search.results_group_1:unique_comma_join'
+  scsi_hardware_err:
+    priority: 2
+    decision: scsi_hardware_error
+    raises:
+      type: KernelWarning
+      message: >-
+        SCSI Hardware Error detected for device {dev}. This typically
+        indicates a failing disk or controller issue.
+      format-dict:
+        dev: '@checks.scsi_hardware_error.search.results_group_1:unique_comma_join'
+  scsi_error:
+    priority: 1
+    decision: scsi_failed_result
+    raises:
+      type: KernelWarning
+      message: >-
+        SCSI error detected for device {dev} (hostbyte={hostbyte},
+        driverbyte={driverbyte}). This may indicate a hardware issue
+        with the disk or controller.
+      format-dict:
+        dev: '@checks.scsi_failed_result.search.results_group_1:unique_comma_join'
+        hostbyte: '@checks.scsi_failed_result.search.results_group_2:unique_comma_join'
+        driverbyte: '@checks.scsi_failed_result.search.results_group_3:unique_comma_join'

--- a/hotsos/defs/tests/scenarios/kernel/scsi_error.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/scsi_error.yaml
@@ -1,0 +1,14 @@
+data-root:
+  files:
+    var/log/kern.log: |
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797102] sd 0:0:11:0: [sdh] tag#2712 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797103] sd 0:0:11:0: [sdh] tag#2712 Sense Key : Aborted Command [current]
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797104] sd 0:0:11:0: [sdh] tag#2712 Add. Sense: No additional sense information
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797105] sd 0:0:11:0: [sdh] tag#2712 CDB: Write(10) 2a 00 a3 39 c1 d8 00 00 08 00
+  copy-from-original:
+    - sos_commands/date/date
+raised-issues:
+  KernelWarning: >-
+    SCSI error detected for device sdh (hostbyte=DID_OK,
+    driverbyte=DRIVER_SENSE). This may indicate a hardware issue with
+    the disk or controller.

--- a/hotsos/defs/tests/scenarios/kernel/scsi_error_hardware.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/scsi_error_hardware.yaml
@@ -1,0 +1,14 @@
+target-name: scsi_error.yaml
+data-root:
+  files:
+    var/log/kern.log: |
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797102] sd 0:0:11:0: [sdh] tag#2712 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797103] sd 0:0:11:0: [sdh] tag#2712 Sense Key : Hardware Error [current]
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797104] sd 0:0:11:0: [sdh] tag#2712 Add. Sense: Internal target failure
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797105] sd 0:0:11:0: [sdh] tag#2712 CDB: Write(10) 2a 00 a3 39 c1 d8 00 00 08 00
+  copy-from-original:
+    - sos_commands/date/date
+raised-issues:
+  KernelWarning: >-
+    SCSI Hardware Error detected for device sdh. This typically
+    indicates a failing disk or controller issue.

--- a/hotsos/defs/tests/scenarios/kernel/scsi_error_medium.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/scsi_error_medium.yaml
@@ -1,0 +1,14 @@
+target-name: scsi_error.yaml
+data-root:
+  files:
+    var/log/kern.log: |
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797102] sd 0:0:11:0: [sdh] tag#2712 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797103] sd 0:0:11:0: [sdh] tag#2712 Sense Key : Medium Error [current]
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797104] sd 0:0:11:0: [sdh] tag#2712 Add. Sense: Unrecovered read error
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797105] sd 0:0:11:0: [sdh] tag#2712 CDB: Read(10) 28 00 00 85 1f 80 00 00 80 00
+  copy-from-original:
+    - sos_commands/date/date
+raised-issues:
+  KernelWarning: >-
+    SCSI Medium Error detected for device sdh. This typically indicates
+    disk surface or media issues.

--- a/hotsos/defs/tests/scenarios/kernel/scsi_error_offlined.yaml
+++ b/hotsos/defs/tests/scenarios/kernel/scsi_error_offlined.yaml
@@ -1,0 +1,13 @@
+target-name: scsi_error.yaml
+data-root:
+  files:
+    var/log/kern.log: |
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797102] sd 0:0:11:0: [sdh] tag#2712 FAILED Result: hostbyte=DID_ERROR driverbyte=DRIVER_OK
+     Jun 06 10:18:14 sf-sby001-hc0120-rack013 kernel: [  725.797103] sd 0:0:11:0: Device offlined - not ready after error recovery
+  copy-from-original:
+    - sos_commands/date/date
+raised-issues:
+  KernelError: >-
+    SCSI device 0:0:11:0 has been offlined after error recovery failed.
+    The device is no longer accessible and may need replacement or
+    manual intervention.


### PR DESCRIPTION
Checks the following scsi related errors:
 - SCSI command failures (FAILED Result with hostbyte/driverbyte)
 - Device offlined after error recovery
 - Medium Errors (disk surface/media issues)
 - Hardware Errors (failing disk/controller)

Fixes #631.

Fixes #SET-2180.