### PR TITLE
Fix lxd summary

### DIFF
--- a/hotsos/core/plugins/lxd/common.py
+++ b/hotsos/core/plugins/lxd/common.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from functools import cached_property
 
+from hotsos.core.log import log
 from hotsos.core.host_helpers import (
     APTPackageHelper,
     CLIHelperFile,
@@ -27,18 +28,38 @@ class LXD():
         """ Return a list of instance names. """
         _instances = []
         s = FileSearcher()
+        colname = 'NAME'
+        record_expr = r'^\|\s+(\S+)\s+\|\s+(\S+)\s+\|'
         seq = SequenceSearchDef(start=SearchDef(r'^## Instances$'),
-                                body=SearchDef(r'^\|\s+(\S+)\s+\|'),
+                                # NOTE: in 4.x NAME is col 1 but 6.x its col 2
+                                body=SearchDef(record_expr),
                                 end=SearchDef(r'##.*'),
                                 tag='instances')
+        colindex = 1
         with CLIHelperFile() as cli:
             s.add(seq, path=cli.lxd_buginfo())
             results = s.run()
             for section in results.find_sequence_sections(seq).values():
+                header = True
                 for r in section:
-                    if 'body' in r.tag:
-                        if r.get(1) != 'NAME' and r.get(1) != '|':
-                            _instances.append(r.get(1))
+                    if 'body' not in r.tag:
+                        continue
+
+                    if header:
+                        if r.get(colindex) != colname:
+                            colindex += 1
+                            if r.get(colindex) != colname:
+                                log.warning("did not get expected column "
+                                            "header %s - instead got %s",
+                                            colname, r.get(colindex))
+                                break
+
+                        header = False
+                        continue
+
+                    val = r.get(colindex)
+                    if val not in [colname, '|']:
+                        _instances.append(val)
 
         return _instances
 

--- a/tests/unit/test_lxd.py
+++ b/tests/unit/test_lxd.py
@@ -4,6 +4,28 @@ from hotsos.plugin_extensions.lxd import summary
 from . import utils
 
 
+LXD6X_BUGINFO = """
+## Instances
+```
++------------+--------+----------+----------------------+--------------+-----------+-----------+
+|  PROJECT   |  NAME  |  STATE   |         IPV4         |     IPV6     |   TYPE    | SNAPSHOTS |
++------------+---------+---------+----------------------+--------------+-----------+-----------+
+| altproj    | ctr2    | STOPPED |                      |              | CONTAINER | 0         |
++------------+---------+---------+----------------------+--------------+-----------+-----------+
+| default    | testctr | RUNNING | 10.44.9.117 (eth0)   |              | CONTAINER | 0         |
++------------+---------+---------+----------------------+--------------+-----------+-----------+
+```
+
+## Images
+
+"""  # noqa
+
+LXD6X_SNAPS = """
+Name                       Version                         Rev    Tracking         Publisher           Notes
+lxd                        6.9-a34e1d7                     39858  6/stable         canonical✓          -
+"""  # noqa
+
+
 class LXDTestsBase(utils.BaseTestCase):
     """ Custom base testcase that sets lxd plugin context. """
     def setUp(self):
@@ -32,6 +54,14 @@ class TestLXDSummary(LXDTestsBase):
                                      'transient': ['snap.lxd.workaround']}},
 
                     'snaps': ['lxd 4.22 (latest/stable)']}
+        inst = summary.LXDSummary()
+        self.assertEqual(self.part_output_to_actual(inst.output), expected)
+
+    @utils.create_data_root({'sos_commands/lxd/lxd.buginfo': LXD6X_BUGINFO,
+                             'sos_commands/snap/snap_list_--all': LXD6X_SNAPS})
+    def test_summary_keys_lxd_6x(self):
+        expected = {'instances': ['ctr2', 'testctr'],
+                    'snaps': ['lxd 6.9-a34e1d7 (6/stable)']}
         inst = summary.LXDSummary()
         self.assertEqual(self.part_output_to_actual(inst.output), expected)
 


### PR DESCRIPTION
The output of lxd.buginfo has changed between 4.x and 6.x so we need to accomodate for NAME column moving from index 1 to 2.