### PR TITLE
[SET-2593] Refactor yaml file discover/traversing logic

### DIFF
--- a/hotsos/core/config.py
+++ b/hotsos/core/config.py
@@ -178,7 +178,11 @@ class RegisteredOpts(UserDict):
     def __setitem__(self, key, item):
         for group in self.optsgroups:
             if key in group.opts:
-                item = group.opts[key].value_type(item)
+                # avoid casting None to str
+                # unlike str, int/bool options already have
+                # the default values defined and are not affected
+                if item is not None:
+                    item = group.opts[key].value_type(item)
                 break
         else:
             raise KeyError(

--- a/hotsos/core/ycheck/engine/common.py
+++ b/hotsos/core/ycheck/engine/common.py
@@ -5,18 +5,57 @@ import yaml
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.log import log
 
+SCENARIOS_SUBDIR = 'scenarios'
+TESTS_SUBDIR = 'tests'
+
+
+def get_defs_dir():
+    """
+    Return the currently configured yaml defs root as an absolute,
+    normalised path (or None if the option has not been set yet).
+
+    Resolved on every call so that changes to HotSOSConfig made after this
+    module has been imported (e.g. during test setup) are honoured.
+    """
+    defs = HotSOSConfig.plugin_yaml_defs
+    if not defs:
+        return None
+    return os.path.abspath(os.path.normpath(defs))
+
+
+def get_defs_tests_dir():
+    """
+    Return <defs>/tests as an absolute path (or None if defs is not set).
+    """
+    defs = get_defs_dir()
+    return os.path.join(defs, TESTS_SUBDIR) if defs else None
+
 
 class YDefsLoader():
-    """ Load yaml definitions. """
+    """ Load yaml definitions with support for file discovery and
+    filtering.
+    """
 
     def __init__(self, ytype, filter_path=None):
         """
         @param ytype: the type of defs we are loading i.e. defs/<ytype>
+        @param filter_path: optional path filter for YAML content
         """
         self.ytype = ytype
         self._loaded_defs = None
         self.stats_num_files_loaded = 0
         self.filter_path = filter_path
+
+    @staticmethod
+    def _walk(path):
+        """Yield absolute paths of every file under path recursively.
+
+        No filtering is applied by the walker itself; callers are
+        responsible for filtering yielded paths as needed.
+        """
+        for root, _dirs, files in os.walk(path):
+            for name in files:
+                yield os.path.join(root, name)
 
     @staticmethod
     def _is_def(abs_path):
@@ -27,18 +66,18 @@ class YDefsLoader():
         return os.path.basename(path).partition('.yaml')[0]
 
     def _get_defs_recursive(self, path):
-        """ Recursively find all yaml/files beneath a directory. """
+        """ Recursively load yaml files beneath a directory into
+        a nested dict. """
         defs = {}
+        # Process immediate children first
         for entry in os.listdir(path):
             abs_path = os.path.join(path, entry)
             if os.path.isdir(abs_path):
                 subdefs = self._get_defs_recursive(abs_path)
                 if subdefs:
                     defs[os.path.basename(abs_path)] = subdefs
-            else:
-                if not self._is_def(abs_path):
-                    continue
-
+            elif self._is_def(abs_path):
+                # Process yaml files using shared filtering logic
                 if self._get_yname(abs_path) == os.path.basename(path):
                     with open(abs_path, encoding='utf-8') as fd:
                         log.debug("applying dir globals %s", entry)
@@ -59,8 +98,8 @@ class YDefsLoader():
 
     def _apply_filter(self, loaded):
         """
-        If a path filter has been provided, exclude any/all properties that are
-        not descendants of that path.
+        If a path filter has been provided, exclude any/all properties that
+        are not descendants of that path.
         """
         if not self.filter_path:
             return loaded
@@ -99,6 +138,79 @@ class YDefsLoader():
                 return loaded
 
         return {}
+
+    @staticmethod
+    def find_files_recursively(path, file_filter=None):
+        """ Find files under path without loading them.
+
+        Only YAML (.yaml) files are yielded; every other file (including
+        editor/disabled artefacts such as *.swp and *.disabled, which do not
+        end in .yaml) is skipped. Callers that want to further narrow the
+        result should pass a file_filter, which is applied on top of the
+        yaml-only filter.
+
+        @param path: absolute directory to search.
+        @param file_filter: optional callable taking an absolute file path
+                            and returning True to skip the file.
+        """
+        if not path or not os.path.isdir(path):
+            log.debug("search path not found: %s", path)
+            return
+        for abs_path in YDefsLoader._walk(path):
+            # Skip all non-yaml files as well as any file rejected by the
+            # optional caller-provided filter.
+            if (YDefsLoader._default_scenario_file_filter(abs_path)
+                    or (file_filter is not None and file_filter(abs_path))):
+                continue
+            yield abs_path
+
+    @staticmethod
+    def _default_scenario_file_filter(abs_path):
+        """Filter everything but .yaml files."""
+        return not YDefsLoader._is_def(abs_path)
+
+    @staticmethod
+    def get_scenario_files(subpath=None, file_filter=None):
+        """ Find all scenario definition YAML files.
+
+        @param subpath: optional path relative to <defs>/scenarios to
+                        narrow the search to.
+        @param file_filter: optional extra callable(abs_path)->bool filter,
+                            returning True to skip the file (exclude).
+        """
+        defs_dir = get_defs_dir()
+        if not defs_dir:
+            return
+        base = os.path.join(defs_dir, SCENARIOS_SUBDIR)
+
+        if subpath:
+            norm_subpath = os.path.normpath(subpath)
+
+            if (os.path.isabs(norm_subpath) or norm_subpath == '..'
+                    or norm_subpath.startswith('..' + os.sep)):
+                raise ValueError(
+                    f"subpath must be relative to {base}: {subpath}")
+
+            target = os.path.join(base, norm_subpath)
+        else:
+            target = base
+        yield from YDefsLoader.find_files_recursively(target, file_filter)
+
+    @staticmethod
+    def get_scenario_test_files(subpath=None, file_filter=None):
+        """ Find all scenario test YAML files.
+
+        @param subpath: optional path relative to <defs>/tests to narrow
+                        the search to (e.g. 'scenarios/kernel'). Kept
+                        relative to <defs>/tests (not <defs>/tests/scenarios)
+        @param file_filter: optional extra callable(abs_path)->bool filter,
+                            returning True to skip the file (exclude).
+        """
+        tests_dir = get_defs_tests_dir()
+        if not tests_dir:
+            return
+        target = os.path.join(tests_dir, subpath) if subpath else tests_dir
+        yield from YDefsLoader.find_files_recursively(target, file_filter)
 
 
 class YHandlerBase():

--- a/tests/unit/test_ut_scenario_loader.py
+++ b/tests/unit/test_ut_scenario_loader.py
@@ -4,6 +4,7 @@ import uuid
 from unittest import mock
 
 from hotsos.core.config import HotSOSConfig
+from hotsos.core.ycheck.engine.common import YDefsLoader
 
 from . import utils
 
@@ -87,8 +88,7 @@ class TestScenarioTestLoader(utils.BaseTestCase):
 
             test_files_without_target = [
                 'myscenario{}.yaml',
-                'myscenario.with.many.dots.{}.yaml',
-                'myscenario_noextension{}'
+                'myscenario.with.many.dots.{}.yaml'
             ]
 
             test_files_with_target = [
@@ -121,21 +121,19 @@ class TestScenarioTestLoader(utils.BaseTestCase):
 
                 a = MyTests()
                 tests = [x for x in dir(a) if x.startswith("test_")]
-                self.assertEqual(len(tests), 4)
+                self.assertEqual(len(tests), 3)
 
                 self.assertTrue("test_yscenario_1_myscenario_with_many_dots_1"
                                 in tests)
                 self.assertTrue("test_yscenario_1_myscenario1" in tests)
                 self.assertTrue("test_yscenario_1_myscenario1alt" in tests)
-                self.assertTrue("test_yscenario_1_myscenario_noextension1"
-                                in tests)
 
     def test_find_all_templated_tests(self):
         """Test discovery of all templated test files."""
         with tempfile.TemporaryDirectory() as dtmp:
             paths = []
             self.create_tests(dtmp, levels=3)
-            for path in utils.find_all_templated_tests(dtmp):
+            for path in YDefsLoader.find_files_recursively(dtmp):
                 paths.append(path)
 
             plugin_path = 'tests/scenarios/testplugin'
@@ -144,15 +142,12 @@ class TestScenarioTestLoader(utils.BaseTestCase):
                 '1/myscenario1.yaml',
                 '1/myscenario1alt.yaml',
                 '1/myscenario.with.many.dots.1.yaml',
-                '1/myscenario_noextension1',
                 '1/2/myscenario2.yaml',
                 '1/2/myscenario2alt.yaml',
                 '1/2/myscenario.with.many.dots.2.yaml',
-                '1/2/myscenario_noextension2',
                 '1/2/3/myscenario3.yaml',
                 '1/2/3/myscenario3alt.yaml',
-                '1/2/3/myscenario.with.many.dots.3.yaml',
-                '1/2/3/myscenario_noextension3'
+                '1/2/3/myscenario.with.many.dots.3.yaml'
             ]
 
             expected = [os.path.join(dtmp, plugin_path, x) for x in expected]

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -15,6 +15,7 @@ from hotsos.core.issues import IssuesManager
 from hotsos.core.log import log, logging, LoggingManager
 from hotsos.core.ycheck.scenarios import YScenarioChecker
 from hotsos.core.ycheck.common import GlobalSearcher
+from hotsos.core.ycheck.engine.common import YDefsLoader
 from hotsos.core.exceptions import (
     NameAlreadyRegisteredError,
     ExpectationNotMetError,
@@ -42,27 +43,6 @@ class FakeOut:
     returncode: int
 
 
-def find_all_templated_tests(path):
-    """
-    Generator to recursively find all templates (files) under path.
-
-    @return: path to test.
-    """
-    if not os.path.exists(path):
-        log.info("templated tests dir not found: %s", path)
-        return
-
-    for testdef in os.listdir(path):
-        if testdef.endswith(('.disabled', '.swp')):
-            continue
-
-        defpath = os.path.join(path, testdef)
-        if os.path.isdir(defpath):
-            yield from find_all_templated_tests(defpath)
-        else:
-            yield defpath
-
-
 def load_templated_tests(path):
     """ Add templated tests to the runner.
 
@@ -72,7 +52,7 @@ def load_templated_tests(path):
     def _inner(cls):
         count = 0
         _path = os.path.join(DEFS_TESTS_DIR, path)
-        for testdef in find_all_templated_tests(_path):
+        for testdef in YDefsLoader.find_files_recursively(_path):
             tg = TemplatedTestGenerator(path, testdef)
             if hasattr(cls, tg.test_method_name):
                 raise NameAlreadyRegisteredError(

--- a/tools/validation/hotyvalidate.py
+++ b/tools/validation/hotyvalidate.py
@@ -1,5 +1,4 @@
 import os
-import glob
 import json
 from unittest import TestCase
 import logging
@@ -7,6 +6,8 @@ import sys
 
 import yaml
 from tests.unit import utils
+from hotsos.core.config import HotSOSConfig
+from hotsos.core.ycheck.engine.common import YDefsLoader
 
 
 class HotYValidate(TestCase):
@@ -14,8 +15,6 @@ class HotYValidate(TestCase):
 
     @staticmethod
     def _discover_tests():
-        tests_root_path = os.path.join(utils.DEFS_TESTS_DIR, 'scenarios')
-
         # This list contains the full paths to all scenario test cases.
         # This information is used for reporting the number of avaliable
         # test cases.
@@ -26,38 +25,43 @@ class HotYValidate(TestCase):
         # with the scenario.
         test_scenario_mappings = {}
 
-        # Iterate over all subdirectories of `hotsos/defs/tests` and try to
-        # discover all the available test cases.
-        for subdir in os.listdir(tests_root_path):
-            logging.info("processing directory [%s/%s]", tests_root_path,
-                         subdir)
-            tests = utils.find_all_templated_tests(
-                os.path.join(tests_root_path, subdir))
+        # Base directory that contains per-plugin scenario test trees. Used
+        # to recover the plugin sub-root (e.g. 'kernel') from each yielded
+        # absolute test path so that TemplatedTestGenerator receives the
+        # correct test_defs_root value ('scenarios/<plugin>').
+        tests_root_path = os.path.join(utils.DEFS_TESTS_DIR, 'scenarios')
 
-            # Load the scenario tests one by one
-            for testdef in tests:
-                # Add the discovered test to list of
-                # all tests
-                all_tests.append(testdef)
+        # Load the scenario tests one by one
+        for testdef in YDefsLoader.get_scenario_test_files('scenarios'):
+            logging.info("processing test definition file: %s", testdef)
 
-                # Load the test. The code needs to access some attributes
-                # stored in the templated test class in order to be able to
-                # determine the associated scenario.
-                tg = utils.TemplatedTestGenerator(
-                    f'scenarios/{subdir}', testdef)
+            # Add the discovered test to list of
+            # all tests
+            all_tests.append(testdef)
 
-                # Determine the test's target scenario path.
-                target_scenario_path = os.path.join(utils.DEFS_DIR,
-                                                    tg.test_defs_root,
-                                                    tg.target_path)
+            # Recover the plugin sub-root from the absolute test path,
+            # e.g. /.../defs/tests/scenarios/kernel/foo.yaml -> 'kernel'.
+            rel = os.path.relpath(testdef, tests_root_path)
+            subdir = rel.split(os.sep, 1)[0]
 
-                # Add the test case's name to tests associated with the
-                # scenario.
-                if target_scenario_path in test_scenario_mappings:
-                    test_scenario_mappings[target_scenario_path].append(
-                        testdef)
-                else:
-                    test_scenario_mappings[target_scenario_path] = [testdef]
+            # Load the test. The code needs to access some attributes
+            # stored in the templated test class in order to be able to
+            # determine the associated scenario.
+            tg = utils.TemplatedTestGenerator(
+                f'scenarios/{subdir}', testdef)
+
+            # Determine the test's target scenario path.
+            target_scenario_path = os.path.join(utils.DEFS_DIR,
+                                                tg.test_defs_root,
+                                                tg.target_path)
+
+            # Add the test case's name to tests associated with the
+            # scenario.
+            if target_scenario_path in test_scenario_mappings:
+                test_scenario_mappings[target_scenario_path].append(
+                    testdef)
+            else:
+                test_scenario_mappings[target_scenario_path] = [testdef]
 
         return all_tests, test_scenario_mappings
 
@@ -66,15 +70,17 @@ class HotYValidate(TestCase):
         every scenario has at least one test.
         """
 
-        scenarios_root_path = os.path.join(utils.DEFS_DIR, 'scenarios')
-
         # At this point, we have all the names of the scenarios which actually
         # have at least one test for it. Now, we're going to grab a list of all
         # scenario YAML files to compare them. We'll also check for a few
         # essential things we require in scenarios (e.g. having `checks` and
         # `conclusions` sections) as well.
-        scenario_files = glob.glob(scenarios_root_path + '/**/*.yaml',
-                                   recursive=True)
+        # Ensure the defs root is configured for YDefsLoader discovery.
+        if not HotSOSConfig.plugin_yaml_defs:
+            HotSOSConfig.plugin_yaml_defs = utils.DEFS_DIR
+
+        # Use YDefsLoader to find all scenario YAML files
+        scenario_files = list(YDefsLoader.get_scenario_files())
 
         all_tests, test_scenario_mappings = self._discover_tests()
 


### PR DESCRIPTION
Depends on #1109 

This commit moves the YAML file discover/traversing logic to YDefsLoader. It removes the duplicated logic, adds support for optional per-caller file filtering and adds public helper methods for use in other modules.

hotsos/core/ycheck/engine/common.py:
  - Introduce SCENARIOS_SUBDIR and TESTS_SUBDIR constants together with get_defs_dir() / get_defs_tests_dir() helpers that resolve HotSOSConfig.plugin_yaml_defs on every call, so the returned paths always reflect the current config (including values set during test setup).
  - Add YDefsLoader._walk(path): a generic recursive file walker that yields every regular file under path with no filtering.
  - Add YDefsLoader.find_files_recursively(path, file_filter=None): public helper that walks a directory and yields only *.yaml files. An optional callable(abs_path) -> bool file_filter is applied on top to further narrow the result.
  - Add YDefsLoader._default_scenario_file_filter that keeps only *.yaml files. This is what makes discovery yaml-only for both scenario definitions and scenario test definitions: non-yaml files, including editor/disabled artefacts (*.swp / *.disabled) and extensionless files, are all excluded since they do not end in .yaml, so no explicit *.swp / *.disabled handling is needed.
  - Add YDefsLoader.get_scenario_files(subpath=None, file_filter=None) and YDefsLoader.get_scenario_test_files( subpath=None, file_filter=None). Both accept an optional subpath, defaulting to <defs>/scenarios and <defs>/tests respectively (get_scenario_test_files' subpath is relative to <defs>/tests to preserve the existing 'scenarios/<plugin>' calling convention). Both apply the yaml-only filter and any caller-provided file_filter on top.

tests/unit/utils.py:
  - Remove the local find_all_templated_tests() helper.
  - load_templated_tests() now iterates YDefsLoader.find_files_recursively() rooted at os.path.join(DEFS_TESTS_DIR, path). No local filter is needed since discovery is yaml-only.

tests/unit/test_ut_scenario_loader.py:
  - test_find_all_templated_tests now calls YDefsLoader.find_files_recursively(dtmp) directly.
  - create_tests() and the test_check_test_names / test_find_all_templated_tests expectations no longer include extensionless test-definition fixtures, matching the yaml-only discovery.

tools/validation/hotyvalidate.py:
  - Drop the manual glob/os.listdir walking of the scenario and scenario-test trees and delegate discovery to YDefsLoader.get_scenario_files() and YDefsLoader.get_scenario_test_files('scenarios').
  - Recover the plugin sub-root (e.g. 'kernel') from each yielded absolute test path via os.path.relpath, and pass the correct 'scenarios/<subdir>' value as TemplatedTestGenerator's test_defs_root argument.

@dosaboy bringing this explicitly to your attention:
This commit removes the historical support for the extensionless test-def files. Currently, no extensionless test-def files exist in the hotsos/defs/tests tree, so runtime impact today is nil — but the feature/contract (and its tests) is broken. 