### PR TITLE
Force fork multiprocessing start method for searchkit on Python 3.14

### DIFF
--- a/hotsos/core/search.py
+++ b/hotsos/core/search.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 from datetime import timedelta
 from functools import cached_property
@@ -15,6 +16,19 @@ from searchkit.constraints import (
 from hotsos.core.config import HotSOSConfig
 from hotsos.core.host_helpers import CLIHelper, UptimeHelper
 from hotsos.core.log import log
+
+
+# NOTE: searchkit's parallel search relies on the 'fork' multiprocessing start
+# method - its worker processes inherit global state (e.g. HotSOSConfig) from
+# the parent and it explicitly identifies its workers as ForkProcess. From
+# Python 3.14 the default start method on Linux changed from 'fork' to
+# 'forkserver' which breaks this: workers no longer inherit HotSOSConfig so
+# search constraints (e.g. result age limiting) get silently skipped and
+# search results can be corrupted. We therefore ensure 'fork' is used where
+# available (all platforms hotsos supports).
+if 'fork' in multiprocessing.get_all_start_methods():
+    if multiprocessing.get_start_method(allow_none=True) != 'fork':
+        multiprocessing.set_start_method('fork', force=True)
 
 
 # This module acts as a proxy to searchkit but with some addons/modifications


### PR DESCRIPTION
searchkit's parallel search relies on the 'fork' start method: worker processes inherit global state (e.g. HotSOSConfig) from the parent and are identified as ForkProcess. Python 3.14 changed the default start method on Linux from 'fork' to 'forkserver', which broke this - workers no longer inherited HotSOSConfig so search constraints (e.g. result age limiting) were silently skipped and search results could be corrupted.

This caused the juju functest to report 72 tracebacks instead of 24 for nova-compute/0. Ensure 'fork' is used where available.

Assisted-By: Claude Opus 4.8