### PR TITLE
SET-2638 fix sunbeam version parsing

### DIFF
--- a/hotsos/core/plugins/openstack/common.py
+++ b/hotsos/core/plugins/openstack/common.py
@@ -207,7 +207,9 @@ class OpenstackBase():  # pylint: disable=too-many-instance-attributes
             for pkg in OST_SUNBEAM_SNAP_NAMES:
                 if pkg in self.snaps.core:
                     ver = self.snaps.get_version(pkg)
-                    relnames.add(OST_SUNBEAM_REL_INFO[ver])
+                    match = re.search(r'\d+\.\d+', ver)
+                    if match:
+                        relnames.add(OST_SUNBEAM_REL_INFO[match.group(0)])
 
         log.debug("release name(s) found: %s", ','.join(relnames))
         return list(relnames)

--- a/tests/unit/openstack/test_sunbeam.py
+++ b/tests/unit/openstack/test_sunbeam.py
@@ -198,6 +198,14 @@ class TestOpenstackSunbeamPluginCore(TestOpenstackSunbeamBase):
                 {'version': '2024.1', 'channel': '2024.1/stable'}}
         self.assertEqual(ost_base.snaps.core, core)
 
+    def test_release_name_from_snap_version_with_suffix(self):
+        """ Test Sunbeam release detection ignores snap version suffixes. """
+        ost_base = openstack_core.OpenstackBase()
+        with mock.patch.object(ost_base.snaps, 'get_version',
+                               return_value='2024.1+build'):
+            self.assertEqual(ost_base.installed_pkg_release_names,
+                             ['caracal'])
+
 
 class TestOpenstackSunbeamAgentEvents(TestOpenstackSunbeamBase):
     """ Unit tests for OpenStack Sunbeam agent event checks. """


### PR DESCRIPTION
Openstack snap versions sometimes have commit sha appended to them so we need to strip this when doing a release lookup.