### PR TITLE
Fix OVS scenario warning when other_config invalid

### DIFF
--- a/hotsos/core/plugins/openvswitch/ovs.py
+++ b/hotsos/core/plugins/openvswitch/ovs.py
@@ -315,7 +315,14 @@ class OVSDPDK(OpenvSwitchBase):
     @cached_property
     def config(self):
         """ Return the OVSDB Open_vSwitch other_config dict. """
-        return self.ovsdb.Open_vSwitch.other_config or {}
+        config = self.ovsdb.Open_vSwitch.other_config
+        if not config:
+            return {}
+
+        if not isinstance(config, dict):
+            return {}
+
+        return config
 
     @property
     def enabled(self):


### PR DESCRIPTION
If the ovs-vsctl "other_config" file is invalid and does not contain a dictionary, the openvswitch plugin will show various warnings for scenarios since it
throws an exception under the hood.

For example, if the file contains a string like:

  "ovs-vsctl: unix:/var/snap/openstack-hypervisor/
   common/run/openvswitch/db.sock: database connection
   failed (No such file or directory)"

You will see:

  HotSOSScenariosWarnings:
      - One or more scenarios failed to run (dpdk_config) - run hotsos in debug mode (--debug) to get more detail

Check it is a dict before trying to use it as such.