### PR TITLE
SET-2637 Improve kubectl config handling

### DIFF
--- a/hotsos/core/host_helpers/cli/commands/kubectl.py
+++ b/hotsos/core/host_helpers/cli/commands/kubectl.py
@@ -1,3 +1,4 @@
+import os
 from collections import UserList
 
 from hotsos.core.host_helpers.cli.common import BinCmd, FileCmd
@@ -8,6 +9,12 @@ KUBECTL_ALIASES = ['kubectl', 'microk8s.kubectl', 'k8s kubectl']
 KUBE_CONFIGS = ['/etc/kubernetes/admin.conf',
                 '/root/cdk/cdk_addons_kubectl_config',
                 '/var/snap/microk8s/current/credentials/client.config']
+
+# See https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config for
+# info on standard config paths.
+#
+# NOTE: the user can optionally set KUBECONFIG env var to override these paths.
+DEFAULT_CFG_PATH = f"{os.environ.get('HOME', '~')}/.kube/config"
 
 
 class KubectlBinCmdBase(BinCmd):

--- a/hotsos/core/plugins/openstack/sunbeam.py
+++ b/hotsos/core/plugins/openstack/sunbeam.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from functools import cached_property
 
 from hotsos.core.host_helpers import CLIHelper, SnapPackageHelper
+from hotsos.core.host_helpers.cli.commands import kubectl
 from hotsos.core.log import log
 
 
@@ -15,7 +16,7 @@ class SunbeamInfo():
         return 'openstack' in SnapPackageHelper(core_snaps=['openstack']).core
 
     @staticmethod
-    def _kubectl_get(opt):
+    def kubectl_get_catch_config_error(opt):
         """ Run kubectl get for the given resource and return its items.
 
         On a controller ~/.kube/config is expected to exist so if kubectl
@@ -30,7 +31,7 @@ class SunbeamInfo():
                                       subopts='')
         if not out or 'items' not in out:
             log.warning("no sunbeam %s found - kubectl returned no data "
-                        "(does ~/.kube/config exist?)", opt)
+                        f"(does {kubectl.DEFAULT_CFG_PATH} exist?)", opt)
             return []
 
         return out['items']
@@ -41,7 +42,7 @@ class SunbeamInfo():
         if not self.is_controller:
             return {}
 
-        items = self._kubectl_get('pods')
+        items = self.kubectl_get_catch_config_error('pods')
         if not items:
             return {}
 
@@ -61,7 +62,7 @@ class SunbeamInfo():
         if not self.is_controller:
             return {}
 
-        items = self._kubectl_get('statefulsets')
+        items = self.kubectl_get_catch_config_error('statefulsets')
         if not items:
             return {}
 

--- a/hotsos/defs/scenarios/openstack/sunbeam/statefulsets.yaml
+++ b/hotsos/defs/scenarios/openstack/sunbeam/statefulsets.yaml
@@ -3,12 +3,15 @@ vars:
 checks:
   is_sunbeam_controller:
     property: hotsos.core.plugins.openstack.sunbeam.SunbeamInfo.is_controller
+  statefulsets_has_incomplete:
+    varops: [[$statefulsets], [contains, incomplete]]
   not_all_statefulsets_complete:
     varops: [[$statefulsets], [getitem, incomplete], [length_hint]]
 conclusions:
   incomplete_statefulsets:
     decision:
       - is_sunbeam_controller
+      - statefulsets_has_incomplete
       - not_all_statefulsets_complete
     raises:
       type: OpenstackError

--- a/hotsos/plugin_extensions/openstack/sunbeam.py
+++ b/hotsos/plugin_extensions/openstack/sunbeam.py
@@ -1,3 +1,4 @@
+from hotsos.core.host_helpers.cli.commands import kubectl
 from hotsos.core.issues import IssuesManager, OpenstackWarning
 from hotsos.core.plugins.openstack.common import (
     OpenstackBase,
@@ -26,7 +27,8 @@ class SunbeamStatus(OpenstackBase, OpenStackChecks):
         if sunbeam.is_controller:
             IssuesManager().add(OpenstackWarning(
                 "this host is a sunbeam controller but no kubernetes data "
-                "was found - kubectl may have failed (does ~/.kube/config "
-                "exist?)"))
+                "was found - kubectl may have failed (does "
+                f"{kubectl.DEFAULT_CFG_PATH} exist? - if not you can try "
+                "setting the KUBECONFIG env var to a valid path)"))
 
         return None

--- a/tests/unit/openstack/test_sunbeam.py
+++ b/tests/unit/openstack/test_sunbeam.py
@@ -4,6 +4,7 @@ from unittest import mock
 from hotsos.core.config import HotSOSConfig
 import hotsos.core.plugins.openstack as openstack_core
 from hotsos.core.plugins.openstack import sunbeam
+from hotsos.core.host_helpers.cli.commands import kubectl
 from hotsos.core.issues import IssuesManager
 from hotsos.plugin_extensions.openstack import agent
 from hotsos.plugin_extensions.openstack import sunbeam as sunbeam_ext
@@ -169,6 +170,21 @@ class TestOpenstackSunbeam(TestOpenstackSunbeamBase):
             self.assertDictEqual(sunbeaminfo.pods, {})
             self.assertDictEqual(sunbeaminfo.statefulsets, {})
 
+    def test_kubectl_get_missing_config_path(self):
+        """ Test empty kubectl output when its config path is unavailable. """
+        cfg_path = '/path/that/does/not/exist'
+        with mock.patch.object(sunbeam, 'CLIHelper') as mock_helper, \
+                mock.patch.object(kubectl, 'DEFAULT_CFG_PATH', cfg_path), \
+                self.assertLogs(logger='hotsos', level='WARNING') as log:
+            mock_helper.return_value.kubectl_get.return_value = None
+            out = sunbeam.SunbeamInfo.kubectl_get_catch_config_error('pods')
+            self.assertEqual(out, [])
+
+        mock_helper.return_value.kubectl_get.assert_called_once_with(
+            namespace='openstack', opt='pods', subopts='')
+        self.assertEqual(len(log.output), 1)
+        self.assertIn(f'does {cfg_path} exist?', log.output[0])
+
     def test_summary_controller_no_kubectl_data_raises_issue(self):
         """ Test issue raised when controller has no kubernetes data. """
         with mock.patch.object(sunbeam.SunbeamInfo, 'is_controller', True), \
@@ -179,8 +195,11 @@ class TestOpenstackSunbeam(TestOpenstackSunbeamBase):
             issues = {'potential-issues': [{
                         'message': ('this host is a sunbeam controller but no '
                                     'kubernetes data was found - kubectl may '
-                                    'have failed (does ~/.kube/config '
-                                    'exist?)'),
+                                    'have failed '
+                                    f'(does {kubectl.DEFAULT_CFG_PATH} '
+                                    'exist? - if not you can try '
+                                    'setting the KUBECONFIG env var to a '
+                                    'valid path)'),
                         'origin': 'openstack.testpart',
                         'type': 'OpenstackWarning'}]}
             self.assertEqual(IssuesManager().load_issues(), issues)


### PR DESCRIPTION
Stop scenario from reporting an error when kubectl failed to run. Improve test coverage and for when config is missing.