### PR TITLE
Fix missing docstrings in a couple of methods

### DIFF
--- a/hotsos/core/plugins/storage/ceph/cluster.py
+++ b/hotsos/core/plugins/storage/ceph/cluster.py
@@ -51,6 +51,7 @@ class CephCluster():  # pylint: disable=too-many-public-methods
 
     @cached_property
     def ceph_config_dump(self):
+        """ Return decoded JSON from ceph config dump. """
         return CLIHelper().ceph_config_dump_json_decoded() or []
 
     @cached_property

--- a/tests/unit/storage/test_ceph_common.py
+++ b/tests/unit/storage/test_ceph_common.py
@@ -104,6 +104,7 @@ class TestCephPluginDeps(CephCommonTestsBase):
 class TestCephChecks(CephCommonTestsBase):
     """ Unit tests for ceph checks. """
     def test_mds_balancer_disabled_by_interval(self):
+        """Test mds balancer disabled by interval."""
         cases = [
             ('mds config dump',
              [{'name': 'mds_bal_interval',
@@ -131,6 +132,7 @@ class TestCephChecks(CephCommonTestsBase):
                 self.assertEqual(checks.mds_balancer_disabled, expected)
 
     def test_mds_balancer_disabled_by_balance_automate(self):
+        """Test mds balancer disabled by balance_automate flag."""
         cases = [
             ('disabled for all filesystems',
              [{'mdsmap': {'flags_state': {'balance_automate': False}}},


### PR DESCRIPTION
After merging #1100 there are a couple of functions that don't pass pylint. Added missing docstrings to make pylint pass for the entire project.